### PR TITLE
Make sure keycloak port bind is bound to 8080 inside container

### DIFF
--- a/query-connector/.env.sample
+++ b/query-connector/.env.sample
@@ -2,6 +2,6 @@ DATABASE_URL=postgresql://postgres@localhost:5432/tefca_db
 AUTH_SECRET="ido5D/uybeAB3AmMQwn+ubw2zYC4t2h7RJlW2R79598="
 AUTH_KEYCLOAK_ID=query-connector
 AUTH_KEYCLOAK_SECRET=ZG3f7R1J3qIwBaw8QtttJnJMinpERQKs
-AUTH_KEYCLOAK_ISSUER=http://localhost:8080/realms/master
+AUTH_KEYCLOAK_ISSUER=http://localhost:8081/realms/master
 ERSD_API_KEY=
 UMLS_API_KEY=

--- a/query-connector/docker-compose-dev.yaml
+++ b/query-connector/docker-compose-dev.yaml
@@ -50,7 +50,7 @@ services:
   keycloak:
     image: quay.io/keycloak/keycloak:26.0.2
     ports:
-      - 8081:8081
+      - 8081:8080
     volumes:
       - ./keycloak:/opt/keycloak/data/import
     restart: always


### PR DESCRIPTION
Follow up to #174 - the internal port bind needs to be 8080 since keycloak runs on 8080 by default inside the container. Also updated the `.env.sample` to reflect the new port in the issuer URL.