### PR TITLE
Bob/translation util followup

### DIFF
--- a/query-connector/src/app/tests/unit/fixtures.ts
+++ b/query-connector/src/app/tests/unit/fixtures.ts
@@ -20,7 +20,7 @@ export const EXPECTED_CHLAMYDIA_VALUESET_LENGTH = Object.values(
   ],
 ).length;
 
-export const CANCER_VALUESETS = [
+export const CANCER_DB_QUERY_VALUES = [
   {
     display: "RESULTS",
     code_system: "http://cap.org/eCC",

--- a/query-connector/src/app/tests/unit/utils.test.tsx
+++ b/query-connector/src/app/tests/unit/utils.test.tsx
@@ -10,7 +10,7 @@ import {
   filterSearchByCategoryAndCondition,
 } from "@/app/queryBuilding/utils";
 import {
-  CANCER_VALUESETS,
+  CANCER_DB_QUERY_VALUES,
   CATEGORY_TO_CONDITION_ARRAY_MAP,
   DEFAULT_CHLAMYDIA_QUERY,
   EXPECTED_CHLAMYDIA_VALUESET_LENGTH,
@@ -139,8 +139,9 @@ describe("data util methods for query building", () => {
   });
 
   describe("groupConditionConceptsByValueSetId", () => {
-    const formattedValueSets =
-      groupConditionConceptsIntoValueSets(CANCER_VALUESETS);
+    const formattedValueSets = groupConditionConceptsIntoValueSets(
+      CANCER_DB_QUERY_VALUES,
+    );
     const EXPECTED_CANCER_VALUESET_GROUPS = 4;
     expect(formattedValueSets.length).toBe(EXPECTED_CANCER_VALUESET_GROUPS);
     expect(

--- a/query-connector/src/app/utils/valueSetTranslation.test.ts
+++ b/query-connector/src/app/utils/valueSetTranslation.test.ts
@@ -1,0 +1,67 @@
+import { DibbsValueSet } from "../constants";
+import { CANCER_DB_QUERY_VALUES } from "../tests/unit/fixtures";
+import { groupConditionConceptsIntoValueSets } from "../utils";
+import {
+  generateValueSetGroupingsByDibbsConceptType,
+  groupValueSetGroupingByConditionId,
+  groupValueSetsByConceptType,
+  groupValueSetsByNameAuthorSystem,
+} from "./valueSetTranslation";
+
+describe("translation utils", () => {
+  let cancerSets: DibbsValueSet[] = groupConditionConceptsIntoValueSets(
+    CANCER_DB_QUERY_VALUES,
+  );
+
+  const CANCER_CONDITION_ID = "2";
+
+  describe("groupValueSetsByNameAuthorSystem", () => {
+    it("returns expected grouped valueset", () => {
+      const groupedValueSets = groupValueSetsByNameAuthorSystem(cancerSets);
+      expect(Object.keys(groupedValueSets).length).toBe(4);
+      expect(
+        Object.values(groupedValueSets).map((v) => v.valueSetName),
+      ).toInclude("Cancer (Leukemia) Lab Result");
+      expect(
+        Object.values(groupedValueSets).map((v) => v.valueSetName),
+      ).toInclude("Cancer (Leukemia) Diagnosis Problem");
+      expect(
+        Object.values(groupedValueSets).map((v) => v.valueSetName),
+      ).toInclude("Cancer (Leukemia) Medication");
+      expect(
+        Object.values(groupedValueSets).map((v) => v.valueSetName),
+      ).toInclude("Suspected Cancer (Leukemia) Diagnosis");
+    });
+  });
+
+  describe("generateValueSetGroupingsByDibbsConceptType", () => {
+    it("returns the expected VsGroupings for each of the concept types", () => {
+      const groupedValueSets =
+        generateValueSetGroupingsByDibbsConceptType(cancerSets);
+
+      expect(Object.values(groupedValueSets["labs"]).length).toBe(1);
+      expect(Object.values(groupedValueSets["conditions"]).length).toBe(2);
+      expect(Object.values(groupedValueSets["medications"]).length).toBe(1);
+    });
+  });
+  describe("groupValueSetGroupingByConditionId", () => {
+    const parentMap = groupValueSetGroupingByConditionId({
+      [CANCER_CONDITION_ID]: cancerSets,
+    });
+
+    const expectedGrouping =
+      generateValueSetGroupingsByDibbsConceptType(cancerSets);
+
+    expect(parentMap[CANCER_CONDITION_ID]).toEqual(expectedGrouping);
+  });
+
+  describe("groupValueSetsByConceptType", () => {
+    it("returns the expected DibbsValueSet arrays for each of the concept types", () => {
+      const groupedValueSets = groupValueSetsByConceptType(cancerSets);
+
+      expect(groupedValueSets["labs"].length).toBe(1);
+      expect(groupedValueSets["conditions"].length).toBe(2);
+      expect(groupedValueSets["medications"].length).toBe(1);
+    });
+  });
+});

--- a/query-connector/src/app/utils/valueSetTranslation.test.ts
+++ b/query-connector/src/app/utils/valueSetTranslation.test.ts
@@ -12,7 +12,6 @@ describe("translation utils", () => {
   let cancerSets: DibbsValueSet[] = groupConditionConceptsIntoValueSets(
     CANCER_DB_QUERY_VALUES,
   );
-
   const CANCER_CONDITION_ID = "2";
 
   describe("groupValueSetsByNameAuthorSystem", () => {

--- a/query-connector/src/app/utils/valueSetTranslation.ts
+++ b/query-connector/src/app/utils/valueSetTranslation.ts
@@ -88,12 +88,13 @@ export function groupValueSetsByNameAuthorSystem(
   return results;
 }
 /**
- * Utility function that grouops an array of DibbsValueSets into the name / author
+ * Utility function that groups an array of DibbsValueSets into the name / author
  * / system groupings and then sorts them into their DibbsConceptType buckets
  * buckets
  * @param vsArray - an array of DibbsValueSets
  * @returns - {[DibbsConceptType]: ValueSetGrouping (VS's that share name / author / system) }
  */
+
 export function generateValueSetGroupingsByDibbsConceptType(
   vsArray: DibbsValueSet[],
 ) {
@@ -131,7 +132,7 @@ export function groupValueSetGroupingByConditionId(
  * @param  valueSetsByConceptType - map of { dibbsConceptType : ValueSet[] }
  * @returns a { dibbsConceptType: {valueSetNameAuthorSystem}: ValueSetGrouping } map
  */
-export function generateValueSetGroupingsByConceptType(valueSetsByConceptType: {
+function generateValueSetGroupingsByConceptType(valueSetsByConceptType: {
   [key in DibbsConceptType]: DibbsValueSet[];
 }) {
   return Object.keys(valueSetsByConceptType).reduce(


### PR DESCRIPTION
# PULL REQUEST

## Summary
Adding some tests to our translation utils folder

## Related Issue
Followup to [this PR](https://github.com/CDCgov/dibbs-query-connector/pull/231#issue-2753308945)

## Additional Information
Per our convo in the 1/2 eng sync, the fact that a bunch of these util methods are needed might be a sign that we can compress down a bunch of corners of our query data structure state. 

Off the top of my head, think that we probably don't need the intermediary `VSGrouping` struct and can just get away with ordering `DibbsValueSets` by concept type in all the places where we're grouping valuesets according to their named key. 

## Checklist

- [ ] Descriptive Pull Request title
- [ ] Link to relevant issues
- [ ] Provide necessary context for design reviewers
- [ ] Update documentation

