### PR TITLE
Adding loading step to customize query selection

### DIFF
--- a/query-connector/src/app/query/components/selectQuery/SelectSavedQuery.tsx
+++ b/query-connector/src/app/query/components/selectQuery/SelectSavedQuery.tsx
@@ -12,6 +12,7 @@ import {
   PAGE_TITLES,
   RETURN_LABEL,
 } from "@/app/query/stepIndicator/StepIndicator";
+import LoadingView from "@/app/query/components/LoadingView";
 
 type SelectSavedQueryProps = {
   selectedQuery: string;
@@ -84,14 +85,20 @@ const SelectSavedQuery: React.FC<SelectSavedQueryProps> = ({
             </option>
           ))}
         </Select>
+
+        {/* Customize Query Button with LoadingView */}
         <Button
           type="button"
           className="usa-button--outline bg-white margin-left-205"
           onClick={() => setShowCustomizedQuery(true)}
+          disabled={loadingQueryValueSets}
         >
           Customize query
         </Button>
       </div>
+
+      {/* Loading View */}
+      <LoadingView loading={loadingQueryValueSets} />
 
       {showAdvanced && (
         <div>

--- a/query-connector/src/app/query/components/selectQuery/SelectSavedQuery.tsx
+++ b/query-connector/src/app/query/components/selectQuery/SelectSavedQuery.tsx
@@ -12,7 +12,6 @@ import {
   PAGE_TITLES,
   RETURN_LABEL,
 } from "@/app/query/stepIndicator/StepIndicator";
-import LoadingView from "@/app/query/components/LoadingView";
 
 type SelectSavedQueryProps = {
   selectedQuery: string;
@@ -91,14 +90,11 @@ const SelectSavedQuery: React.FC<SelectSavedQueryProps> = ({
           type="button"
           className="usa-button--outline bg-white margin-left-205"
           onClick={() => setShowCustomizedQuery(true)}
-          disabled={loadingQueryValueSets}
+          disabled={loadingQueryValueSets || !selectedQuery} // Disable based on loading state and query selection
         >
           Customize query
         </Button>
       </div>
-
-      {/* Loading View */}
-      <LoadingView loading={loadingQueryValueSets} />
 
       {showAdvanced && (
         <div>

--- a/query-connector/src/app/query/components/selectQuery/SelectSavedQuery.tsx
+++ b/query-connector/src/app/query/components/selectQuery/SelectSavedQuery.tsx
@@ -85,12 +85,12 @@ const SelectSavedQuery: React.FC<SelectSavedQueryProps> = ({
           ))}
         </Select>
 
-        {/* Customize Query Button with LoadingView */}
+        {/* Customize Query Button */}
         <Button
           type="button"
           className="usa-button--outline bg-white margin-left-205"
           onClick={() => setShowCustomizedQuery(true)}
-          disabled={loadingQueryValueSets || !selectedQuery} // Disable based on loading state and query selection
+          disabled={loadingQueryValueSets || !selectedQuery}
         >
           Customize query
         </Button>


### PR DESCRIPTION
# PULL REQUEST

## Summary

This adds a loading step to the customize query step to prevent from getting ahead of the db load.

I think the only other open questions I had:
* do we want the customize query button unclickable until an actual selection is made? If you click the button, it just takes you to a blank version of the page, which could be a little confusing if the user does think they made a selection.
<img width="1083" alt="Screenshot 2024-10-23 at 10 50 20 AM" src="https://github.com/user-attachments/assets/f100bf00-d970-4046-85a9-42e5ee2b4664">

* is Social Determinants of Health supposed to be broken? Getting this error:
```No results found for query: Social Determinants of Health```

I can open up a ticket to look more closely at it, but I wasn't sure if this was a known bug or if anyone knew offhand why it may now be broken. 


## Related Issue



Fixes #47 

## Acceptance Criteria

Please copy the acceptance criteria from your ticket and paste it here for your reviewer(s)

For frontend PR’s - include a description (including anything that’s out of scope) for what you want the designers to review

- ex: _“Check out the whitespace on the page, as well as the dropdowns in the form. Here is the corresponding Figma link. You can ignore everything else. Also, the button at the bottom doesn’t work now”_

## Additional Information

Anything else the review team should know?

## Checklist

- [ ] If this code affects the other scrum team, have they been notified? (In Slack, as reviewers, etc.)

[//]: # "PR title: Remember to name your PR descriptively!"
