### PR TITLE
Add `dibbsConceptType` to valuesets table

### DIFF
--- a/query-connector/flyway/sql/V01_06__add_dibbsConceptType.sql
+++ b/query-connector/flyway/sql/V01_06__add_dibbsConceptType.sql
@@ -1,0 +1,8 @@
+ALTER TABLE valuesets
+ADD COLUMN dibbsConceptType text GENERATED ALWAYS AS (
+    CASE
+        WHEN type IN ('lotc', 'lrtc', 'ostc') THEN 'labs'
+        WHEN type = 'mrtc' THEN 'medications'
+        ELSE 'conditions'
+    END
+) STORED;


### PR DESCRIPTION
# PULL REQUEST

## Summary

This PR adds a dibbsConceptType column to the `valuesets` table and populates the column with the appropriate data. The new column, `dibbsConceptType` is one of the following values: labs, medications, or conditions, and is based off the ersdConceptType (AKA the `type` column in valuesets). Adding this column and making the data available when queried will allow us to cut down on some of the transformations we complete in order to properly display the data on the CustomQuery page and during query execution. 

## Related Issue

Fixes #[phdi #2788](https://app.zenhub.com/workspaces/skylight-dibbs-viper-6480ba23b5a07644e0e46d23/issues/gh/cdcgov/phdi/2788)

## Acceptance Criteria

- [x] We'll write a migration that adds the DibbsDisplayType column to the valuesets table
- [x] We'll write a migration that fills in this field for each row of the valueset table by mapping the value currently stored in the type column (which holds a clinical service abbreviation code) to its appropriate DisplayType.

## Additional Information

This ticket will allow Brandon to continue working on [phdi #2789](https://app.zenhub.com/workspaces/skylight-dibbs-viper-6480ba23b5a07644e0e46d23/issues/gh/cdcgov/phdi/2789)

## Checklist

- [ ] If this code affects the other scrum team, have they been notified? (In Slack, as reviewers, etc.)

[//]: # "PR title: Remember to name your PR descriptively!"
