### PR TITLE
Replace non-numeric characters in phone numbers with url encoding

### DIFF
--- a/query-connector/src/app/format-service.tsx
+++ b/query-connector/src/app/format-service.tsx
@@ -269,7 +269,7 @@ export async function GetPhoneQueryFormats(phone: string) {
  */
 export const formatValueSetsAsQuerySpec = async (
   useCase: string,
-  valueSets: ValueSet[]
+  valueSets: ValueSet[],
 ) => {
   let secondEncounter: boolean = false;
   if (["cancer", "chlamydia", "gonorrhea", "syphilis"].includes(useCase)) {

--- a/query-connector/src/app/format-service.tsx
+++ b/query-connector/src/app/format-service.tsx
@@ -227,12 +227,12 @@ export function FormatPhoneAsDigits(givenPhone: string) {
 
 const FORMATS_TO_SEARCH: string[] = [
   "$1$2$3",
-  "$1-$2-$3",
-  "$1+$2+$3",
-  "($1)+$2+$3",
-  "($1)-$2-$3",
-  "($1)$2-$3",
-  "1($1)$2-$3",
+  "$1%2D$2%2D$3",
+  "$1%2B$2%2B$3",
+  "%28$1%29%2B$2%2B$3",
+  "%28$1%29%2D$2%2D$3",
+  "%28$1%29$2%2D$3",
+  "1%28$1%29$2%2D$3",
 ];
 
 /**
@@ -250,7 +250,7 @@ const FORMATS_TO_SEARCH: string[] = [
 export async function GetPhoneQueryFormats(phone: string) {
   // Digit-only phone numbers will resolve as actual numbers
   if (isNaN(Number(phone)) || phone.length != 10) {
-    const strippedPhone = phone.replace(" ", "+");
+    const strippedPhone = phone.replace(" ", "%2D");
     return [strippedPhone];
   }
   // Map the phone number into each format we want to check
@@ -269,7 +269,7 @@ export async function GetPhoneQueryFormats(phone: string) {
  */
 export const formatValueSetsAsQuerySpec = async (
   useCase: string,
-  valueSets: ValueSet[],
+  valueSets: ValueSet[]
 ) => {
   let secondEncounter: boolean = false;
   if (["cancer", "chlamydia", "gonorrhea", "syphilis"].includes(useCase)) {

--- a/query-connector/src/app/format-service.tsx
+++ b/query-connector/src/app/format-service.tsx
@@ -227,12 +227,12 @@ export function FormatPhoneAsDigits(givenPhone: string) {
 
 const FORMATS_TO_SEARCH: string[] = [
   "$1$2$3",
-  "$1%2D$2%2D$3",
-  "$1%2B$2%2B$3",
-  "%28$1%29%2B$2%2B$3",
-  "%28$1%29%2D$2%2D$3",
-  "%28$1%29$2%2D$3",
-  "1%28$1%29$2%2D$3",
+  "$1-$2-$3",
+  "$1+$2+$3",
+  "($1)+$2+$3",
+  "($1)-$2-$3",
+  "($1)$2-$3",
+  "1($1)$2-$3",
 ];
 
 /**
@@ -255,7 +255,7 @@ export async function GetPhoneQueryFormats(phone: string) {
   }
   // Map the phone number into each format we want to check
   const possibleFormats: string[] = FORMATS_TO_SEARCH.map((fmt) => {
-    return phone.replace(/(\d{3})(\d{3})(\d{4})/gi, fmt);
+    return encodeURIComponent(phone.replace(/(\d{3})(\d{3})(\d{4})/gi, fmt));
   });
   return possibleFormats;
 }
@@ -269,7 +269,7 @@ export async function GetPhoneQueryFormats(phone: string) {
  */
 export const formatValueSetsAsQuerySpec = async (
   useCase: string,
-  valueSets: ValueSet[],
+  valueSets: ValueSet[]
 ) => {
   let secondEncounter: boolean = false;
   if (["cancer", "chlamydia", "gonorrhea", "syphilis"].includes(useCase)) {

--- a/query-connector/src/app/tests/unit/format-service.test.tsx
+++ b/query-connector/src/app/tests/unit/format-service.test.tsx
@@ -184,11 +184,11 @@ describe("formatIdentifier", () => {
     // the value across multiple elements
     expect(getByText("999-99-9999", { exact: false })).toBeInTheDocument();
     expect(
-      getByText("Social Security Number", { exact: false }),
+      getByText("Social Security Number", { exact: false })
     ).toBeInTheDocument();
     expect(getByText("0123456789", { exact: false })).toBeInTheDocument();
     expect(
-      getByText("Internal Reference Identifier", { exact: false }),
+      getByText("Internal Reference Identifier", { exact: false })
     ).toBeInTheDocument();
   });
 
@@ -470,7 +470,7 @@ describe("FormatPhoneAsDigits", () => {
 describe("GetPhoneQueryFormats", () => {
   it("should fail gracefully on partial phone number inputs", async () => {
     const partialPhone = "456 7890";
-    const expectedResult = ["456+7890"];
+    const expectedResult = ["456%2D7890"]; //456+7890
     expect(await GetPhoneQueryFormats(partialPhone)).toEqual(expectedResult);
   });
   it("should fail gracefully on given phones with separators remaining", async () => {
@@ -485,12 +485,12 @@ describe("GetPhoneQueryFormats", () => {
     const inputPhone = "1234567890";
     const expectedResult = [
       "1234567890",
-      "123-456-7890",
-      "123+456+7890",
-      "(123)+456+7890",
-      "(123)-456-7890",
-      "(123)456-7890",
-      "1(123)456-7890",
+      "123%2D456%2D7890", //123-456-7890
+      "123%2B456%2B7890", //123+456+7890
+      "%28123%29%2B456%2B7890", //(123)+456+7890
+      "%28123%29%2D456%2D7890", //(123)-456-7890,
+      "%28123%29456%2D7890", //(123)456-7890
+      "1%28123%29456%2D7890", //1(123)456-7890,
     ];
     expect(await GetPhoneQueryFormats(inputPhone)).toEqual(expectedResult);
   });

--- a/query-connector/src/app/tests/unit/format-service.test.tsx
+++ b/query-connector/src/app/tests/unit/format-service.test.tsx
@@ -184,11 +184,11 @@ describe("formatIdentifier", () => {
     // the value across multiple elements
     expect(getByText("999-99-9999", { exact: false })).toBeInTheDocument();
     expect(
-      getByText("Social Security Number", { exact: false })
+      getByText("Social Security Number", { exact: false }),
     ).toBeInTheDocument();
     expect(getByText("0123456789", { exact: false })).toBeInTheDocument();
     expect(
-      getByText("Internal Reference Identifier", { exact: false })
+      getByText("Internal Reference Identifier", { exact: false }),
     ).toBeInTheDocument();
   });
 

--- a/query-connector/src/app/tests/unit/format-service.test.tsx
+++ b/query-connector/src/app/tests/unit/format-service.test.tsx
@@ -184,11 +184,11 @@ describe("formatIdentifier", () => {
     // the value across multiple elements
     expect(getByText("999-99-9999", { exact: false })).toBeInTheDocument();
     expect(
-      getByText("Social Security Number", { exact: false }),
+      getByText("Social Security Number", { exact: false })
     ).toBeInTheDocument();
     expect(getByText("0123456789", { exact: false })).toBeInTheDocument();
     expect(
-      getByText("Internal Reference Identifier", { exact: false }),
+      getByText("Internal Reference Identifier", { exact: false })
     ).toBeInTheDocument();
   });
 
@@ -485,12 +485,12 @@ describe("GetPhoneQueryFormats", () => {
     const inputPhone = "1234567890";
     const expectedResult = [
       "1234567890",
-      "123%2D456%2D7890", //123-456-7890
+      "123-456-7890",
       "123%2B456%2B7890", //123+456+7890
-      "%28123%29%2B456%2B7890", //(123)+456+7890
-      "%28123%29%2D456%2D7890", //(123)-456-7890,
-      "%28123%29456%2D7890", //(123)456-7890
-      "1%28123%29456%2D7890", //1(123)456-7890,
+      "(123)%2B456%2B7890", //(123)+456+7890
+      "(123)-456-7890",
+      "(123)456-7890",
+      "1(123)456-7890",
     ];
     expect(await GetPhoneQueryFormats(inputPhone)).toEqual(expectedResult);
   });


### PR DESCRIPTION
# PULL REQUEST

## Summary

This PR changes the way that we generate the list of phone numbers to search for by replacing non-numeric characters, e.g. `+` and `-`, with their url encoded equivalents. This allows us to query for multiple phone numbers via eHealth Exchange, which eHealth devs recommend. 

## Related Issue

Fixes #167 

## Additional Information

We may look into more robust URL encoding for other fields, e.g., first names with spaces.

## Checklist

- [X] Descriptive Pull Request title
- [X] Link to relevant issues
- [ ] Provide necessary context for design reviewers
- [ ] Update documentation

