### PR TITLE
Vs insertion check

### DIFF
--- a/query-connector/src/app/database-service.ts
+++ b/query-connector/src/app/database-service.ts
@@ -461,17 +461,12 @@ export async function insertQuery(input: QueryInput) {
  *   2. Whether each concept included in that value set bundle was inserted
  *   3. Whether these concepts are now mapped to this value set via foreign key
  * If any data is found to be missing, it is collected and logged to the user.
- * @param setToCheck The FHIR formatted value set to check.
- * @param ersdConcept The eRSD concept this value set belongs to.
+ * @param vs The DIBBs internal representation of the value set to check.
  * @returns A data structure reporting on missing concepts or value set links.
  */
-export async function checkValueSetInsertion(
-  setToCheck: FhirValueSet,
-  ersdConcept: ErsdConceptType,
-) {
+export async function checkValueSetInsertion(vs: ValueSet) {
   // Translate to our internal representation and begin accumulating
   // missing data
-  const vs = await translateVSACToInternalValueSet(setToCheck, ersdConcept);
   const missingData = {
     missingValueSet: false,
     missingConcepts: [] as Array<String>,

--- a/query-connector/src/app/database-service.ts
+++ b/query-connector/src/app/database-service.ts
@@ -465,8 +465,7 @@ export async function insertQuery(input: QueryInput) {
  * @returns A data structure reporting on missing concepts or value set links.
  */
 export async function checkValueSetInsertion(vs: ValueSet) {
-  // Translate to our internal representation and begin accumulating
-  // missing data
+  // Begin accumulating missing data
   const missingData = {
     missingValueSet: false,
     missingConcepts: [] as Array<String>,

--- a/query-connector/src/app/database-service.ts
+++ b/query-connector/src/app/database-service.ts
@@ -453,3 +453,120 @@ export async function insertQuery(input: UserQueryInput) {
   if (errorArray.length === 0) return { success: true };
   return { success: false, error: errorArray.join(",") };
 }
+
+/**
+ * Function that verifies that a particular value set and all its affiliated
+ * concepts were successfully inserted into the DB. Given a FHIR formatted
+ * value set, the function checks three things:
+ *   1. Whether the value set itself was inserted
+ *   2. Whether each concept included in that value set bundle was inserted
+ *   3. Whether these concepts are now mapped to this value set via foreign key
+ * If any data is found to be missing, it is collected and logged to the user.
+ * @param setToCheck The FHIR formatted value set to check.
+ * @param ersdConcept The eRSD concept this value set belongs to.
+ * @returns A data structure reporting on missing concepts or value set links.
+ */
+export async function checkValueSetInsertion(
+  setToCheck: FhirValueSet,
+  ersdConcept: ErsdConceptType,
+) {
+  // Translate to our internal representation and begin accumulating
+  // missing data
+  const vs = await translateVSACToInternalValueSet(setToCheck, ersdConcept);
+  const missingData = {
+    missingValueSet: false,
+    missingConcepts: [] as Array<String>,
+    missingMappings: [] as Array<String>,
+  };
+
+  // Check that the value set itself was inserted
+  const vsSql = `SELECT * FROM valuesets WHERE oid = $1;`;
+  try {
+    const result = await dbClient.query(vsSql, [vs.valueSetExternalId]);
+    const foundVS: ValueSet = result.rows[0];
+    if (
+      foundVS.valueSetVersion !== vs.valueSetVersion ||
+      foundVS.valueSetName !== vs.valueSetName ||
+      foundVS.author !== vs.author ||
+      foundVS.dibbsConceptType !== vs.dibbsConceptType
+    ) {
+      console.error(
+        "Retrieved value set information differs from given value set",
+      );
+      missingData.missingValueSet = true;
+    }
+  } catch (error) {
+    console.error("Couldn't fetch inserted value set from DB: ", error);
+    missingData.missingValueSet = true;
+  }
+
+  // Check that all concepts under the value set's umbrella were inserted
+  const brokenConcepts = await Promise.all(
+    vs.concepts.map(async (c) => {
+      const systemPrefix = stripProtocolAndTLDFromSystemUrl(vs.system);
+      const conceptId = `${systemPrefix}_${c.code}`;
+      const conceptSql = `SELECT * FROM concepts WHERE id = $1;`;
+
+      try {
+        const result = await dbClient.query(conceptSql, [conceptId]);
+        const foundConcept: Concept = result.rows[0];
+
+        // We accumulate the unique DIBBs concept IDs of anything that's missing
+        if (
+          foundConcept.code !== c.code ||
+          foundConcept.display !== c.display
+        ) {
+          console.error(
+            "Retrieved concept " +
+              conceptId +
+              " has different values than given concept",
+          );
+          return conceptId;
+        }
+      } catch (error) {
+        console.error(
+          "Couldn't fetch concept with ID " + conceptId + ": ",
+          error,
+        );
+        return conceptId;
+      }
+    }),
+  );
+  missingData.missingConcepts = brokenConcepts.filter((bc) => bc !== undefined);
+
+  // Confirm that valueset_to_concepts contains all relevant FK mappings
+  const valueSetUniqueId = `${vs.valueSetId}_${vs.valueSetVersion}`;
+  const mappingSql = `SELECT * FROM valueset_to_concept WHERE valueset_id = $1;`;
+  try {
+    const result = await dbClient.query(mappingSql, [valueSetUniqueId]);
+    const rows = result.rows;
+    const missingConceptsFromMappings = vs.concepts.map((c) => {
+      const systemPrefix = stripProtocolAndTLDFromSystemUrl(vs.system);
+      const conceptUniqueId = `${systemPrefix}_${c.code}`;
+
+      // Accumulate unique IDs of any concept we can't find among query rows
+      const fIdx = rows.findIndex((r) => r["concept_id"] === conceptUniqueId);
+      if (fIdx === -1) {
+        console.error(
+          "Couldn't locate concept " + conceptUniqueId + " in fetched mappings",
+        );
+        return conceptUniqueId;
+      }
+    });
+    missingData.missingMappings = missingConceptsFromMappings.filter(
+      (item) => item !== undefined,
+    );
+  } catch (error) {
+    console.error(
+      "Couldn't fetch value set to concept mappings for this valueset: ",
+      error,
+    );
+    const systemPrefix = stripProtocolAndTLDFromSystemUrl(vs.system);
+    vs.concepts.forEach((c) => {
+      const conceptUniqueId = `${systemPrefix}_${c.code}`;
+      missingData.missingMappings.push(conceptUniqueId);
+    });
+  }
+
+  return missingData;
+}


### PR DESCRIPTION
# Sanity Check Value Set Insertion

## Summary

This PR introduces a function that verifies that a value set has been successfully inserted into our Postgres DB. Given a FHIR-formatted value set, the function checks that the value set itself has been inserted, all related concepts have been inserted, and all foreign key associations between the two are stored in the relevant tables. This PR also corrects a bug that was introduced when trying to add external IDs, namely that ValueSet IDs were having the version appended twice, which was causing cascading failures when inserting.

## Related Issue

Fixes https://github.com/CDCgov/dibbs-query-connector/issues/84

## Additional Information

As usual, I've built a test branch with a button that allows you to check the integrity of the insertion and sanity counting code. It's accessible here: https://github.com/CDCgov/dibbs-query-connector/tree/test-vs-count . Start the app, open the console, then click the button to see some tests happen.
