### PR TITLE
Rework name regex on patient search page

### DIFF
--- a/query-connector/src/app/query/components/SearchForm.tsx
+++ b/query-connector/src/app/query/components/SearchForm.tsx
@@ -79,7 +79,7 @@ const SearchForm: React.FC<SearchFormProps> = ({
     [setUseCase],
   );
 
-  const nameRegex = "^[A-Za-z\u00C0-\u024F\u1E00-\u1EFF\ \-\'\.]+$"
+  const nameRegex = "^[A-Za-z\u00C0-\u024F\u1E00-\u1EFF\-\'\.\ ]+$"
   const nameRuleHint = "Enter a name using only letters, hyphens, apostrophes, spaces, or periods."
 
   async function HandleSubmit(event: React.FormEvent<HTMLFormElement>) {

--- a/query-connector/src/app/query/components/SearchForm.tsx
+++ b/query-connector/src/app/query/components/SearchForm.tsx
@@ -79,6 +79,9 @@ const SearchForm: React.FC<SearchFormProps> = ({
     [setUseCase],
   );
 
+  const nameRegex = "^[A-Za-z\ \-\'\.]+$"
+  const nameRuleHint = "Enter a name using only letters, hyphens, apostrophes, spaces, or periods."
+
   async function HandleSubmit(event: React.FormEvent<HTMLFormElement>) {
     event.preventDefault();
     if (!fhirServer) {
@@ -191,9 +194,10 @@ const SearchForm: React.FC<SearchFormProps> = ({
               </Label>
               <TextInput
                 id="firstName"
+                title={nameRuleHint}
                 name="first_name"
                 type="text"
-                pattern="^[A-Za-z ]+$"
+                pattern={nameRegex}
                 value={firstName}
                 onChange={(event) => {
                   setFirstName(event.target.value);
@@ -210,9 +214,10 @@ const SearchForm: React.FC<SearchFormProps> = ({
               </Label>
               <TextInput
                 id="lastName"
+                title={nameRuleHint}
                 name="last_name"
                 type="text"
-                pattern="^[A-Za-z ]+$"
+                pattern={nameRegex}
                 value={lastName}
                 onChange={(event) => {
                   setLastName(event.target.value);

--- a/query-connector/src/app/query/components/SearchForm.tsx
+++ b/query-connector/src/app/query/components/SearchForm.tsx
@@ -79,7 +79,7 @@ const SearchForm: React.FC<SearchFormProps> = ({
     [setUseCase],
   );
 
-  const nameRegex = "^[A-Za-z\ \-\'\.]+$"
+  const nameRegex = "^[A-Za-z\u00C0-\u024F\u1E00-\u1EFF\ \-\'\.]+$"
   const nameRuleHint = "Enter a name using only letters, hyphens, apostrophes, spaces, or periods."
 
   async function HandleSubmit(event: React.FormEvent<HTMLFormElement>) {

--- a/query-connector/src/app/query/components/SearchForm.tsx
+++ b/query-connector/src/app/query/components/SearchForm.tsx
@@ -79,7 +79,7 @@ const SearchForm: React.FC<SearchFormProps> = ({
     [setUseCase],
   );
 
-  const nameRegex = "^[A-Za-z\u00C0-\u024F\u1E00-\u1EFF-'. ]+$";
+  const nameRegex = "^[A-Za-z\u00C0-\u024F\u1E00-\u1EFF\\-'. ]+$";
   const nameRuleHint =
     "Enter a name using only letters, hyphens, apostrophes, spaces, or periods.";
 

--- a/query-connector/src/app/query/components/SearchForm.tsx
+++ b/query-connector/src/app/query/components/SearchForm.tsx
@@ -79,8 +79,9 @@ const SearchForm: React.FC<SearchFormProps> = ({
     [setUseCase],
   );
 
-  const nameRegex = "^[A-Za-z\u00C0-\u024F\u1E00-\u1EFF\-\'\.\ ]+$"
-  const nameRuleHint = "Enter a name using only letters, hyphens, apostrophes, spaces, or periods."
+  const nameRegex = "^[A-Za-z\u00C0-\u024F\u1E00-\u1EFF-'. ]+$";
+  const nameRuleHint =
+    "Enter a name using only letters, hyphens, apostrophes, spaces, or periods.";
 
   async function HandleSubmit(event: React.FormEvent<HTMLFormElement>) {
     event.preventDefault();


### PR DESCRIPTION
# PULL REQUEST

## Summary
- Update regex for first name/last name to allow letters, hyphens, apostrophes, spaces, periods, and diacritics.
- Add `title` to `TextInput`s to display validation rule on tooltip message

## Related Issue

Fixes #56 

## Acceptance Criteria
_Patient form field accepts a reasonable (up to the dev to determine what reasonable means!) set of patient names, which would include dashes / apostrophes etc. that might show up in a name_

Allowed characters were chosen based on [USWDS Guidance](https://designsystem.digital.gov/patterns/create-a-user-profile/name/#guidance-2) and [HealthCare.gov](https://www.healthcare.gov/create-account) validation rules/messaging

Some names that should pass validation:
- A'ja Wilson
- Björk Guðmundsdóttir
- Julia Louis-Dreyfus
- Magdalena Carmen Frida Kahlo y Calderón
- St. Joan of Arc

Some names that should fail validation:
- Queen Elizabeth the 2nd
- Dwayne "The Rock" Johnson
- Panic! At the Disco

When an input fails validation, the tooltip should now display details on acceptable input characters like so:

<img width="400" alt="Screenshot 2024-10-25 at 15 14 29" src="https://github.com/user-attachments/assets/f366fa99-f0cd-46c6-a9fd-f6ee8bd715ea">

## Additional Information

There's an argument to be made (see [USWDS Usability Guidance](https://designsystem.digital.gov/templates/form-templates/name-form/#usability-guidance)) that we shouldn't restrict characters at all; however, this PR's changes align with current usage on various other HHS sites.

The browser tooltip for error handling isn't great for a11y either, so I'd recommend some future work on inline error styling a là the [CMS Design System](https://design.cms.gov/patterns/Forms/error-validation/?theme=core)

## Checklist

- [ ] If this code affects the other scrum team, have they been notified? (In Slack, as reviewers, etc.)

[//]: # "PR title: Remember to name your PR descriptively!"
