### PR TITLE
Changing conflicting ports in docker-compose-dev

### DIFF
--- a/query-connector/README.md
+++ b/query-connector/README.md
@@ -12,7 +12,7 @@ The Query Connector app can be run using Docker (or any other OCI container runt
 
 Before running the Query Connector locally, you will need to obtain an API key for the electronic Reporting and Surveillance Distribution (eRSD). With the API key, you have access to 200+ pre-built queries for reportable conditions, e.g., chlamydia, influenza, hepatitis A, etc. These queries can be used and modified in the Query Connector app.
 
-To obtain a free API key, please visit <https://ersd.aimsplatform.org/#/api-keys> and follow the sign up instructions.
+To obtain a free API key, please visit [https://ersd.aimsplatform.org/#/api-keys](https://ersd.aimsplatform.org/#/api-keys) and follow the sign up instructions.
 
 Next, set up your `.env` file with the following command: `cp .env.sample .env`
 
@@ -23,7 +23,7 @@ Add your API keys as an environment variables called `ERSD_API_KEY` and `UMLS_AP
 #### Running Keycloak for Authentication
 
 ```
-docker compose up -f docker-compose-dev.yaml up keycloak
+docker compose -f docker-compose-dev.yaml up keycloak
 ```
 
 To login via Keycloak, make sure your `.env` is updated using `cp` command above and use the following credentials to login at `localhost:8080` after spinning up the container:
@@ -33,7 +33,7 @@ Username: qc-admin
 Password: QcDev2024!
 ```
 
-Next, run the app with `npm run dev` or `npm run dev-win`. You should see a sign in button at <http://localhost:3000>. Click it and login with the above credentials, and it should redirect back to <http://localhost:3000/query>!
+Next, run the app with `npm run dev` or `npm run dev-win`. You should see a sign in button at [http://localhost:3000](http://localhost:3000). Click it and login with the above credentials, and it should redirect back to [http://localhost:3000/query](http://localhost:3000/query)!
 
 #### Running with Docker (Recommended)
 

--- a/query-connector/docker-compose-dev.yaml
+++ b/query-connector/docker-compose-dev.yaml
@@ -50,7 +50,7 @@ services:
   keycloak:
     image: quay.io/keycloak/keycloak:26.0.2
     ports:
-      - 8080:8080
+      - 8081:8081
     volumes:
       - ./keycloak:/opt/keycloak/data/import
     restart: always


### PR DESCRIPTION
# PULL REQUEST

## Summary

There's two `8080:8080` ports that are causing `npm run dev` to fail due to the bind already existing.

## Related Issue

Fixes baby bug.

## Additional Information

Anything else the review team should know?

## Checklist

- [x] Descriptive Pull Request title
- [ ] Link to relevant issues
- [x] Provide necessary context for design reviewers
- [x] Update documentation

