### PR TITLE
Hook up button to creation script

### DIFF
--- a/query-connector/src/app/queryBuilding/emptyState/EmptyQueriesDisplay.tsx
+++ b/query-connector/src/app/queryBuilding/emptyState/EmptyQueriesDisplay.tsx
@@ -19,7 +19,6 @@ export const EmptyQueriesDisplay: React.FC = () => {
     // DB Creation Function
     console.log("Creating DB...");
 
-    // await new Promise((r) => setTimeout(r, 5000)); //remove once DB creation is implemented
     await createDibbsDB();
 
     // Stop loading and redirect once function is complete

--- a/query-connector/src/app/queryBuilding/emptyState/EmptyQueriesDisplay.tsx
+++ b/query-connector/src/app/queryBuilding/emptyState/EmptyQueriesDisplay.tsx
@@ -4,6 +4,7 @@ import styles from "../queryBuilding.module.scss";
 import { useRouter } from "next/navigation";
 import classNames from "classnames";
 import WorkSpaceSetUpView from "../loadingState/WorkspaceSetUp";
+import { createDibbsDB } from "@/db-creation";
 /**
  * Empty-state component for query building
  * @returns the EmptyQueriesDisplay to render the empty state status
@@ -18,14 +19,14 @@ export const EmptyQueriesDisplay: React.FC = () => {
     // DB Creation Function
     console.log("Creating DB...");
 
-    await new Promise((r) => setTimeout(r, 5000)); //remove once DB creation is implemented
-    // await createDibbsDB();
+    // await new Promise((r) => setTimeout(r, 5000)); //remove once DB creation is implemented
+    await createDibbsDB();
 
     // Stop loading and redirect once function is complete
     setLoading(false);
 
     // Redirect to query building page
-    // router.push("/queryBuilding/buildFromTemplates");
+    router.push("/queryBuilding/buildFromTemplates");
   };
 
   if (loading) {

--- a/query-connector/src/db-creation.ts
+++ b/query-connector/src/db-creation.ts
@@ -1,3 +1,5 @@
+"use server";
+
 import { ersdToDibbsConceptMap, ErsdConceptType } from "@/app/constants";
 import { Bundle, BundleEntry, ValueSet } from "fhir/r4";
 import {


### PR DESCRIPTION
# Make DB Creation Button Work

## Summary

This lightweight little PR hooks up the button Marcelle created with the DB Creation functions I wrote. Took longer than anticipated to get set up  because of debugging some connectivity issues, though they've since been resolved. The only main thing to note is the `use server` declaration on dbCreation, which forces all the retrieval to occur server-side and keep the API load on the client low.

## Notes
Since this PR doesn't actually delete the migrations or modify the first one, hitting the button right now isn't needed. The task of actually deleting the migrations will require an overhaul of our end to end tests (which currently rely on seeded data), as well as will make things painful for local devs until or if an extract is prepared that circumvents the need to hit press the button every spinup. 

This PR was tested through console logs and tunneling in via DBeaver to verify valuesets were inserted.