### PR TITLE
tweak toast styles

### DIFF
--- a/query-connector/src/app/query/components/CustomizeQuery.tsx
+++ b/query-connector/src/app/query/components/CustomizeQuery.tsx
@@ -173,8 +173,7 @@ const CustomizeQuery: React.FC<CustomizeQueryProps> = ({
     setQueryValuesets(selectedItems);
     goBack();
     showToastConfirmation({
-      heading: QUERY_CUSTOMIZATION_CONFIRMATION_HEADER,
-      headingLevel: "h4",
+      body: QUERY_CUSTOMIZATION_CONFIRMATION_BODY,
     });
   };
 
@@ -252,5 +251,5 @@ const CustomizeQuery: React.FC<CustomizeQueryProps> = ({
 };
 
 export default CustomizeQuery;
-export const QUERY_CUSTOMIZATION_CONFIRMATION_HEADER =
+export const QUERY_CUSTOMIZATION_CONFIRMATION_BODY =
   "Query Customization Successful!";

--- a/query-connector/src/app/query/designSystem/toast/Toast.tsx
+++ b/query-connector/src/app/query/designSystem/toast/Toast.tsx
@@ -4,7 +4,7 @@ import classNames from "classnames";
 
 export type AlertType = "info" | "success" | "warning" | "error";
 
-type RedirectToastProps = {
+type ToastProps = {
   toastVariant: AlertType;
   heading?: string;
   body: string;
@@ -22,7 +22,7 @@ type RedirectToastProps = {
  * defaults to h4
  * @returns A toast component using the USWDS alert
  */
-const RedirectToast: React.FC<RedirectToastProps> = ({
+const Toast: React.FC<ToastProps> = ({
   toastVariant,
   heading,
   body,
@@ -77,7 +77,7 @@ export function showToastConfirmation(content: {
   const toastDuration = content.duration ?? 5000; // Default to 5000ms
 
   toast[toastVariant](
-    <RedirectToast
+    <Toast
       toastVariant={toastVariant}
       heading={content.heading}
       headingLevel={content.headingLevel}
@@ -87,4 +87,4 @@ export function showToastConfirmation(content: {
   );
 }
 
-export default RedirectToast;
+export default Toast;

--- a/query-connector/src/app/query/designSystem/toast/Toast.tsx
+++ b/query-connector/src/app/query/designSystem/toast/Toast.tsx
@@ -67,8 +67,8 @@ const options = {
  * @param content.duration - Duration in milliseconds for how long the toast is visible. Defaults to 5000ms.
  */
 export function showToastConfirmation(content: {
+  body: string;
   heading?: string;
-  body?: string;
   variant?: AlertType;
   headingLevel?: HeadingLevel;
   duration?: number;

--- a/query-connector/src/app/queryBuilding/buildFromTemplates/buildfromTemplate.module.scss
+++ b/query-connector/src/app/queryBuilding/buildFromTemplates/buildfromTemplate.module.scss
@@ -3,11 +3,13 @@
 .queryTemplateContainer {
   padding: 3.5rem 5rem;
   border-radius: 4px;
+  min-height: 30rem;
 }
 
 .querySelectionForm {
   background-color: #fff;
   padding: 2rem;
+  min-height: 25rem;
 }
 
 .querySelectionFormSearch {

--- a/query-connector/src/styles/custom-styles.scss
+++ b/query-connector/src/styles/custom-styles.scss
@@ -405,15 +405,26 @@ ul.usa-sidenav
   padding-top: 0 !important;
 }
 
+.Toastify__toast-body {
+  .usa-alert__body::before {
+    mask-size: 1.5rem 1.5rem !important;
+    top: unset !important;
+  }
+
+  .usa-alert__body > * {
+    margin-left: 2rem !important;
+  }
+}
+
 .usa-alert__heading {
   &.h1 {
-    font-size: 2.125rem; 
+    font-size: 2.125rem;
     font-weight: bold;
     line-height: 1.5;
   }
 
   &.h2 {
-    font-size: 1.875rem; 
+    font-size: 1.875rem;
     font-weight: bold;
     line-height: 1.5;
   }
@@ -437,12 +448,11 @@ ul.usa-sidenav
   }
 
   &.h6 {
-    font-size: 1rem; 
+    font-size: 1rem;
     font-weight: bold;
     line-height: 1.2;
   }
 }
-
 
 .custom-query-step-indicator .usa-step-indicator__header {
   display: none !important;


### PR DESCRIPTION
# PULL REQUEST

## Summary
Follow up to this [slack thread](https://skylight-hq.slack.com/archives/C07PQ078KK2/p1733860243725119?thread_ts=1733499173.941749&cid=C07PQ078KK2)
- Makes body text required / default rendering for toasts
- Tweaks the size of the icons / spacing to be more visually balanced with the smaller text
- Added a min height to the selection form to prevent the UI from blinking on filter

## Additional Information

### For design
Make sure these toasts look good
<img width="1412" alt="Screenshot 2024-12-12 at 11 38 13 AM" src="https://github.com/user-attachments/assets/533d577c-644e-4a50-a54b-79b442b68a30" />
<img width="1438" alt="Screenshot 2024-12-12 at 11 08 33 AM" src="https://github.com/user-attachments/assets/9cd5c6cf-ad7a-4207-9650-5b585cd26024" />

## Checklist

- [x] Descriptive Pull Request title
- [x] Link to relevant issues
- [x] Provide necessary context for design reviewers
- [ ] Update documentation

