### PR TITLE
Fix all the e2e stuff

### DIFF
--- a/query-connector/e2e/customize_query.spec.ts
+++ b/query-connector/e2e/customize_query.spec.ts
@@ -39,6 +39,7 @@ test.describe("querying with the Query Connector", () => {
   });
 
   test("customize query successfully filtering some data", async ({ page }) => {
+    test.slow();
     await expect(
       page.getByText(
         "249 labs found, 4 medications found, 104 conditions found.",
@@ -104,6 +105,7 @@ test.describe("querying with the Query Connector", () => {
   test("customize query select / deselect all filters whole DibbsConceptType, across tabs", async ({
     page,
   }) => {
+    test.slow();
     await page.getByRole("link", { name: "Labs" }).click();
     await page.getByRole("button", { name: "Deselect all labs" }).click();
 

--- a/query-connector/e2e/query_workflow.spec.ts
+++ b/query-connector/e2e/query_workflow.spec.ts
@@ -48,11 +48,6 @@ test.describe("querying with the Query Connector", () => {
     ).toBeVisible();
 
     await page.getByRole("button", { name: "Fill fields" }).click();
-    await page.getByLabel("First Name").fill(TEST_PATIENT.FirstName);
-    await page.getByLabel("Last Name").fill(TEST_PATIENT.LastName);
-    await page.getByLabel("Date of Birth").fill(TEST_PATIENT.DOB);
-    await page.getByLabel("Medical Record Number").fill(TEST_PATIENT.MRN);
-    await page.getByLabel("Phone Number").fill(TEST_PATIENT.Phone);
     await page.getByRole("button", { name: "Search for patient" }).click();
     await expect(page.getByText("Loading")).toHaveCount(0, { timeout: 10000 });
 
@@ -68,13 +63,6 @@ test.describe("querying with the Query Connector", () => {
     // Switching to chlymdia seemed to solve the issue, but leaving this check
     // in just in case something similar happens in the future so the unlucky
     // dev can have a note to help debug.
-    // Update as the unlucky dev: Chromium now has issues with this check present
-    // for chlamydia, as well as issues in another test checking for non-zero values.
-    // Other browsers have no problem navigating both checks as they stand.
-    // Update to the update: the connection issue has broadened to include webkit
-    // and seems to apply with no rhyme or reason to use case. Commenting this out
-    // because it no longer acts as a sanity check but leaving it here as a warning
-    // to others.
     await page.getByRole("button", { name: "Customize Query" }).click();
     await expect(
       page.getByRole("heading", { name: "Customize Query" }),
@@ -113,8 +101,45 @@ test.describe("querying with the Query Connector", () => {
       page.getByRole("button", { name: "Medication Requests", expanded: true }),
     ).toBeVisible();
 
-    // We can also just directly ask the page to find us filtered table rows
-    await expect(page.locator("tbody").locator("tr")).toHaveCount(32);
+    // We can also just directly ask the page to find us the number of rows
+    // in each section of the results page
+    // Observations
+    await expect(
+      page
+        .getByRole("table")
+        .filter({ hasText: "Chlamydia trachomatis DNA" })
+        .getByRole("row"),
+    ).toHaveCount(18);
+    // Encounters
+    await expect(
+      page
+        .getByRole("table")
+        .filter({ hasText: "Sexual overexposure" })
+        .getByRole("row"),
+    ).toHaveCount(5);
+    // Conditions
+    await expect(
+      page
+        .getByRole("table")
+        .filter({ hasText: "Chlamydial infection, unspecified" })
+        .getByRole("row"),
+    ).toHaveCount(3);
+    // Diagnostic Reports
+    await expect(
+      page
+        .getByRole("table")
+        .filter({
+          hasText: "Chlamydia trachomatis and Neisseria gonorrhoeae DNA panel",
+        })
+        .getByRole("row"),
+    ).toHaveCount(4);
+    // Medication Requests
+    await expect(
+      page
+        .getByRole("table")
+        .filter({ hasText: "azithromycin 1000 MG" })
+        .getByRole("row"),
+    ).toHaveCount(7);
 
     // Now let's use the return to search to go back to a blank form
     await page.getByRole("button", { name: "New patient search" }).click();

--- a/query-connector/e2e/query_workflow.spec.ts
+++ b/query-connector/e2e/query_workflow.spec.ts
@@ -75,14 +75,14 @@ test.describe("querying with the Query Connector", () => {
     // and seems to apply with no rhyme or reason to use case. Commenting this out
     // because it no longer acts as a sanity check but leaving it here as a warning
     // to others.
-    // await page.getByRole("button", { name: "Customize Query" }).click();
-    // await expect(
-    //   page.getByRole("heading", { name: "Customize Query" }),
-    // ).toBeVisible();
-    // await expect(
-    //   page.getByText("0 labs found, 0 medications found, 0 conditions found."),
-    // ).not.toBeVisible();
-    // await page.getByText("Return to Select query").click();
+    await page.getByRole("button", { name: "Customize Query" }).click();
+    await expect(
+      page.getByRole("heading", { name: "Customize Query" }),
+    ).toBeVisible();
+    await expect(
+      page.getByText("0 labs found, 0 medications found, 0 conditions found."),
+    ).not.toBeVisible();
+    await page.getByText("Return to Select query").click();
 
     await page.getByRole("button", { name: "Submit" }).click();
     await expect(page.getByText("Loading")).toHaveCount(0, { timeout: 10000 });

--- a/query-connector/playwright.config.ts
+++ b/query-connector/playwright.config.ts
@@ -17,8 +17,8 @@ export default defineConfig({
   /* Fail the build on CI if you accidentally left test.only in the source code. */
   forbidOnly: !!process.env.CI,
   /* Retry on CI only */
-  retries: process.env.CI ? 2 : 0,
-  workers: process.env.CI ? 1 : 1,
+  retries: process.env.CI ? 2 : 2,
+  workers: process.env.CI ? 2 : 2,
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */
   reporter: "html",
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
@@ -29,6 +29,9 @@ export default defineConfig({
     /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
     trace: "on-first-retry",
     video: "on-first-retry",
+  },
+  expect: {
+    timeout: 10 * 1000,
   },
 
   /* Configure projects for major browsers */

--- a/query-connector/src/app/query/SelectQuery.tsx
+++ b/query-connector/src/app/query/SelectQuery.tsx
@@ -61,7 +61,7 @@ const SelectQuery: React.FC<SelectQueryProps> = ({
     [] as ValueSet[],
   );
   const [loadingQueryValueSets, setLoadingQueryValueSets] =
-    useState<boolean>(false);
+    useState<boolean>(true);
 
   const [loadingResultResponse, setLoadingResultResponse] =
     useState<boolean>(false);

--- a/query-connector/src/app/query/components/selectQuery/SelectSavedQuery.tsx
+++ b/query-connector/src/app/query/components/selectQuery/SelectSavedQuery.tsx
@@ -133,8 +133,12 @@ const SelectSavedQuery: React.FC<SelectSavedQueryProps> = ({
       <div className="margin-top-5">
         <Button
           type="button"
-          disabled={!selectedQuery && !loadingQueryValueSets}
-          className={selectedQuery ? "usa-button" : "usa-button disabled"}
+          disabled={!selectedQuery || loadingQueryValueSets}
+          className={
+            selectedQuery && !loadingQueryValueSets
+              ? "usa-button"
+              : "usa-button disabled"
+          }
           onClick={() => handleSubmit()}
         >
           Submit


### PR DESCRIPTION
# Reducing e2e Flakiness

## Summary

This PR attempts to cleanup, refactor, and optimize the settings of our end to end tests to minimized flakiness and errors, both locally and on github. Particular attention is paid to reducing the odds that a dev needs to "rerun" the tests in order to force a github pass, as well as to make sure the tests simply work on run when executing locally. With the browser switch already in place, I used the video/trace logs produced by the e2e's (which are absolutely _fantastic_ and get captured for any end to end test that fails at least once) to create a grid-search optimization table to find the best combination of parameters with which to run the tests. This PR introduces the following changes:

- pins the number of retries for each test to 2, since some tests involving public database calls are flaky and work on subsequent reruns (expected behavior)
- pins the number of parallel workers for all tests and runs to 2, since this reduces timeout probability on github while minimizing impact to runner actions
- eliminates manual field setting after using the FILL FIELDS patient option in test workflows
- marks the customize query tests as natively `.slow()` to allow for additional timeout leniency and suppress warnings (which are now gone across the board for these tests)
- augments global `.expect()` timeouts to allow for different browsers to take more time with display visibility
- fixes the disabling logic of the submit query button after the query select dropdown--previously, the way we had our state setting and `isSubscribed` variables configured means that a query could be selected but the DB query valueset fetch hasn't returned yet. This is now impossible, and the button is fully disabled until a query is selected _and_ the app is no longer loading value sets, a state which is possible only after all `isSusbcribed` followers have been set
- refactors large scale table row count of 32 rows into concrete sections of specific counts per clinical service type, both to reduce flakiness and allow rendering time and to pinpoint an error source if the test does break due to the public server not returning medication requests / diagnostic reports

## Related Issue

No issue was created for this, but this is my final attempt at cleaning up local e2e development troubles once and for all

## Additional Information

I ran the tests on this github page four separate times after my latest commit and all four passed with no retries or breaks in between, so this configuration seems like something github can handle.