### PR TITLE
fix translation methods between query pages

### DIFF
--- a/query-connector/src/app/api/query/route.ts
+++ b/query-connector/src/app/api/query/route.ts
@@ -17,7 +17,7 @@ import {
 
 import { handleRequestError } from "./error-handling-service";
 import { getSavedQueryByName } from "@/app/database-service";
-import { mapQueryRowsToValueSets } from "@/app/utils";
+import { unnestValueSetsFromQuery } from "@/app/utils";
 
 /**
  * Health check for TEFCA Viewer
@@ -90,7 +90,7 @@ export async function POST(request: NextRequest) {
   // Lookup default parameters for particular use-case search
   const queryName = UseCaseToQueryName[use_case as USE_CASES];
   const queryResults = await getSavedQueryByName(queryName);
-  const valueSets = mapQueryRowsToValueSets(queryResults);
+  const valueSets = unnestValueSetsFromQuery(queryResults);
 
   // Add params & patient identifiers to UseCaseRequest
   const UseCaseRequest: UseCaseQueryRequest = {

--- a/query-connector/src/app/database-service.ts
+++ b/query-connector/src/app/database-service.ts
@@ -688,8 +688,7 @@ export async function getCustomQueries(): Promise<CustomUserQuery[]> {
       q.query_data,
       q.conditions_list
     FROM
-      query q
-    WHERE     q.query_name IN ('Gonorrhea case investigation', 'Newborn screening follow-up', 'Syphilis case investigation', 'Cancer case investigation', 'Chlamydia case investigation');
+      query q;
   `;
   // TODO: this will eventually need to take into account user permissions and specific authors
   // We'll probably also need to refactor this to not show up in any user-facing containers

--- a/query-connector/src/app/query/components/selectQuery/queryHooks.ts
+++ b/query-connector/src/app/query/components/selectQuery/queryHooks.ts
@@ -5,7 +5,7 @@ import {
   hyperUnluckyPatient,
 } from "@/app/constants";
 import { getSavedQueryByName } from "@/app/database-service";
-import { mapQueryRowsToValueSets } from "@/app/utils";
+import { unnestValueSetsFromQuery } from "@/app/utils";
 import { UseCaseQuery, UseCaseQueryResponse } from "@/app/query-service";
 import { Patient } from "fhir/r4";
 
@@ -18,7 +18,7 @@ type SetStateCallback<T> = React.Dispatch<React.SetStateAction<T>>;
  */
 export async function fetchUseCaseValueSets(queryName: string) {
   const queryResults = await getSavedQueryByName(queryName);
-  const valueSets = mapQueryRowsToValueSets(queryResults);
+  const valueSets = unnestValueSetsFromQuery(queryResults);
 
   return valueSets;
 }

--- a/query-connector/src/app/queryBuilding/buildFromTemplates/page.tsx
+++ b/query-connector/src/app/queryBuilding/buildFromTemplates/page.tsx
@@ -21,7 +21,7 @@ import SiteAlert from "@/app/query/designSystem/SiteAlert";
 import { BuildStep } from "../../constants";
 import LoadingView from "../../query/components/LoadingView";
 import classNames from "classnames";
-import { groupConditionConceptsByValueSetId } from "@/app/utils";
+import { groupConditionConceptsIntoValueSets } from "@/app/utils";
 import { batchToggleConcepts } from "../utils";
 
 export type FormError = {
@@ -83,7 +83,7 @@ export default function QueryTemplateSelection() {
     if (idsToQuery && idsToQuery.length > 0) {
       const results = await getValueSetsAndConceptsByConditionIDs(conditionIds);
       const formattedResults =
-        results && groupConditionConceptsByValueSetId(results);
+        results && groupConditionConceptsIntoValueSets(results);
 
       // when fetching directly from conditions table (as opposed to a saved query),
       // default to including all value sets

--- a/query-connector/src/app/queryBuilding/buildFromTemplates/page.tsx
+++ b/query-connector/src/app/queryBuilding/buildFromTemplates/page.tsx
@@ -21,7 +21,7 @@ import SiteAlert from "@/app/query/designSystem/SiteAlert";
 import { BuildStep } from "../../constants";
 import LoadingView from "../../query/components/LoadingView";
 import classNames from "classnames";
-import { populateSavedValueSetWithConcepts } from "@/app/utils";
+import { groupConditionConceptsByValueSetId } from "@/app/utils";
 import { batchToggleConcepts } from "../utils";
 
 export type FormError = {
@@ -83,7 +83,7 @@ export default function QueryTemplateSelection() {
     if (idsToQuery && idsToQuery.length > 0) {
       const results = await getValueSetsAndConceptsByConditionIDs(conditionIds);
       const formattedResults =
-        results && populateSavedValueSetWithConcepts(results);
+        results && groupConditionConceptsByValueSetId(results);
 
       // when fetching directly from conditions table (as opposed to a saved query),
       // default to including all value sets

--- a/query-connector/src/app/queryBuilding/buildFromTemplates/page.tsx
+++ b/query-connector/src/app/queryBuilding/buildFromTemplates/page.tsx
@@ -13,7 +13,7 @@ import {
 import {
   CategoryNameToConditionOptionMap,
   ConditionIdToValueSetArray,
-  mapFetchedDataToFrontendStructure,
+  groupConditionDataByCategoryName,
 } from "../utils";
 import { ConditionSelection } from "../components/ConditionSelection";
 import { ValueSetSelection } from "../components/ValueSetSelection";
@@ -21,7 +21,10 @@ import SiteAlert from "@/app/query/designSystem/SiteAlert";
 import { BuildStep } from "../../constants";
 import LoadingView from "../../query/components/LoadingView";
 import classNames from "classnames";
-import { mapQueryRowsToValueSets } from "@/app/utils";
+import {
+  unnestValueSetsFromQuery,
+  populateSavedValueSetWithConcepts,
+} from "@/app/utils";
 import { batchToggleConcepts } from "../utils";
 
 export type FormError = {
@@ -82,7 +85,8 @@ export default function QueryTemplateSelection() {
     // if there are new ids, we need to query the db
     if (idsToQuery && idsToQuery.length > 0) {
       const results = await getValueSetsAndConceptsByConditionIDs(conditionIds);
-      const formattedResults = results && mapQueryRowsToValueSets(results);
+      const formattedResults =
+        results && populateSavedValueSetWithConcepts(results);
 
       // when fetching directly from conditions table (as opposed to a saved query),
       // default to including all value sets
@@ -138,7 +142,7 @@ export default function QueryTemplateSelection() {
 
       if (isSubscribed) {
         setFetchedConditions(
-          mapFetchedDataToFrontendStructure(categoryToConditionArrayMap),
+          groupConditionDataByCategoryName(categoryToConditionArrayMap),
         );
       }
     }

--- a/query-connector/src/app/queryBuilding/buildFromTemplates/page.tsx
+++ b/query-connector/src/app/queryBuilding/buildFromTemplates/page.tsx
@@ -21,10 +21,7 @@ import SiteAlert from "@/app/query/designSystem/SiteAlert";
 import { BuildStep } from "../../constants";
 import LoadingView from "../../query/components/LoadingView";
 import classNames from "classnames";
-import {
-  unnestValueSetsFromQuery,
-  populateSavedValueSetWithConcepts,
-} from "@/app/utils";
+import { populateSavedValueSetWithConcepts } from "@/app/utils";
 import { batchToggleConcepts } from "../utils";
 
 export type FormError = {

--- a/query-connector/src/app/queryBuilding/components/ConditionSelection.tsx
+++ b/query-connector/src/app/queryBuilding/components/ConditionSelection.tsx
@@ -6,7 +6,7 @@ import classNames from "classnames";
 import { getConditionsData } from "@/app/database-service";
 import {
   CategoryNameToConditionOptionMap,
-  mapFetchedDataToFrontendStructure,
+  groupConditionDataByCategoryName,
   ConditionIdToValueSetArray,
 } from "../utils";
 import ConditionColumnDisplay from "../buildFromTemplates/ConditionColumnDisplay";
@@ -78,7 +78,7 @@ export const ConditionSelection: React.FC<ConditionSelectionProps> = ({
 
       if (isSubscribed) {
         setFetchedConditions(
-          mapFetchedDataToFrontendStructure(categoryToConditionArrayMap),
+          groupConditionDataByCategoryName(categoryToConditionArrayMap),
         );
       }
     }

--- a/query-connector/src/app/queryBuilding/utils.ts
+++ b/query-connector/src/app/queryBuilding/utils.ts
@@ -49,7 +49,7 @@ export type CategoryNameToConditionOptionMap = {
  * category mapping
  * @returns - The data in a CategoryNameToConditionOptionMap shape
  */
-export function mapFetchedDataToFrontendStructure(fetchedData: {
+export function groupConditionDataByCategoryName(fetchedData: {
   [categoryName: string]: ConditionIdToNameMap[];
 }) {
   const result: CategoryNameToConditionOptionMap = {};

--- a/query-connector/src/app/tests/unit/fixtures.ts
+++ b/query-connector/src/app/tests/unit/fixtures.ts
@@ -1,0 +1,155 @@
+import categoryToConditionArrayMap from "../assets/aphlCategoryMapping.json";
+import queryTableDefaults from "../../assets/dibbs_db_seed_query.json";
+import { ConditionIdToNameMap } from "@/app/queryBuilding/utils";
+import { QueryResultRow } from "pg";
+
+export const CATEGORY_TO_CONDITION_ARRAY_MAP =
+  categoryToConditionArrayMap as unknown as {
+    [categoryName: string]: ConditionIdToNameMap[];
+  };
+
+export const DEFAULT_CHLAMYDIA_QUERY = [
+  queryTableDefaults.query.find((v) =>
+    v.query_name.includes("Chlamydia case investigation"),
+  ),
+] as QueryResultRow[];
+
+export const EXPECTED_CHLAMYDIA_VALUESET_LENGTH = Object.values(
+  DEFAULT_CHLAMYDIA_QUERY[0].query_data[
+    "Chlamydia trachomatis infection (disorder)"
+  ],
+).length;
+
+export const CANCER_VALUESETS = [
+  {
+    display: "RESULTS",
+    code_system: "http://cap.org/eCC",
+    code: "9484.100004300",
+    valueset_name: "Cancer (Leukemia) Lab Result",
+    valueset_id: "14_20240923",
+    valueset_external_id: "14",
+    version: "20240923",
+    author: "DIBBs",
+    type: "lrtc",
+    dibbs_concept_type: "labs",
+    condition_id: "2",
+  },
+  {
+    display:
+      "Presence of DNA mismatch repair protein MSH2 in primary malignant neoplasm of colon by immunohistochemistry (observable entity)",
+    code_system: "http://snomed.info/sct",
+    code: "1255068005",
+    valueset_name: "Cancer (Leukemia) Lab Result",
+    valueset_id: "14_20240923",
+    valueset_external_id: "14",
+    version: "20240923",
+    author: "DIBBs",
+    type: "lrtc",
+    dibbs_concept_type: "labs",
+    condition_id: "2",
+  },
+  {
+    display: "MSH2 Result",
+    code_system: "http://cap.org/eCC",
+    code: "30000.100004300",
+    valueset_name: "Cancer (Leukemia) Lab Result",
+    valueset_id: "14_20240923",
+    valueset_external_id: "14",
+    version: "20240923",
+    author: "DIBBs",
+    type: "lrtc",
+    dibbs_concept_type: "labs",
+    condition_id: "2",
+  },
+  {
+    display: "Malignant neoplastic disease (disorder)",
+    code_system: "http://snomed.info/sct",
+    code: "363346000",
+    valueset_name: "Suspected Cancer (Leukemia) Diagnosis",
+    valueset_id: "15_20240923",
+    valueset_external_id: "15",
+    version: "20240923",
+    author: "DIBBs",
+    type: "sdtc",
+    dibbs_concept_type: "conditions",
+    condition_id: "2",
+  },
+  {
+    display: "1 ML alemtuzumab 30 MG/ML Injection",
+    code_system: "http://www.nlm.nih.gov/research/umls/rxnorm",
+    code: "828265",
+    valueset_name: "Cancer (Leukemia) Medication",
+    valueset_id: "3_20240909",
+    valueset_external_id: "3",
+    version: "20240909",
+    author: "DIBBs",
+    type: "mrtc",
+    dibbs_concept_type: "medications",
+    condition_id: "2",
+  },
+  {
+    display: "Stage II (localized)",
+    code_system: "http://snomed.info/sct",
+    code: "36929009",
+    valueset_name: "Cancer (Leukemia) Diagnosis Problem",
+    valueset_id: "2_20240909",
+    valueset_external_id: "2",
+    version: "20240909",
+    author: "DIBBs",
+    type: "dxtc",
+    dibbs_concept_type: "conditions",
+    condition_id: "2",
+  },
+  {
+    display: "Stage group.clinical Cancer",
+    code_system: "http://loinc.org",
+    code: "21908-9",
+    valueset_name: "Cancer (Leukemia) Diagnosis Problem",
+    valueset_id: "2_20240909",
+    valueset_external_id: "2",
+    version: "20240909",
+    author: "DIBBs",
+    type: "dxtc",
+    dibbs_concept_type: "conditions",
+    condition_id: "2",
+  },
+  {
+    display: "Pathology Synoptic report",
+    code_system: "http://loinc.org",
+    code: "60568-3",
+    valueset_name: "Cancer (Leukemia) Diagnosis Problem",
+    valueset_id: "2_20240909",
+    valueset_external_id: "2",
+    version: "20240909",
+    author: "DIBBs",
+    type: "dxtc",
+    dibbs_concept_type: "conditions",
+    condition_id: "2",
+  },
+  {
+    display: "Chronic lymphoid leukemia, disease (disorder)",
+    code_system: "http://snomed.info/sct",
+    code: "92814006",
+    valueset_name: "Cancer (Leukemia) Diagnosis Problem",
+    valueset_id: "2_20240909",
+    valueset_external_id: "2",
+    version: "20240909",
+    author: "DIBBs",
+    type: "dxtc",
+    dibbs_concept_type: "conditions",
+    condition_id: "2",
+  },
+  {
+    display: "Allergy to sulfonamide",
+    code_system: "http://snomed.info/sct",
+    code: "418689008",
+    valueset_name: "Cancer (Leukemia) Diagnosis Problem",
+    valueset_id: "2_20240909",
+    valueset_external_id: "2",
+    version: "20240909",
+    author: "DIBBs",
+    type: "dxtc",
+    dibbs_concept_type: "conditions",
+    condition_id: "2",
+  },
+];

--- a/query-connector/src/app/tests/unit/utils.test.tsx
+++ b/query-connector/src/app/tests/unit/utils.test.tsx
@@ -11,7 +11,6 @@ import {
   groupConditionDataByCategoryName,
   filterSearchByCategoryAndCondition,
 } from "@/app/queryBuilding/utils";
-import { QueryResultRow } from "pg";
 import {
   CANCER_VALUESETS,
   CATEGORY_TO_CONDITION_ARRAY_MAP,

--- a/query-connector/src/app/tests/unit/utils.test.tsx
+++ b/query-connector/src/app/tests/unit/utils.test.tsx
@@ -3,7 +3,7 @@ import { render, screen } from "@testing-library/react";
 import {
   DataDisplay,
   DataDisplayInfo,
-  groupConditionConceptsByValueSetId,
+  groupConditionConceptsIntoValueSets,
   unnestValueSetsFromQuery,
 } from "../../utils";
 
@@ -141,7 +141,7 @@ describe("data util methods for query building", () => {
 
   describe("groupConditionConceptsByValueSetId", () => {
     const formattedValueSets =
-      groupConditionConceptsByValueSetId(CANCER_VALUESETS);
+      groupConditionConceptsIntoValueSets(CANCER_VALUESETS);
     const EXPECTED_CANCER_VALUESET_GROUPS = 4;
     expect(formattedValueSets.length).toBe(EXPECTED_CANCER_VALUESET_GROUPS);
     expect(

--- a/query-connector/src/app/tests/unit/utils.test.tsx
+++ b/query-connector/src/app/tests/unit/utils.test.tsx
@@ -3,7 +3,7 @@ import { render, screen } from "@testing-library/react";
 import {
   DataDisplay,
   DataDisplayInfo,
-  populateSavedValueSetWithConcepts,
+  groupConditionConceptsByValueSetId,
   unnestValueSetsFromQuery,
 } from "../../utils";
 
@@ -139,9 +139,9 @@ describe("data util methods for query building", () => {
     expect(unnestedVals.length).toBe(EXPECTED_CHLAMYDIA_VALUESET_LENGTH);
   });
 
-  describe("populateSavedValueSetWithConcepts", () => {
+  describe("groupConditionConceptsByValueSetId", () => {
     const formattedValueSets =
-      populateSavedValueSetWithConcepts(CANCER_VALUESETS);
+      groupConditionConceptsByValueSetId(CANCER_VALUESETS);
     const EXPECTED_CANCER_VALUESET_GROUPS = 4;
     expect(formattedValueSets.length).toBe(EXPECTED_CANCER_VALUESET_GROUPS);
     expect(

--- a/query-connector/src/app/utils.tsx
+++ b/query-connector/src/app/utils.tsx
@@ -129,29 +129,25 @@ export const groupConditionConceptsIntoValueSets = (rows: QueryResultRow[]) => {
 
 // TODO?: Type the input param more explicitly to not be a generic DB return?
 function mapStoredValueSetIntoInternalValueset(
-  storedValueSetGroup: QueryResultRow[],
+  conceptGroup: QueryResultRow[],
 ): ValueSet {
   // For info that should be the same at the valueset-level, just use the first
-  // valueset to populate them for everything
-  const storedValueSet = storedValueSetGroup[0];
+  // fetched concept to populate
+  const storedConcept = conceptGroup[0];
   const valueSet: ValueSet = {
-    valueSetId: storedValueSet["valueset_id"],
-    valueSetVersion: storedValueSet["version"],
-    valueSetName: storedValueSet["valueset_name"],
+    valueSetId: storedConcept["valueset_id"],
+    valueSetVersion: storedConcept["version"],
+    valueSetName: storedConcept["valueset_name"],
     // External ID might not be defined for user-defined valuesets
-    valueSetExternalId: storedValueSet["valueset_external_id"]
-      ? storedValueSet["valueset_external_id"]
+    valueSetExternalId: storedConcept["valueset_external_id"]
+      ? storedConcept["valueset_external_id"]
       : undefined,
-    author: storedValueSet["author"],
-    system: storedValueSet["code_system"],
-    ersdConceptType: storedValueSet["type"]
-      ? storedValueSet["type"]
-      : undefined,
-    dibbsConceptType: storedValueSet["dibbs_concept_type"],
-    includeValueSet: storedValueSetGroup.find((c) => c["include"])
-      ? true
-      : false,
-    concepts: storedValueSetGroup.map((c) => {
+    author: storedConcept["author"],
+    system: storedConcept["code_system"],
+    ersdConceptType: storedConcept["type"] ? storedConcept["type"] : undefined,
+    dibbsConceptType: storedConcept["dibbs_concept_type"],
+    includeValueSet: conceptGroup.find((c) => c["include"]) ? true : false,
+    concepts: conceptGroup.map((c) => {
       return {
         code: c["code"],
         display: c["display"],
@@ -159,7 +155,7 @@ function mapStoredValueSetIntoInternalValueset(
       };
     }),
   };
-  const conditionId = storedValueSet["condition_id"];
+  const conditionId = storedConcept["condition_id"];
   if (conditionId) {
     valueSet["conditionId"] = conditionId;
   }

--- a/query-connector/src/app/utils.tsx
+++ b/query-connector/src/app/utils.tsx
@@ -82,11 +82,6 @@ type QueryTableQueryDataColumn = {
  * @param rows The Rows returned from the ValueSet table.
  * @returns A list of ValueSets, which hold the Concepts pulled from the DB.
  */
-
-/**
- *
- * @param rows
- */
 export const unnestValueSetsFromQuery = (
   rows: QueryResultRow[],
 ): ValueSet[] => {

--- a/query-connector/src/app/utils.tsx
+++ b/query-connector/src/app/utils.tsx
@@ -128,6 +128,12 @@ export const groupConditionConceptsIntoValueSets = (rows: QueryResultRow[]) => {
 };
 
 // TODO?: Type the input param more explicitly to not be a generic DB return?
+/**
+ *
+ * @param conceptGroup - a grouping of concepts fetched from various coding
+ * systems that share the same ValueSet ID
+ * @returns a ValueSet shaped to our internal ValueSet structure
+ */
 function mapStoredValueSetIntoInternalValueset(
   conceptGroup: QueryResultRow[],
 ): ValueSet {

--- a/query-connector/src/app/utils.tsx
+++ b/query-connector/src/app/utils.tsx
@@ -107,7 +107,7 @@ export const unnestValueSetsFromQuery = (
  * @param rows The Rows returned from the ValueSet table.
  * @returns A list of ValueSets, which hold the Concepts pulled from the DB.
  */
-export const groupConditionConceptsByValueSetId = (rows: QueryResultRow[]) => {
+export const groupConditionConceptsIntoValueSets = (rows: QueryResultRow[]) => {
   // Create groupings of rows (each of which is a single Concept) by their ValueSet ID
   const vsIdGroupedRows = rows.reduce((conceptsByVSId, r) => {
     if (!(r["valueset_id"] in conceptsByVSId)) {
@@ -121,34 +121,47 @@ export const groupConditionConceptsByValueSetId = (rows: QueryResultRow[]) => {
   // Iterate over them to create formal Concept Groups attached to a formal VS
   const valueSets = Object.keys(vsIdGroupedRows).map((vsID) => {
     const conceptGroup: QueryResultRow[] = vsIdGroupedRows[vsID];
-    const valueSet: ValueSet = {
-      valueSetId: conceptGroup[0]["valueset_id"],
-      valueSetVersion: conceptGroup[0]["version"],
-      valueSetName: conceptGroup[0]["valueset_name"],
-      // External ID might not be defined for user-defined valuesets
-      valueSetExternalId: conceptGroup[0]["valueset_external_id"]
-        ? conceptGroup[0]["valueset_external_id"]
-        : undefined,
-      author: conceptGroup[0]["author"],
-      system: conceptGroup[0]["code_system"],
-      ersdConceptType: conceptGroup[0]["type"]
-        ? conceptGroup[0]["type"]
-        : undefined,
-      dibbsConceptType: conceptGroup[0]["dibbs_concept_type"],
-      includeValueSet: conceptGroup.find((c) => c["include"]) ? true : false,
-      concepts: conceptGroup.map((c) => {
-        return {
-          code: c["code"],
-          display: c["display"],
-          include: c["include"] ?? true,
-        };
-      }),
-    };
-    const conditionId = conceptGroup[0]["condition_id"];
-    if (conditionId) {
-      valueSet["conditionId"] = conditionId;
-    }
+    const valueSet = mapStoredValueSetIntoInternalValueset(conceptGroup);
     return valueSet;
   });
   return valueSets;
 };
+
+// TODO?: Type the input param more explicitly to not be a generic DB return?
+function mapStoredValueSetIntoInternalValueset(
+  storedValueSetGroup: QueryResultRow[],
+): ValueSet {
+  // For info that should be the same at the valueset-level, just use the first
+  // valueset to populate them for everything
+  const storedValueSet = storedValueSetGroup[0];
+  const valueSet: ValueSet = {
+    valueSetId: storedValueSet["valueset_id"],
+    valueSetVersion: storedValueSet["version"],
+    valueSetName: storedValueSet["valueset_name"],
+    // External ID might not be defined for user-defined valuesets
+    valueSetExternalId: storedValueSet["valueset_external_id"]
+      ? storedValueSet["valueset_external_id"]
+      : undefined,
+    author: storedValueSet["author"],
+    system: storedValueSet["code_system"],
+    ersdConceptType: storedValueSet["type"]
+      ? storedValueSet["type"]
+      : undefined,
+    dibbsConceptType: storedValueSet["dibbs_concept_type"],
+    includeValueSet: storedValueSetGroup.find((c) => c["include"])
+      ? true
+      : false,
+    concepts: storedValueSetGroup.map((c) => {
+      return {
+        code: c["code"],
+        display: c["display"],
+        include: c["include"] ?? true,
+      };
+    }),
+  };
+  const conditionId = storedValueSet["condition_id"];
+  if (conditionId) {
+    valueSet["conditionId"] = conditionId;
+  }
+  return valueSet;
+}

--- a/query-connector/src/app/utils.tsx
+++ b/query-connector/src/app/utils.tsx
@@ -107,7 +107,7 @@ export const unnestValueSetsFromQuery = (
  * @param rows The Rows returned from the ValueSet table.
  * @returns A list of ValueSets, which hold the Concepts pulled from the DB.
  */
-export const populateSavedValueSetWithConcepts = (rows: QueryResultRow[]) => {
+export const groupConditionConceptsByValueSetId = (rows: QueryResultRow[]) => {
   // Create groupings of rows (each of which is a single Concept) by their ValueSet ID
   const vsIdGroupedRows = rows.reduce((conceptsByVSId, r) => {
     if (!(r["valueset_id"] in conceptsByVSId)) {

--- a/query-connector/src/app/utils.tsx
+++ b/query-connector/src/app/utils.tsx
@@ -83,6 +83,10 @@ type QueryTableQueryDataColumn = {
  * @returns A list of ValueSets, which hold the Concepts pulled from the DB.
  */
 
+/**
+ *
+ * @param rows
+ */
 export const unnestValueSetsFromQuery = (
   rows: QueryResultRow[],
 ): ValueSet[] => {


### PR DESCRIPTION
# PULL REQUEST

## Summary
The code that just went in for the new DB tables overloaded a mapping method between @katyasoup and I's PR's that should have been two separate functions. This PR separates them and adds some unit tests to prevent this in the future

## Additional Information
Another example of us not having testing infra biting us! Will bring this up at retro

Something else that might have caught this earlier would be more explicitly typing the response from the DB beyond the provided `QueryRow`. **Would love opinions on how we might type our queries more explicitly to tell application code what the shape of data coming back from the DB looks like**

## Checklist
- [x] Descriptive Pull Request title
- [ ] Update documentation

