### PR TITLE
Create json for custom valuesets using internal valueset schema

### DIFF
--- a/query-connector/src/app/assets/DIBBS_Custom_ValueSets.json
+++ b/query-connector/src/app/assets/DIBBS_Custom_ValueSets.json
@@ -1,0 +1,962 @@
+{
+  "newborn_screening": [
+    {
+      "valueSetId": "1_20241031_16",
+      "valueSetVersion": "1",
+      "valueSetName": "Newborn Screening Metabolic Disorder Confirmatory Labs",
+      "valueSetExternalId": "20241031_16",
+      "author": "Center for Public Health Innovation",
+      "system": "http://loinc.org",
+      "ersdConceptType": "lrtc",
+      "dibbsConceptType": "labs",
+      "includeValueSet": true,
+      "concepts": [
+        {
+          "code": "46252-3",
+          "display": "Acylcarnitine pattern [Interpretation] in Serum or Plasma",
+          "include": true
+        },
+        {
+          "code": "30191-1",
+          "display": "Acetylcarnitine (C2) [Moles/volume] in Serum or Plasma",
+          "include": true
+        },
+        {
+          "code": "30551-6",
+          "display": "Propionylcarnitine (C3) [Moles/volume] in Serum or Plasma",
+          "include": true
+        },
+        {
+          "code": "51413-3",
+          "display": "Butyrylcarnitine+Isobutyrylcarnitine (C4) [Moles/volume] in Serum or Plasma",
+          "include": true
+        },
+        {
+          "code": "30531-8",
+          "display": "Isovalerylcarnitine+Methylbutyrylcarnitine (C5) [Moles/volume] in Serum or Plasma",
+          "include": true
+        },
+        {
+          "code": "30349-5",
+          "display": "Glutarylcarnitine (C5-DC) [Moles/volume] in Serum or Plasma",
+          "include": true
+        },
+        {
+          "code": "39001-3",
+          "display": "3-Hydroxyisovalerylcarnitine (C5-OH) [Moles/volume] in Serum or Plasma",
+          "include": true
+        },
+        {
+          "code": "30358-6",
+          "display": "Hexanoylcarnitine (C6) [Moles/volume] in Serum or Plasma",
+          "include": true
+        },
+        {
+          "code": "30540-9",
+          "display": "Octanoylcarnitine (C8) [Moles/volume] in Serum or Plasma",
+          "include": true
+        },
+        {
+          "code": "30541-7",
+          "display": "Octenoylcarnitine (C8:1) [Moles/volume] in Serum or Plasma",
+          "include": true
+        },
+        {
+          "code": "30327-1",
+          "display": "Decanoylcarnitine (C10) [Moles/volume] in Serum or Plasma",
+          "include": true
+        },
+        {
+          "code": "30328-9",
+          "display": "Decenoylcarnitine (C10:1) [Moles/volume] in Serum or Plasma",
+          "include": true
+        },
+        {
+          "code": "30331-3",
+          "display": "Dodecanoylcarnitine (C12) [Moles/volume] in Serum or Plasma",
+          "include": true
+        },
+        {
+          "code": "30332-1",
+          "display": "Dodecenoylcarnitine (C12:1) [Moles/volume] in Serum or Plasma",
+          "include": true
+        },
+        {
+          "code": "30233-1",
+          "display": "3-Hydroxydodecanoylcarnitine (C12-OH) [Moles/volume] in Serum or Plasma",
+          "include": true
+        },
+        {
+          "code": "30564-9",
+          "display": "Tetradecadienoylcarnitine (C14:2) [Moles/volume] in Serum or Plasma",
+          "include": true
+        },
+        {
+          "code": "30565-6",
+          "display": "Tetradecanoylcarnitine (C14) [Moles/volume] in Serum or Plasma",
+          "include": true
+        },
+        {
+          "code": "30566-4",
+          "display": "Tetradecenoylcarnitine (C14:1) [Moles/volume] in Serum or Plasma",
+          "include": true
+        },
+        {
+          "code": "30190-3",
+          "display": "3-Hydroxytetradecenoylcarnitine (C14:1-OH) [Moles/volume] in Serum or Plasma",
+          "include": true
+        },
+        {
+          "code": "30238-0",
+          "display": "3-Hydroxytetradecanoylcarnitine (C14-OH) [Moles/volume] in Serum or Plasma",
+          "include": true
+        },
+        {
+          "code": "30356-0",
+          "display": "Palmitoylcarnitine (C16) [Moles/volume] in Serum or Plasma",
+          "include": true
+        },
+        {
+          "code": "30357-8",
+          "display": "Palmitoleylcarnitine (C16:1) [Moles/volume] in Serum or Plasma",
+          "include": true
+        },
+        {
+          "code": "30235-6",
+          "display": "3-Hydroxypalmitoleylcarnitine (C16:1-OH) [Moles/volume] in Serum or Plasma",
+          "include": true
+        },
+        {
+          "code": "30234-9",
+          "display": "3-Hydroxypalmitoylcarnitine (C16-OH) [Moles/volume] in Serum or Plasma",
+          "include": true
+        },
+        {
+          "code": "30560-7",
+          "display": "Stearoylcarnitine (C18) [Moles/volume] in Serum or Plasma",
+          "include": true
+        },
+        {
+          "code": "35656-8",
+          "display": "3-Hydroxystearoylcarnitine (C18-OH) [Moles/volume] in Serum or Plasma",
+          "include": true
+        },
+        {
+          "code": "30542-5",
+          "display": "Oleoylcarnitine (C18:1) [Moles/volume] in Serum or Plasma",
+          "include": true
+        },
+        {
+          "code": "30312-3",
+          "display": "3-Hydroxyoleoylcarnitine (C18:1-OH) [Moles/volume] in Serum or Plasma",
+          "include": true
+        },
+        {
+          "code": "30534-2",
+          "display": "Linoleoylcarnitine (C18:2) [Moles/volume] in Serum or Plasma",
+          "include": true
+        },
+        {
+          "code": "30237-2",
+          "display": "3-Hydroxylinoleoylcarnitine (C18:2-OH) [Moles/volume] in Serum or Plasma",
+          "include": true
+        },
+        {
+          "code": "53718-3",
+          "display": "Acylglycines [Interpretation] in Urine Narrative",
+          "include": true
+        },
+        {
+          "code": "2161-8",
+          "display": "Creatinine [Mass/volume] in Urine",
+          "include": true
+        },
+        {
+          "code": "24442-6",
+          "display": "Propionylglycine/Creatinine [Molar ratio] in Urine",
+          "include": true
+        },
+        {
+          "code": "24437-6",
+          "display": "Butyrylglycine/Creatinine [Molar ratio] in Urine",
+          "include": true
+        },
+        {
+          "code": "24438-4",
+          "display": "Hexanoylglycine/Creatinine [Molar ratio] in Urine",
+          "include": true
+        },
+        {
+          "code": "24439-2",
+          "display": "Isobutyrylglycine/Creatinine [Molar ratio] in Urine",
+          "include": true
+        },
+        {
+          "code": "24440-0",
+          "display": "Isovalerylglycine/Creatinine [Molar ratio] in Urine",
+          "include": true
+        },
+        {
+          "code": "24435-0",
+          "display": "2-Methylbutyrylglycine/Creatinine [Molar ratio] in Urine",
+          "include": true
+        },
+        {
+          "code": "24441-8",
+          "display": "Phenylpropionylglycine/Creatinine [Molar ratio] in Urine",
+          "include": true
+        },
+        {
+          "code": "24443-4",
+          "display": "Suberylglycine/Creatinine [Molar ratio] in Urine",
+          "include": true
+        },
+        {
+          "code": "24436-8",
+          "display": "3-Methylcrotonylglycine/Creatinine [Molar ratio] in Urine",
+          "include": true
+        },
+        {
+          "code": "24444-2",
+          "display": "Tiglylglycine/Creatinine [Molar ratio] in Urine",
+          "include": true
+        },
+        {
+          "code": "14286-9",
+          "display": "Carnitine free (C0) [Moles/volume] in Serum or Plasma",
+          "include": true
+        },
+        {
+          "code": "14288-5",
+          "display": "Carnitine [Moles/volume] in Serum or Plasma",
+          "include": true
+        },
+        {
+          "code": "19074-4",
+          "display": "Carnitine esters [Moles/volume] in Serum or Plasma",
+          "include": true
+        },
+        {
+          "code": "40869-0",
+          "display": "Carnitine esters/Carnitine.free (C0) [Molar ratio] in Serum or Plasma",
+          "include": true
+        },
+        {
+          "code": "17866-5",
+          "display": "Carnitine/Creatinine [Ratio] in Urine",
+          "include": true
+        },
+        {
+          "code": "17867-3",
+          "display": "Carnitine free (C0)/Creatinine [Ratio] in Urine",
+          "include": true
+        },
+        {
+          "code": "28589-0",
+          "display": "Carnitine esters/Creatinine [Ratio] in Urine",
+          "include": true
+        },
+        {
+          "code": "54442-9",
+          "display": "Carnitine esters/Carnitine.free (C0) [Molar ratio] in Urine",
+          "include": true
+        },
+        {
+          "code": "79291-1",
+          "display": "Creatine and guanidinoacetate pattern [Interpretation] in Serum or Plasma Narrative",
+          "include": true
+        },
+        {
+          "code": "15045-8",
+          "display": "Creatine [Moles/volume] in Serum or Plasma",
+          "include": true
+        },
+        {
+          "code": "33244-5",
+          "display": "Guanidinoacetate [Moles/volume] in Serum or Plasma",
+          "include": true
+        },
+        {
+          "code": "79292-9",
+          "display": "Creatine, guanidinoacetate and creatinine pattern [Interpretation] in Urine Narrative",
+          "include": true
+        },
+        {
+          "code": "14683-7",
+          "display": "Creatinine [Moles/volume] in Urine",
+          "include": true
+        },
+        {
+          "code": "34275-8",
+          "display": "Creatine/Creatinine [Molar ratio] in Urine",
+          "include": true
+        },
+        {
+          "code": "34155-2",
+          "display": "Guanidinoacetate/Creatinine [Molar ratio] in Urine",
+          "include": true
+        },
+        {
+          "code": "13500-4",
+          "display": "Amino acid pattern [Interpretation] in Serum or Plasma",
+          "include": true
+        },
+        {
+          "code": "26604-9",
+          "display": "Beta alanine [Moles/volume] in Serum or Plasma",
+          "include": true
+        },
+        {
+          "code": "20636-7",
+          "display": "Alanine [Moles/volume] in Serum or Plasma",
+          "include": true
+        },
+        {
+          "code": "22670-4",
+          "display": "Alloisoleucine [Moles/volume] in Serum or Plasma",
+          "include": true
+        },
+        {
+          "code": "26600-7",
+          "display": "Alpha aminoadipate [Moles/volume] in Serum or Plasma",
+          "include": true
+        },
+        {
+          "code": "26609-8",
+          "display": "Gamma aminobutyrate [Moles/volume] in Serum or Plasma",
+          "include": true
+        },
+        {
+          "code": "26605-6",
+          "display": "Beta aminoisobutyrate [Moles/volume] in Serum or Plasma",
+          "include": true
+        },
+        {
+          "code": "20634-2",
+          "display": "Alpha aminobutyrate [Moles/volume] in Serum or Plasma",
+          "include": true
+        },
+        {
+          "code": "26599-1",
+          "display": "Anserine [Moles/volume] in Serum or Plasma",
+          "include": true
+        },
+        {
+          "code": "20637-5",
+          "display": "Arginine [Moles/volume] in Serum or Plasma",
+          "include": true
+        },
+        {
+          "code": "32227-1",
+          "display": "Argininosuccinate [Moles/volume] in Serum or Plasma",
+          "include": true
+        },
+        {
+          "code": "20638-3",
+          "display": "Asparagine [Moles/volume] in Serum or Plasma",
+          "include": true
+        },
+        {
+          "code": "20639-1",
+          "display": "Aspartate [Moles/volume] in Serum or Plasma",
+          "include": true
+        },
+        {
+          "code": "20640-9",
+          "display": "Citrulline [Moles/volume] in Serum or Plasma",
+          "include": true
+        },
+        {
+          "code": "26607-2",
+          "display": "Cystathionine [Moles/volume] in Serum or Plasma",
+          "include": true
+        },
+        {
+          "code": "22672-0",
+          "display": "Cystine [Moles/volume] in Serum or Plasma",
+          "include": true
+        },
+        {
+          "code": "26608-0",
+          "display": "Ethanolamine [Moles/volume] in Serum or Plasma",
+          "include": true
+        },
+        {
+          "code": "20642-5",
+          "display": "Glutamate [Moles/volume] in Serum or Plasma",
+          "include": true
+        },
+        {
+          "code": "20643-3",
+          "display": "Glutamine [Moles/volume] in Serum or Plasma",
+          "include": true
+        },
+        {
+          "code": "20644-1",
+          "display": "Glycine [Moles/volume] in Serum or Plasma",
+          "include": true
+        },
+        {
+          "code": "20645-8",
+          "display": "Histidine [Moles/volume] in Serum or Plasma",
+          "include": true
+        },
+        {
+          "code": "55876-7",
+          "display": "Homocitrulline [Moles/volume] in Serum or Plasma",
+          "include": true
+        },
+        {
+          "code": "20646-6",
+          "display": "Homocystine [Moles/volume] in Serum or Plasma",
+          "include": true
+        },
+        {
+          "code": "26610-6",
+          "display": "Hydroxylysine [Moles/volume] in Serum or Plasma",
+          "include": true
+        },
+        {
+          "code": "20647-4",
+          "display": "Hydroxyproline [Moles/volume] in Serum or Plasma",
+          "include": true
+        },
+        {
+          "code": "20648-2",
+          "display": "Isoleucine [Moles/volume] in Serum or Plasma",
+          "include": true
+        },
+        {
+          "code": "20649-0",
+          "display": "Leucine [Moles/volume] in Serum or Plasma",
+          "include": true
+        },
+        {
+          "code": "20650-8",
+          "display": "Lysine [Moles/volume] in Serum or Plasma",
+          "include": true
+        },
+        {
+          "code": "20651-6",
+          "display": "Methionine [Moles/volume] in Serum or Plasma",
+          "include": true
+        },
+        {
+          "code": "20652-4",
+          "display": "Ornithine [Moles/volume] in Serum or Plasma",
+          "include": true
+        },
+        {
+          "code": "14875-9",
+          "display": "Phenylalanine [Moles/volume] in Serum or Plasma",
+          "include": true
+        },
+        {
+          "code": "20655-7",
+          "display": "Proline [Moles/volume] in Serum or Plasma",
+          "include": true
+        },
+        {
+          "code": "26613-0",
+          "display": "Sarcosine [Moles/volume] in Serum or Plasma",
+          "include": true
+        },
+        {
+          "code": "20656-5",
+          "display": "Serine [Moles/volume] in Serum or Plasma",
+          "include": true
+        },
+        {
+          "code": "20657-3",
+          "display": "Taurine [Moles/volume] in Serum or Plasma",
+          "include": true
+        },
+        {
+          "code": "20658-1",
+          "display": "Threonine [Moles/volume] in Serum or Plasma",
+          "include": true
+        },
+        {
+          "code": "20659-9",
+          "display": "Tryptophan [Moles/volume] in Serum or Plasma",
+          "include": true
+        },
+        {
+          "code": "20660-7",
+          "display": "Tyrosine [Moles/volume] in Serum or Plasma",
+          "include": true
+        },
+        {
+          "code": "20661-5",
+          "display": "Valine [Moles/volume] in Serum or Plasma",
+          "include": true
+        },
+        {
+          "code": "49248-8",
+          "display": "Amino acid pattern [Interpretation] in Urine Narrative",
+          "include": true
+        },
+        {
+          "code": "28588-2",
+          "display": "Beta alanine/Creatinine [Ratio] in Urine",
+          "include": true
+        },
+        {
+          "code": "30068-1",
+          "display": "Alanine/Creatinine [Ratio] in Urine",
+          "include": true
+        },
+        {
+          "code": "28598-1",
+          "display": "Alpha aminoadipate/Creatinine [Ratio] in Urine",
+          "include": true
+        },
+        {
+          "code": "28590-8",
+          "display": "Alpha aminobutyrate/Creatinine [Ratio] in Urine",
+          "include": true
+        },
+        {
+          "code": "28596-5",
+          "display": "Anserine/Creatinine [Ratio] in Urine",
+          "include": true
+        },
+        {
+          "code": "30062-4",
+          "display": "Arginine/Creatinine [Ratio] in Urine",
+          "include": true
+        },
+        {
+          "code": "32229-7",
+          "display": "Argininosuccinate/Creatinine [Ratio] in Urine",
+          "include": true
+        },
+        {
+          "code": "28603-9",
+          "display": "Asparagine/Creatinine [Ratio] in Urine",
+          "include": true
+        },
+        {
+          "code": "30061-6",
+          "display": "Aspartate/Creatinine [Ratio] in Urine",
+          "include": true
+        },
+        {
+          "code": "28602-1",
+          "display": "Beta aminoisobutyrate/Creatinine [Ratio] in Urine",
+          "include": true
+        },
+        {
+          "code": "30161-4",
+          "display": "Citrulline/Creatinine [Ratio] in Urine",
+          "include": true
+        },
+        {
+          "code": "28599-9",
+          "display": "Cystathionine/Creatinine [Ratio] in Urine",
+          "include": true
+        },
+        {
+          "code": "30065-7",
+          "display": "Cystine/Creatinine [Ratio] in Urine",
+          "include": true
+        },
+        {
+          "code": "28605-4",
+          "display": "Ethanolamine/Creatinine [Ratio] in Urine",
+          "include": true
+        },
+        {
+          "code": "28593-2",
+          "display": "Gamma aminobutyrate/Creatinine [Ratio] in Urine",
+          "include": true
+        },
+        {
+          "code": "30059-0",
+          "display": "Glutamate/Creatinine [Ratio] in Urine",
+          "include": true
+        },
+        {
+          "code": "30056-6",
+          "display": "Glutamine/Creatinine [Ratio] in Urine",
+          "include": true
+        },
+        {
+          "code": "30066-5",
+          "display": "Glycine/Creatinine [Ratio] in Urine",
+          "include": true
+        },
+        {
+          "code": "30047-5",
+          "display": "Histidine/Creatinine [Ratio] in Urine",
+          "include": true
+        },
+        {
+          "code": "32248-7",
+          "display": "Homocitrulline/Creatinine [Ratio] in Urine",
+          "include": true
+        },
+        {
+          "code": "30050-9",
+          "display": "Hydroxylysine/Creatinine [Ratio] in Urine",
+          "include": true
+        },
+        {
+          "code": "28601-3",
+          "display": "Hydroxyproline/Creatinine [Ratio] in Urine",
+          "include": true
+        },
+        {
+          "code": "30052-5",
+          "display": "Isoleucine/Creatinine [Ratio] in Urine",
+          "include": true
+        },
+        {
+          "code": "30053-3",
+          "display": "Leucine/Creatinine [Ratio] in Urine",
+          "include": true
+        },
+        {
+          "code": "30048-3",
+          "display": "Lysine/Creatinine [Ratio] in Urine",
+          "include": true
+        },
+        {
+          "code": "30063-2",
+          "display": "Methionine/Creatinine [Ratio] in Urine",
+          "include": true
+        },
+        {
+          "code": "30049-1",
+          "display": "Ornithine/Creatinine [Ratio] in Urine",
+          "include": true
+        },
+        {
+          "code": "30055-8",
+          "display": "Phenylalanine/Creatinine [Ratio] in Urine",
+          "include": true
+        },
+        {
+          "code": "30067-3",
+          "display": "Proline/Creatinine [Ratio] in Urine",
+          "include": true
+        },
+        {
+          "code": "28610-4",
+          "display": "Sarcosine/Creatinine [Ratio] in Urine",
+          "include": true
+        },
+        {
+          "code": "30058-2",
+          "display": "Serine/Creatinine [Ratio] in Urine",
+          "include": true
+        },
+        {
+          "code": "28595-7",
+          "display": "Taurine/Creatinine [Ratio] in Urine",
+          "include": true
+        },
+        {
+          "code": "30057-4",
+          "display": "Threonine/Creatinine [Ratio] in Urine",
+          "include": true
+        },
+        {
+          "code": "28608-8",
+          "display": "Tryptophan/Creatinine [Ratio] in Urine",
+          "include": true
+        },
+        {
+          "code": "30054-1",
+          "display": "Tyrosine/Creatinine [Ratio] in Urine",
+          "include": true
+        },
+        {
+          "code": "30064-0",
+          "display": "Valine/Creatinine [Ratio] in Urine",
+          "include": true
+        },
+        {
+          "code": "33477-1",
+          "display": "Organic acids pattern [Interpretation] in Urine",
+          "include": true
+        },
+        {
+          "code": "25112-4",
+          "display": "Lactate/Creatinine [Molar ratio] in Urine",
+          "include": true
+        },
+        {
+          "code": "25132-2",
+          "display": "Pyruvate/Creatinine [Molar ratio] in Urine",
+          "include": true
+        },
+        {
+          "code": "25136-3",
+          "display": "Succinate/Creatinine [Molar ratio] in Urine",
+          "include": true
+        },
+        {
+          "code": "29507-1",
+          "display": "Alpha ketoglutarate/Creatinine [Molar ratio] in Urine",
+          "include": true
+        },
+        {
+          "code": "25101-7",
+          "display": "Fumarate/Creatinine [Molar ratio] in Urine",
+          "include": true
+        },
+        {
+          "code": "25116-5",
+          "display": "Methylmalonate/Creatinine [Molar ratio] in Urine",
+          "include": true
+        },
+        {
+          "code": "29509-7",
+          "display": "Beta hydroxybutyrate/Creatinine [Molar ratio] in Urine",
+          "include": true
+        },
+        {
+          "code": "29524-6",
+          "display": "Acetoacetate/Creatinine [Molar ratio] in Urine",
+          "include": true
+        },
+        {
+          "code": "25083-7",
+          "display": "2-Oxo,3-Methylvalerate/Creatinine [Molar ratio] in Urine",
+          "include": true
+        },
+        {
+          "code": "25084-5",
+          "display": "2-Oxoisocaproate/Creatinine [Molar ratio] in Urine",
+          "include": true
+        },
+        {
+          "code": "25085-2",
+          "display": "2-Oxoisovalerate/Creatinine [Molar ratio] in Urine",
+          "include": true
+        },
+        {
+          "code": "25099-3",
+          "display": "Ethylmalonate/Creatinine [Molar ratio] in Urine",
+          "include": true
+        },
+        {
+          "code": "29859-6",
+          "display": "Adipate/Creatinine [Molar ratio] in Urine",
+          "include": true
+        },
+        {
+          "code": "25135-5",
+          "display": "Suberate/Creatinine [Molar ratio] in Urine",
+          "include": true
+        },
+        {
+          "code": "25134-8",
+          "display": "Sebacate (C8)/Creatinine [Molar ratio] in Urine",
+          "include": true
+        },
+        {
+          "code": "25088-6",
+          "display": "4-Hydroxyphenylacetate/Creatinine [Molar ratio] in Urine",
+          "include": true
+        },
+        {
+          "code": "25089-4",
+          "display": "4-Hydroxyphenyllactate/Creatinine [Molar ratio] in Urine",
+          "include": true
+        },
+        {
+          "code": "29519-6",
+          "display": "4-Hydroxyphenylpyruvate/Creatinine [Molar ratio] in Urine",
+          "include": true
+        },
+        {
+          "code": "25137-1",
+          "display": "Succinylacetone/Creatinine [Molar ratio] in Urine",
+          "include": true
+        },
+        {
+          "code": "1982-8",
+          "display": "Biotinidase [Enzymatic activity/volume] in Serum or Plasma",
+          "include": true
+        },
+        {
+          "code": "54457-7",
+          "display": "Biotinidase [Enzymatic activity/volume] in Serum or Plasma from Normal control",
+          "include": true
+        },
+        {
+          "code": "3024-7",
+          "display": "Thyroxine (T4) free [Mass/volume] in Serum or Plasma",
+          "include": true
+        },
+        {
+          "code": "3016-3",
+          "display": "Thyrotropin [Units/volume] in Serum or Plasma",
+          "include": true
+        },
+        {
+          "code": "1668-3",
+          "display": "17-Hydroxyprogesterone [Mass/volume] in Serum or Plasma",
+          "include": true
+        },
+        {
+          "code": "2077-6",
+          "display": "Chloride [Moles/volume] in Sweat",
+          "include": true
+        },
+        {
+          "code": "2954-6",
+          "display": "Sodium [Moles/volume] in Sweat",
+          "include": true
+        },
+        {
+          "code": "42940-7",
+          "display": "GALT gene allele 1 [Presence] in Blood by Molecular genetics method",
+          "include": true
+        },
+        {
+          "code": "42941-5",
+          "display": "GALT gene allele 2 [Presence] in Blood by Molecular genetics method",
+          "include": true
+        },
+        {
+          "code": "10970-2",
+          "display": "Galactose 1 phosphate uridyl transferase [Enzymatic activity/volume] in Blood",
+          "include": true
+        },
+        {
+          "code": "2312-7",
+          "display": "Galactose 1 phosphate [Mass/volume] in Red Blood Cells",
+          "include": true
+        },
+        {
+          "code": "33360-9",
+          "display": "Galactose 1 phosphate [Mass/mass] in Red Blood Cells",
+          "include": true
+        },
+        {
+          "code": "38485-9",
+          "display": "Galactose 1 phosphate [Moles/mass] in Red Blood Cells",
+          "include": true
+        },
+        {
+          "code": "48767-8",
+          "display": "Annotation comment [Interpretation] Narrative",
+          "include": true
+        },
+        {
+          "code": "33617-2",
+          "display": "HLA-DR+ cells [#/volume] in Blood",
+          "include": true
+        },
+        {
+          "code": "15195-1",
+          "display": "CD3-CD19+ cells [#/volume] in Blood",
+          "include": true
+        },
+        {
+          "code": "32519-1",
+          "display": "CD3-CD16+CD56+ (Natural killer) cells/100 cells in Unspecified specimen",
+          "include": true
+        },
+        {
+          "code": "20604-5",
+          "display": "CD3-CD16+CD56+ (Natural killer) cells [#/volume] in Unspecified specimen",
+          "include": true
+        },
+        {
+          "code": "34475-4",
+          "display": "CD4+CD45RO+ cells [#/volume] in Blood",
+          "include": true
+        },
+        {
+          "code": "41994-5",
+          "display": "CD4+CD45RO+ cells/100 cells in Blood",
+          "include": true
+        },
+        {
+          "code": "26759-1",
+          "display": "CD4+CD45RA+ cells [#/volume] in Blood",
+          "include": true
+        },
+        {
+          "code": "17157-9",
+          "display": "CD45RA cells/100 cells in Blood",
+          "include": true
+        },
+        {
+          "code": "31113-4",
+          "display": "HLA-DR+ cells/100 cells in Blood",
+          "include": true
+        },
+        {
+          "code": "8122-4",
+          "display": "CD3 cells [#/volume] in Blood",
+          "include": true
+        },
+        {
+          "code": "20599-7",
+          "display": "CD3 cells/100 cells in Unspecified specimen",
+          "include": true
+        },
+        {
+          "code": "24467-3",
+          "display": "CD3+CD4+ (T4 helper) cells [#/volume] in Blood",
+          "include": true
+        },
+        {
+          "code": "14135-8",
+          "display": "CD3+CD8+ (T8 suppressor cells) cells [#/volume] in Blood",
+          "include": true
+        },
+        {
+          "code": "8123-2",
+          "display": "CD3+CD4+ (T4 helper) cells/100 cells in Blood",
+          "include": true
+        },
+        {
+          "code": "32518-3",
+          "display": "CD3+CD8+ (T8 suppressor cells) cells/100 cells in Unspecified specimen",
+          "include": true
+        },
+        {
+          "code": "20593-0",
+          "display": "CD19 cells/100 cells in Unspecified specimen",
+          "include": true
+        },
+        {
+          "code": "54218-3",
+          "display": "CD3+CD4+ (T4 helper) cells/CD3+CD8+ (T8 suppressor cells) cells [# Ratio] in Blood",
+          "include": true
+        },
+        {
+          "code": "8118-2",
+          "display": "CD2 cells/100 cells in Blood",
+          "include": true
+        },
+        {
+          "code": "9557-0",
+          "display": "CD2 cells [#/volume] in Blood",
+          "include": true
+        },
+        {
+          "code": "49857-6",
+          "display": "SMN1 gene+SMN2 gene targeted mutation analysis in Blood or Tissue by Molecular genetics method Narrative",
+          "include": true
+        },
+        {
+          "code": "35462-1",
+          "display": "SMN1 gene targeted mutation analysis in Blood or Tissue by Molecular genetics method Narrative",
+          "include": true
+        },
+        {
+          "code": "54449-4",
+          "display": "SMN2 gene targeted mutation analysis in Blood or Tissue by Molecular genetics method Narrative",
+          "include": true
+        }
+      ]
+    }
+  ]
+}

