### PR TITLE
add translation function: vsac --> internal valueset

### DIFF
--- a/query-connector/src/app/constants.ts
+++ b/query-connector/src/app/constants.ts
@@ -324,6 +324,26 @@ export const valueSetTypeToClincalServiceTypeMap = {
 };
 /// TODO: Remove the above once ticket #2789 is resolved
 
+type DibbsConceptType = "labs" | "medications" | "conditions";
+export type ErsdConceptType =
+  | "ostc"
+  | "lotc"
+  | "lrtc"
+  | "mrtc"
+  | "dxtc"
+  | "sdtc";
+
+export const ersdToDibbsConceptMap: {
+  [k in ErsdConceptType]: DibbsConceptType;
+} = {
+  ostc: "labs",
+  lotc: "labs",
+  lrtc: "labs",
+  mrtc: "medications",
+  dxtc: "conditions",
+  sdtc: "conditions",
+};
+
 /*
  * The expected type of a ValueSet concept.
  */
@@ -336,17 +356,17 @@ export interface Concept {
 /*
  * The expected type of a ValueSet.
  */
-// export interface ValueSet {
-//   valueset_id: string;
-//   valueset_version: string;
-//   valueset_name: string;
-//   author: string;
-//   system: string;
-//   ersdConceptType?: string;
-//   dibbsConceptType: string;
-//   includeValueSet: boolean;
-//   concepts: Concept[];
-// }
+export interface InternalValueSet {
+  valueset_id: string;
+  valueset_version: string;
+  valueset_name: string;
+  author: string;
+  system: string;
+  ersdConceptType?: string;
+  dibbsConceptType: string;
+  includeValueSet: boolean;
+  concepts: Concept[];
+}
 
 /*
  * The expected type of ValueSets grouped by dibbsConceptType for the purpose of display.

--- a/query-connector/src/app/database-service.ts
+++ b/query-connector/src/app/database-service.ts
@@ -171,13 +171,19 @@ export async function getVSACValueSet(
   }
 }
 
+/**
+ * Translates a VSAC FHIR bundle to our internal ValueSet struct
+ * @param fhirValueset - The FHIR ValueSet response from VSAC
+ * @param ersdConceptType - The associated clinical concept type from ERSD
+ * @returns An object of type InternalValueSet
+ */
 export function translateVSACToInternalValueSet(
   fhirValueset: ValueSet,
   ersdConceptType: ErsdConceptType,
 ) {
   const id = fhirValueset.id;
-  // does this need any interpolation? ie example "version": "20230602",
-  // needs to be maped to v2 or v3?
+  // does this need any interpolation?
+  // ie example "version": "20230602" needs to be maped to v2 or v3?
   const version = fhirValueset.version;
 
   // would we prefer this over the less readable "name?"

--- a/query-connector/src/app/tests/assets/VSACValueSet.json
+++ b/query-connector/src/app/tests/assets/VSACValueSet.json
@@ -1,0 +1,174 @@
+{
+  "resourceType": "ValueSet",
+  "id": "2.16.840.1.113762.1.4.1146.170",
+  "meta": {
+    "versionId": "58",
+    "lastUpdated": "2023-12-21T17:43:03.000-05:00",
+    "profile": [
+      "http://hl7.org/fhir/StructureDefinition/shareablevalueset",
+      "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/computable-valueset-cqfm",
+      "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/publishable-valueset-cqfm"
+    ]
+  },
+  "extension": [
+    {
+      "url": "http://hl7.org/fhir/StructureDefinition/valueset-author",
+      "valueContactDetail": {
+        "name": "CSTE Author"
+      }
+    },
+    {
+      "url": "http://hl7.org/fhir/StructureDefinition/valueset-keyWord",
+      "valueString": "Chlamydia,G_STI,Trigger"
+    },
+    {
+      "url": "http://hl7.org/fhir/StructureDefinition/resource-lastReviewDate",
+      "valueDate": "2024-06-05"
+    },
+    {
+      "url": "http://hl7.org/fhir/StructureDefinition/valueset-effectiveDate",
+      "valueDate": "2023-06-02"
+    }
+  ],
+  "url": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1146.170",
+  "identifier": [
+    {
+      "system": "urn:ietf:rfc:3986",
+      "value": "urn:oid:2.16.840.1.113762.1.4.1146.170"
+    }
+  ],
+  "version": "20230602",
+  "name": "ChlamydiaTrachomatisInfectionOrganismOrSubstanceInLabResults",
+  "title": "Chlamydia trachomatis Infection (Organism or Substance in Lab Results)",
+  "status": "active",
+  "date": "2023-06-02T01:03:51-04:00",
+  "publisher": "CSTE Steward",
+  "jurisdiction": [
+    {
+      "extension": [
+        {
+          "url": "http://hl7.org/fhir/StructureDefinition/data-absent-reason",
+          "valueCode": "unknown"
+        }
+      ]
+    }
+  ],
+  "purpose": "(Clinical Focus: This set of values contains organisms or substances relevant for reporting Chlamydia),(Data Element Scope: Organism names reported in laboratory results),(Inclusion Criteria: Chlamydia trachomatis organism or Chlamydia trachomatis substance),(Exclusion Criteria: antibody substances)",
+  "compose": {
+    "include": [
+      {
+        "system": "http://snomed.info/sct",
+        "concept": [
+          {
+            "code": "115289001",
+            "display": "Chlamydia trachomatis, serotype A (organism)"
+          },
+          {
+            "code": "115290005",
+            "display": "Chlamydia trachomatis, serotype B (organism)"
+          },
+          {
+            "code": "115291009",
+            "display": "Chlamydia trachomatis, serotype Ba (organism)"
+          },
+          {
+            "code": "115292002",
+            "display": "Chlamydia trachomatis, serotype C (organism)"
+          },
+          {
+            "code": "115293007",
+            "display": "Chlamydia trachomatis, serotype D (organism)"
+          },
+          {
+            "code": "115294001",
+            "display": "Chlamydia trachomatis, serotype E (organism)"
+          },
+          {
+            "code": "115295000",
+            "display": "Chlamydia trachomatis, serotype F (organism)"
+          },
+          {
+            "code": "115296004",
+            "display": "Chlamydia trachomatis, serotype I (organism)"
+          },
+          {
+            "code": "115297008",
+            "display": "Chlamydia trachomatis, serotype J (organism)"
+          },
+          {
+            "code": "115298003",
+            "display": "Chlamydia trachomatis, serotype K (organism)"
+          },
+          {
+            "code": "115299006",
+            "display": "Chlamydia trachomatis, serotype L (organism)"
+          },
+          {
+            "code": "115300003",
+            "display": "Chlamydia trachomatis, serotype L1 (organism)"
+          },
+          {
+            "code": "115301004",
+            "display": "Chlamydia trachomatis, serotype L2 (organism)"
+          },
+          {
+            "code": "115318000",
+            "display": "Chlamydia trachomatis, serotype L3 (organism)"
+          },
+          {
+            "code": "115319008",
+            "display": "Chlamydia trachomatis, serotype G (organism)"
+          },
+          {
+            "code": "115328009",
+            "display": "Chlamydia trachomatis, serotype H (organism)"
+          },
+          {
+            "code": "121002007",
+            "display": "Antigen of Chlamydia trachomatis (substance)"
+          },
+          {
+            "code": "121015003",
+            "display": "Antigen of Chlamydia trachomatis serotype F (substance)"
+          },
+          {
+            "code": "121016002",
+            "display": "Antigen of Chlamydia trachomatis serotype G (substance)"
+          },
+          {
+            "code": "121017006",
+            "display": "Antigen of Chlamydia trachomatis serotype K (substance)"
+          },
+          {
+            "code": "121106008",
+            "display": "Ribosomal ribonucleic acid of Chlamydia trachomatis (substance)"
+          },
+          {
+            "code": "121181000",
+            "display": "Deoxyribonucleic acid of Chlamydia trachomatis (substance)"
+          },
+          {
+            "code": "442505006",
+            "display": "Chlamydia trachomatis, serotype Ja (organism)"
+          },
+          {
+            "code": "454431000124102",
+            "display": "Chlamydia trachomatis nucleic acid detected (finding)"
+          },
+          {
+            "code": "59134003",
+            "display": "Lymphogranuloma venereum antigen (substance)"
+          },
+          {
+            "code": "63938009",
+            "display": "Chlamydia trachomatis (organism)"
+          },
+          {
+            "code": "708219005",
+            "display": "Deoxyribonucleic acid of Chlamydia trachomatis L2 (substance)"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/query-connector/src/app/tests/integration/translation.test.ts
+++ b/query-connector/src/app/tests/integration/translation.test.ts
@@ -1,0 +1,29 @@
+import { InternalValueSet } from "@/app/constants";
+import ExampleVsacValueSet from "../assets/VSACValueSet.json";
+import { translateVSACToInternalValueSet } from "../../database-service";
+import { ValueSet } from "fhir/r4";
+
+const EXPECTED_INTERNAL_VALUESET: InternalValueSet = {
+  valueset_id: ExampleVsacValueSet.id,
+  valueset_version: ExampleVsacValueSet.version,
+  valueset_name: ExampleVsacValueSet.title,
+  author: ExampleVsacValueSet.publisher,
+  system: ExampleVsacValueSet.compose.include[0].system,
+  ersdConceptType: "ostc",
+  dibbsConceptType: "labs",
+  includeValueSet: false,
+  concepts: ExampleVsacValueSet.compose.include[0].concept.map((c) => {
+    return { ...c, include: false };
+  }),
+};
+
+describe("VSAC FHIR response to internal application type", () => {
+  it("translate to expected fixture", () => {
+    const translationResult = translateVSACToInternalValueSet(
+      ExampleVsacValueSet as ValueSet,
+      "ostc",
+    );
+
+    expect(translationResult).toEqual(EXPECTED_INTERNAL_VALUESET);
+  });
+});


### PR DESCRIPTION
# PULL REQUEST

## Summary

Adds a translation function / stubs out a test for translating a VSAC ValueSet response into our internal ValueSet type.

## Related Issue
Fixes [#phdi 2792](https://app.zenhub.com/workspaces/skylight-dibbs-viper-6480ba23b5a07644e0e46d23/issues/gh/cdcgov/phdi/2792)

## Acceptance Criteria
Since we will use ValueSet internally to model valuesets within the application and we will receive valuesets in a FHIR format from VSAC and possibly other terminology services in the future we need a way to transfrom from FHIR to our ValueSet model.

## Additional Information
Left a slew of questions in the translation function that'd love feedback on!
