### PR TITLE
Add internal data model for ValueSet

### DIFF
--- a/query-connector/src/app/constants.ts
+++ b/query-connector/src/app/constants.ts
@@ -287,6 +287,14 @@ export const stateOptions = [
 /* Mode that pages can be in; determines what is displayed to the user */
 export type Mode = "search" | "results" | "select-query" | "patient-results";
 
+export const metadata = {
+  title: "Query Connector",
+  description: "Try out TEFCA with queries for public health use cases.",
+};
+
+// TODO: Remove ValueSetItem, ValueSet, and valueSetTypeToClincalServiceTypeMap once
+// ticket #2789 is resolved
+
 /*Type to specify the expected components for each item in a value set that will be 
 displayed in the CustomizeQuery component*/
 export interface ValueSetItem {
@@ -314,8 +322,37 @@ export const valueSetTypeToClincalServiceTypeMap = {
   medications: ["mrtc"],
   conditions: ["dxtc", "sdtc"],
 };
+/// TODO: Remove the above once ticket #2789 is resolved
 
-export const metadata = {
-  title: "Query Connector",
-  description: "Try out TEFCA with queries for public health use cases.",
-};
+/*
+ * The expected type of a ValueSet concept.
+ */
+export interface Concept {
+  code: string;
+  display: string;
+  include: boolean;
+}
+
+/*
+ * The expected type of a ValueSet.
+ */
+// export interface ValueSet {
+//   valueset_id: string;
+//   valueset_version: string;
+//   valueset_name: string;
+//   author: string;
+//   system: string;
+//   ersdConceptType?: string;
+//   dibbsConceptType: string;
+//   includeValueSet: boolean;
+//   concepts: Concept[];
+// }
+
+/*
+ * The expected type of ValueSets grouped by dibbsConceptType for the purpose of display.
+ */
+export interface ValueSetDisplay {
+  labs: ValueSet[];
+  medications: ValueSet[];
+  conditions: ValueSet[];
+}


### PR DESCRIPTION
# PULL REQUEST

## Summary

This PR adds `Concept`, `ValueSet` and `ValueSetDisplay` data models to our constants. Note: these concepts have not yet been implemented but will be in the follow up ticket [phdi #2789
](https://app.zenhub.com/workspaces/skylight-dibbs-viper-6480ba23b5a07644e0e46d23/issues/gh/cdcgov/phdi/2789) at which point the old data model can be deleted. 

## Related Issue

Fixes # [phdi#2760](https://app.zenhub.com/workspaces/skylight-dibbs-viper-6480ba23b5a07644e0e46d23/issues/gh/cdcgov/phdi/2760)

## Acceptance Criteria

Please copy the acceptance criteria from your ticket and paste it here for your reviewer(s)
A dataclass for this model has been added to the codebase.

## Additional Information

Anything else the review team should know?

## Checklist

- [ ] If this code affects the other scrum team, have they been notified? (In Slack, as reviewers, etc.)

[//]: # "PR title: Remember to name your PR descriptively!"
