### PR TITLE
Trust self-signed certificates when using the eHX FHIR proxy

### DIFF
--- a/containers/tefca-viewer/src/app/fhir-servers.ts
+++ b/containers/tefca-viewer/src/app/fhir-servers.ts
@@ -1,6 +1,7 @@
 import fetch, { RequestInit, HeaderInit, Response } from "node-fetch";
 import { v4 as uuidv4 } from "uuid";
 import { FHIR_SERVERS } from "./constants";
+import https from "https";
 /**
  * Defines the model for a FHIR server configuration
  */
@@ -50,6 +51,10 @@ function configureEHX(xdestination: string): FHIR_SERVER_CONFIG {
       prefer: "return=representation",
       "Cache-Control": "no-cache",
     } as HeaderInit,
+    // Trust eHealth Exchange's self-signed certificate
+    agent: new https.Agent({
+      rejectUnauthorized: false,
+    }),
   };
   if (xdestination === "CernerHelios" && init.headers) {
     (init.headers as Record<string, string>)["OAUTHSCOPES"] =


### PR DESCRIPTION
# PULL REQUEST

## Summary

The eHealth Exchange FHIR proxy currently uses a self-signed TLS certificate. Since we are no longer trusting self-signed certs globally in the application to restore our connection with eHX we need to configure trust them when making requests to eHX 

## Related Issue

Fixes #2578

## Acceptance Criteria

Please copy the acceptance criteria from your ticket and paste it here for your reviewer(s)

For frontend PR’s - include a description (including anything that’s out of scope) for what you want the designers to review

- ex: _“Check out the whitespace on the page, as well as the dropdowns in the form. Here is the corresponding Figma link. You can ignore everything else. Also, the button at the bottom doesn’t work now”_

## Additional Information

Anything else the review team should know?

## Checklist

- [ ] If this code affects the other scrum team, have they been notified? (In Slack, as reviewers, etc.)

[//]: # "PR title: Remember to name your PR descriptively!"
