### PR TITLE
enable image publishing on merges to main

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -40,4 +40,4 @@ jobs:
         with:
           context: ./query-connector
           push: true
-          tags: ghcr.io/${{ github.repository }}/query-connector:main, ghcr.io/${{ github.repository }}/query-connector:latest
+          tags: ghcr.io/cdcgov/dibbs-query-connector/query-connector:main, ghcr.io/cdcgov/dibbs-query-connector/query-connector:latest

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -35,9 +35,16 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: lowercase repo name to use in following step
+        env:
+          REPO: ${{ github.repository }}
+        run: |
+          echo "REPO=${GITHUB_REPOSITORY,,}" >> $GITHUB_ENV
+
       - name: Build and push
         uses: docker/build-push-action@v3
         with:
           context: ./query-connector
           push: true
-          tags: ghcr.io/cdcgov/dibbs-query-connector/query-connector:main, ghcr.io/cdcgov/dibbs-query-connector/query-connector:latest
+          tags: |
+            ghcr.io/${{ env.REPO }}/query-connector:main, ghcr.io/${{ env.REPO }}/query-connector:latest


### PR DESCRIPTION
# PULL REQUEST

## Summary

Followup to https://github.com/CDCgov/dibbs-query-connector/pull/28 that gets the build / publish step working.

## Related Issue
Fixes the lowercase issue that was breaking the workflow run

Manual run of the workflow [here](https://github.com/CDCgov/dibbs-query-connector/actions/runs/11373266225/job/31639453237) that resulted in a published image [here](https://github.com/CDCgov/dibbs-query-connector/pkgs/container/dibbs-query-connector%2Fquery-connector/versions?filters%5Bversion_type%5D=tagged)