--- a/query-connector/src/app/assets/DIBBS_Custom_ValueSets.json
+++ b/query-connector/src/app/assets/DIBBS_Custom_ValueSets.json
@@ -1,10 +1,10 @@
 {
   "newborn_screening": [
     {
-      "valueSetId": "1_20241031_16",
+      "valueSetId": "1_20241015_16",
       "valueSetVersion": "1",
       "valueSetName": "Newborn Screening Metabolic Disorder Confirmatory Labs",
-      "valueSetExternalId": "20241031_16",
+      "valueSetExternalId": "20241015_16",
       "author": "Center for Public Health Innovation",
       "system": "http://loinc.org",
       "ersdConceptType": "lrtc",
@@ -954,6 +954,381 @@
         {
           "code": "54449-4",
           "display": "SMN2 gene targeted mutation analysis in Blood or Tissue by Molecular genetics method Narrative",
+          "include": true
+        }
+      ]
+    },
+    {
+      "valueSetId": "1_20240909_1",
+      "valueSetVersion": "1",
+      "valueSetName": "Basic Newborn Screening Panel",
+      "valueSetExternalId": "20240909_1",
+      "author": "DIBBs",
+      "system": "http://loinc.org",
+      "ersdConceptType": "lotc",
+      "dibbsConceptType": "labs",
+      "includeValueSet": true,
+      "concepts": [
+        {
+          "code": "73700-7",
+          "display": "CCHD newborn screening interpretation",
+          "include": true
+        },
+        {
+          "code": "73698-3",
+          "display": "Reason CCHD oxygen saturation screening not performed",
+          "include": true
+        },
+        {
+          "code": "54108-6",
+          "display": "Newborn hearing screen of Ear - left",
+          "include": true
+        },
+        {
+          "code": "54109-4",
+          "display": "Newborn hearing screen of Ear - right",
+          "include": true
+        },
+        {
+          "code": "58232-0",
+          "display": "Hearing loss risk indicators",
+          "include": true
+        },
+        {
+          "code": "57700-7",
+          "display": "Hearing loss newborn screening comment-discussion",
+          "include": true
+        },
+        {
+          "code": "73739-5",
+          "display": "Newborn hearing screen reason not performed of Ear - left",
+          "include": true
+        },
+        {
+          "code": "73742-9",
+          "display": "Newborn hearing screen reason not performed of Ear - right",
+          "include": true
+        },
+        {
+          "code": "2708-6",
+          "display": "Cannabinoids [Presence] in Vitreous fluid",
+          "include": true
+        },
+        {
+          "code": "8336-0",
+          "display": "Body weight [Percentile] Per age",
+          "include": true
+        }
+      ]
+    }
+  ],
+  "cancer": [
+    {
+      "valueSetId": "1_20240909_2",
+      "valueSetVersion": "1",
+      "valueSetName": "Cancer (Leukemia) Diagnosis Problems",
+      "valueSetExternalId": "20240909_2",
+      "author": "DIBBs",
+      "system": "http://snomed.info/sct",
+      "ersdConceptType": "dxtc",
+      "dibbsConceptType": "conditions",
+      "includeValueSet": true,
+      "concepts": [
+        {
+          "code": "2.16.840.1.113762.1.4.1146.1407_92814006",
+          "display": "Chronic lymphoid leukemia, disease (disorder)",
+          "include": true
+        },
+        {
+          "code": "418689008",
+          "display": "Allergy to sulfonamide",
+          "include": true
+        },
+        {
+          "code": "363346000",
+          "display": "Malignant neoplastic disease (disorder)",
+          "include": true
+        }
+      ]
+    },
+    {
+      "valueSetId": "1_20240909_3",
+      "valueSetVersion": "1",
+      "valueSetName": "Cancer (Leukemia) Medications",
+      "valueSetExternalId": "20240909_3",
+      "author": "DIBBs",
+      "system": "http://www.nlm.nih.gov/research/umls/rxnorm",
+      "ersdConceptType": "mrtc",
+      "dibbsConceptType": "medications",
+      "includeValueSet": true,
+      "concepts": [
+        {
+          "code": "828265",
+          "display": "1 ML alemtuzumab 30 MG/ML Injection",
+          "include": true
+        }
+      ]
+    },
+    {
+      "valueSetId": "1_20240923_14",
+      "valueSetVersion": "1",
+      "valueSetName": "Cancer (Leukemia) Lab Results",
+      "valueSetExternalId": "20240923_14",
+      "author": "DIBBs",
+      "system": "http://cap.org/eCC",
+      "ersdConceptType": "lrtc",
+      "dibbsConceptType": "labs",
+      "includeValueSet": true,
+      "concepts": [
+        {
+          "code": "30000.100004300",
+          "display": "MSH2 Result",
+          "include": true
+        },
+        {
+          "code": "9484.100004300",
+          "display": "RESULTS",
+          "include": true
+        }
+      ]
+    },
+    {
+      "valueSetId": "1_20240923_15",
+      "valueSetVersion": "1",
+      "valueSetName": "Suspected Cancer (Leukemia) Diagnosis",
+      "valueSetExternalId": "20240923_15",
+      "author": "DIBBs",
+      "system": "http://snomed.info/sct",
+      "ersdConceptType": "sdtc",
+      "dibbsConceptType": "conditions",
+      "includeValueSet": true,
+      "concepts": [
+        {
+          "code": "1255068005",
+          "display": "Presence of DNA mismatch repair protein MSH2 in primary malignant neoplasm of colon by immunohistochemistry (observable entity)",
+          "include": true
+        }
+      ]
+    }
+  ],
+  "syphilis": [
+    {
+      "valueSetId": "1_20240909_4",
+      "valueSetVersion": "1",
+      "valueSetName": "Syphilis Medications",
+      "valueSetExternalId": "20240909_4",
+      "author": "DIBBs",
+      "system": "http://www.nlm.nih.gov/research/umls/rxnorm",
+      "ersdConceptType": "mrtc",
+      "dibbsConceptType": "medications",
+      "includeValueSet": true,
+      "concepts": [
+        {
+          "code": "2671695",
+          "display": "penicillin G benzathine 2400000 UNT Injection",
+          "include": true
+        }
+      ]
+    },
+    {
+      "valueSetId": "1_20240909_5",
+      "valueSetVersion": "1",
+      "valueSetName": "Syphilis Diagnosis Problems",
+      "valueSetExternalId": "20240909_5",
+      "author": "DIBBs",
+      "system": "http://snomed.info/sct",
+      "ersdConceptType": "dxtc",
+      "dibbsConceptType": "conditions",
+      "includeValueSet": true,
+      "concepts": [
+        {
+          "code": "76272004",
+          "display": "Syphilis (disorder)",
+          "include": true
+        },
+        {
+          "code": "186647001",
+          "display": "Primary genital syphilis",
+          "include": true
+        }
+      ]
+    }
+  ],
+  "gonorrhea": [
+    {
+      "valueSetId": "1_20240909_7",
+      "valueSetVersion": "1",
+      "valueSetName": "Gonorrhea Medications",
+      "valueSetExternalId": "20240909_7",
+      "author": "DIBBs",
+      "system": "http://www.nlm.nih.gov/research/umls/rxnorm",
+      "ersdConceptType": "mrtc",
+      "dibbsConceptType": "medications",
+      "includeValueSet": true,
+      "concepts": [
+        {
+          "code": "434692",
+          "display": "azithromycin 1000 MG",
+          "include": true
+        },
+        {
+          "code": "1665005",
+          "display": "ceftriaxone 500 MG Injection",
+          "include": true
+        }
+      ]
+    },
+    {
+      "valueSetId": "1_20240909_8",
+      "valueSetVersion": "1",
+      "valueSetName": "Gonorrhea Diagnosis Problems",
+      "valueSetExternalId": "20240909_8",
+      "author": "DIBBs",
+      "system": "http://snomed.info/sct",
+      "ersdConceptType": "dxtc",
+      "dibbsConceptType": "conditions",
+      "includeValueSet": true,
+      "concepts": [
+        {
+          "code": "2339001",
+          "display": "Sexual overexposure",
+          "include": true
+        },
+        {
+          "code": "72531000052105",
+          "display": "Counseling for contraception",
+          "include": true
+        }
+      ]
+    },
+    {
+      "valueSetId": "1_20240909_9",
+      "valueSetVersion": "1",
+      "valueSetName": "Gonorrhea Diagnosis Problems",
+      "valueSetExternalId": "20240909_9",
+      "author": "DIBBs",
+      "system": "http://loinc.org",
+      "ersdConceptType": "dxtc",
+      "dibbsConceptType": "conditions",
+      "includeValueSet": true,
+      "concepts": [
+        {
+          "code": "11350-6",
+          "display": "History of Sexual behavior Narrative",
+          "include": true
+        },
+        {
+          "code": "82810-3",
+          "display": "Pregnancy status",
+          "include": true
+        },
+        {
+          "code": "83317-8",
+          "display": "Sexual activity with anonymous partner in the past year",
+          "include": true
+        }
+      ]
+    },
+    {
+      "valueSetId": "1_20240909_10",
+      "valueSetVersion": "1",
+      "valueSetName": "Gonorrhea Labs",
+      "valueSetExternalId": "20240909_10",
+      "author": "DIBBs",
+      "system": "http://loinc.org",
+      "ersdConceptType": "lrtc",
+      "dibbsConceptType": "labs",
+      "includeValueSet": true,
+      "concepts": [
+        {
+          "code": "21613-5",
+          "display": "Chlamydia trachomatis DNA [Presence] in Specimen by NAA with probe detection",
+          "include": true
+        }
+      ]
+    }
+  ],
+  "chlamydia": [
+    {
+      "valueSetId": "1_20240910_11",
+      "valueSetVersion": "1",
+      "valueSetName": "Chlamydia Medications",
+      "valueSetExternalId": "20240910_11",
+      "author": "DIBBs",
+      "system": "http://www.nlm.nih.gov/research/umls/rxnorm",
+      "ersdConceptType": "mrtc",
+      "dibbsConceptType": "medications",
+      "includeValueSet": true,
+      "concepts": [
+        {
+          "code": "434692",
+          "display": "azithromycin 1000 MG",
+          "include": true
+        },
+        {
+          "code": "82122",
+          "display": "levofloxacin",
+          "include": true
+        },
+        {
+          "code": "1649987",
+          "display": "doxycycline hyclate 100 MG",
+          "include": true
+        },
+        {
+          "code": "1665005",
+          "display": "ceftriaxone 500 MG Injection",
+          "include": true
+        }
+      ]
+    },
+    {
+      "valueSetId": "1_20240910_12",
+      "valueSetVersion": "1",
+      "valueSetName": "Chlamydia Labs",
+      "valueSetExternalId": "20240910_12",
+      "author": "DIBBs",
+      "system": "http://loinc.org",
+      "ersdConceptType": "ltrc",
+      "dibbsConceptType": "labs",
+      "includeValueSet": true,
+      "concepts": [
+        {
+          "code": "21613-5",
+          "display": "Chlamydia trachomatis DNA [Presence] in Specimen by NAA with probe detection",
+          "include": true
+        },
+        {
+          "code": "24111-7",
+          "display": "Neisseria gonorrhoeae DNA [Presence] in Specimen by NAA with probe detection",
+          "include": true
+        }
+      ]
+    },
+    {
+      "valueSetId": "1_20240910_13",
+      "valueSetVersion": "1",
+      "valueSetName": "Chlamydia Diagnosis Problems",
+      "valueSetExternalId": "20240910_13",
+      "author": "DIBBs",
+      "system": "http://loinc.org",
+      "ersdConceptType": "dxtc",
+      "dibbsConceptType": "conditions",
+      "includeValueSet": true,
+      "concepts": [
+        {
+          "code": "11350-6",
+          "display": "History of Sexual behavior Narrative",
+          "include": true
+        },
+        {
+          "code": "82810-3",
+          "display": "Pregnancy status",
+          "include": true
+        },
+        {
+          "code": "83317-8",
+          "display": "Sexual activity with anonymous partner in the past year",
           "include": true
         }
       ]

--- a/query-connector/src/app/assets/DIBBS_Custom_ValueSets.json
+++ b/query-connector/src/app/assets/DIBBS_Custom_ValueSets.json
@@ -1,5 +1,5 @@
 {
-  "newborn_screening": [
+  "Newborn Screening": [
     {
       "valueSetId": "1_20241015_16",
       "valueSetVersion": "1",
@@ -1022,7 +1022,7 @@
       ]
     }
   ],
-  "cancer": [
+  "Cancer (Leukemia)": [
     {
       "valueSetId": "1_20240909_2",
       "valueSetVersion": "1",
@@ -1111,7 +1111,7 @@
       ]
     }
   ],
-  "syphilis": [
+  "Syphilis (disorder)": [
     {
       "valueSetId": "1_20240909_4",
       "valueSetVersion": "1",
@@ -1154,7 +1154,7 @@
       ]
     }
   ],
-  "gonorrhea": [
+  "Gonorrhea (disorder)": [
     {
       "valueSetId": "1_20240909_7",
       "valueSetVersion": "1",
@@ -1248,7 +1248,7 @@
       ]
     }
   ],
-  "chlamydia": [
+  "Chlamydia trachomatis infection (disorder)": [
     {
       "valueSetId": "1_20240910_11",
       "valueSetVersion": "1",


### PR DESCRIPTION
# PULL REQUEST

## Summary

This ticket adds the custom valuesets we've developed thus far as a JSON object following the `ValueSet` convention we came up with. This will allow us to insert the custom valuesets when creating the database. There's a [follow up ticket](https://linear.app/skylight-cdc/issue/QUE-49/write-script-to-insert-custom-valuesets-into-db) to actually do the insertions. 

## Related Issue

Fixes #98 

## Additional Information

Note: we do not expect to add any more custom valuesets to this file as we expect users to add their own once we have the query creation work completed.

## Checklist

- [ ] If this code affects the other scrum team, have they been notified? (In Slack, as reviewers, etc.)

[//]: # "PR title: Remember to name your PR descriptively!"
