### PR TITLE
Allow overwriting inserts

### DIFF
--- a/query-connector/src/app/database-service.ts
+++ b/query-connector/src/app/database-service.ts
@@ -311,7 +311,22 @@ function generateConceptSqlPromises(vs: ValueSet) {
   const insertConceptsSqlArray = vs.concepts.map((concept) => {
     const systemPrefix = stripProtocolAndTLDFromSystemUrl(vs.system);
     const conceptUniqueId = `${systemPrefix}_${concept.code}`;
-    const insertConceptSql = `INSERT INTO concepts VALUES($1,$2,$3,$4,$5,$6) RETURNING id;`;
+
+    // Duplicate value set insertion is likely to percolate to the concept level
+    // Apply the same logic of overwriting if unique keys are the same
+    const insertConceptSql = `
+    INSERT INTO concepts
+      VALUES($1,$2,$3,$4,$5,$6)
+      ON CONFLICT(id)
+      DO UPDATE SET
+        id = EXCLUDED.id,
+        code = EXCLUDED.code,
+        code_system = EXCLUDED.code_system,
+        display = EXCLUDED.display,
+        gem_formatted_code = EXCLUDED.gem_formatted_code,
+        version = EXCLUDED.version
+      RETURNING id;
+    `;
     const conceptInsertPromise = dbClient.query(insertConceptSql, [
       conceptUniqueId,
       concept.code,
@@ -333,7 +348,20 @@ function generateValuesetConceptJoinSqlPromises(vs: ValueSet) {
   const insertConceptsSqlArray = vs.concepts.map((concept) => {
     const systemPrefix = stripProtocolAndTLDFromSystemUrl(vs.system);
     const conceptUniqueId = `${systemPrefix}_${concept.code}`;
-    const insertJoinSql = `INSERT INTO valueset_to_concept VALUES($1,$2, $3) RETURNING valueset_id, concept_id;`;
+
+    // Last place to make an overwriting upsert adjustment
+    // Even if the duplicate entries have the same data, PG will attempt to
+    // insert another row, so just make that upsert the relationship
+    const insertJoinSql = `
+    INSERT INTO valueset_to_concept
+    VALUES($1,$2,$3)
+    ON CONFLICT(id)
+    DO UPDATE SET
+      id = EXCLUDED.id,
+      valueset_id = EXCLUDED.valueset_id,
+      concept_id = EXCLUDED.concept_id
+    RETURNING valueset_id, concept_id;
+    `;
     const conceptInsertPromise = dbClient.query(insertJoinSql, [
       `${valueSetUniqueId}_${conceptUniqueId}`,
       valueSetUniqueId,


### PR DESCRIPTION
# Allow overwriting inserts

## Summary

This PR modifies the `INSERT` statement of our `InsertValueSet` function to allow for duplicated uniqueIDs to overwrite those of existing entries. Our DB creation process will go through a fair number of duplicate value sets after pulling down the eRSD, so simply overwriting them with the same data will allow the seeding process to proceed more smoothly than error-ing and breaking the transaction.

## Related Issue

Fixes #81 

## Additional Information

I created a test branch here https://github.com/CDCgov/dibbs-query-connector/tree/test-vs-overwrite that removes database seeding in migrations 2 through 6, and instead adds a button to the landing page that tests a couple cases of inserting valuesets and duplicates into the DB. No errors get thrown and viewing the DB in DBeaver shows all rows correctly entered.