### PR TITLE
new content for query building empty state

### DIFF
--- a/query-connector/src/app/queryBuilding/components/ConditionSelection.tsx
+++ b/query-connector/src/app/queryBuilding/components/ConditionSelection.tsx
@@ -97,7 +97,7 @@ export const ConditionSelection: React.FC<ConditionSelectionProps> = ({
       )}
     >
       <div className="display-flex flex-justify flex-align-end margin-bottom-3 width-full">
-        <h2 className="margin-y-0-important">Select condition(s)</h2>
+        <h2 className="margin-y-0-important">Select condition template(s)</h2>
       </div>
       <div className={classNames(styles.conditionSelectionForm, "radius-lg")}>
         <SearchField

--- a/query-connector/src/app/queryBuilding/querySelection/EmptyQueriesDisplay.tsx
+++ b/query-connector/src/app/queryBuilding/querySelection/EmptyQueriesDisplay.tsx
@@ -1,14 +1,21 @@
-import { Button, Icon } from "@trussworks/react-uswds";
-import { useState } from "react";
+import { Button } from "@trussworks/react-uswds";
+import { Dispatch, SetStateAction, useState } from "react";
 import styles from "./querySelection.module.scss";
 import classNames from "classnames";
 import WorkSpaceSetUpView from "./WorkspaceSetUp";
 import { createDibbsDB } from "@/app/backend/dbCreation/db-creation";
+import { BuildStep } from "@/app/constants";
+
+type EmptyQueryProps = {
+  setBuildStep: Dispatch<SetStateAction<BuildStep>>;
+};
 /**
  * Empty-state component for query building
  * @returns the EmptyQueriesDisplay to render the empty state status
  */
-export const EmptyQueriesDisplay: React.FC = () => {
+export const EmptyQueriesDisplay: React.FC<EmptyQueryProps> = ({
+  setBuildStep,
+}) => {
   const [loading, setLoading] = useState(false);
 
   const handleClick = async () => {
@@ -31,34 +38,35 @@ export const EmptyQueriesDisplay: React.FC = () => {
   }
 
   return (
-    <>
-      <div
-        className={classNames(
-          "bg-gray-5",
-          "display-flex",
-          "flex-align-center",
-          "flex-justify-center",
-          styles.emptyStateQueryContainer,
-        )}
-      >
-        <div className="display-flex flex-column flex-align-center">
-          <Icon.GridView
-            aria-label="Icon of four boxes in a grid to indicate empty query state"
-            className={styles.emptyQueryIcon}
-          ></Icon.GridView>
-          <h2 className={styles.emptyQueryTitle}>
-            No custom queries available
-          </h2>
-          <Button
-            onClick={() => handleClick()}
-            className={styles.createQueryButton}
-            type={"button"}
-          >
-            Create Query
-          </Button>
-        </div>
+    <div className={classNames("bg-gray-5", styles.emptyStateQueryContainer)}>
+      <div className="display-flex flex-column flex-align-left">
+        <h2 className={styles.emptyQueryTitle}>Start with Query Builder</h2>
+        <h3 className={styles.emptyQuerySubtitle}>
+          Create custom queries that your staff can use to search for relevant
+          data
+        </h3>
+
+        <ul className={styles.emptyQueryExplainer}>
+          <li>
+            <strong>Leverage</strong> our pre-populated templates with public
+            health codes from LOINC, ICD-10, SNOMED, and more.
+          </li>
+          <li>
+            <strong>Decide</strong> which codes to include in each query.
+          </li>
+          <li>
+            <strong>Combine</strong> codes from different conditions.
+          </li>
+        </ul>
+        <Button
+          onClick={() => setBuildStep("condition")}
+          className={styles.createQueryButton}
+          type={"button"}
+        >
+          Build your first query
+        </Button>
       </div>
-    </>
+    </div>
   );
 };
 

--- a/query-connector/src/app/queryBuilding/querySelection/QueryLibrary.tsx
+++ b/query-connector/src/app/queryBuilding/querySelection/QueryLibrary.tsx
@@ -73,7 +73,7 @@ export const MyQueriesDisplay: React.FC<UserQueriesDisplayProps> = ({
           context,
         )}
       <div className="display-flex flex-justify-between flex-align-center width-full margin-bottom-4">
-        <h1 className="flex-align-center">My queries</h1>
+        <h1 className="flex-align-center">Query Library</h1>
         <div className="margin-left-auto">
           <Button
             onClick={() =>

--- a/query-connector/src/app/queryBuilding/querySelection/QuerySelection.tsx
+++ b/query-connector/src/app/queryBuilding/querySelection/QuerySelection.tsx
@@ -12,7 +12,7 @@ import {
 } from "react";
 import { ToastContainer } from "react-toastify";
 import EmptyQueriesDisplay from "./EmptyQueriesDisplay";
-import MyQueriesDisplay from "./MyQueries";
+import MyQueriesDisplay from "./QueryLibrary";
 import { SelectedQueryDetails, SelectedQueryState } from "./utils";
 import styles from "./querySelection.module.scss";
 import { BuildStep } from "@/app/constants";
@@ -70,9 +70,9 @@ const QuerySelection: React.FC<QuerySelectionProps> = ({
   return (
     <>
       {queries.length === 0 ? (
-        <div className="main-container">
-          <h1 className={styles.queryTitle}>My queries</h1>
-          <EmptyQueriesDisplay />
+        <div className="main-container__wide">
+          <h1 className={styles.queryTitle}>Query Library</h1>
+          <EmptyQueriesDisplay setBuildStep={setBuildStep} />
         </div>
       ) : (
         <div className="main-container__wide">

--- a/query-connector/src/app/queryBuilding/querySelection/querySelection.module.scss
+++ b/query-connector/src/app/queryBuilding/querySelection/querySelection.module.scss
@@ -25,19 +25,28 @@ $conditionColumnSpacing: 2fr 3fr 3fr;
 }
 
 .emptyStateQueryContainer {
-  height: 27.75rem;
+  padding: 2.5rem 5rem;
 }
 
 .emptyQueryTitle {
   width: fit-content;
-  margin: 0.5rem 0 1.5rem 0;
-  font-family: $sans-serif-font;
+  margin: 0;
+}
+
+.emptyQuerySubtitle {
+  width: fit-content;
+  margin: 0.5rem 0;
 }
 
 .emptyQueryIcon {
   width: 7.5rem;
   height: 7.5rem;
   color: $gray-20;
+}
+
+.emptyQueryExplainer {
+  padding-left: 1.5rem;
+  margin: 0 0 1.5rem 0;
 }
 
 .createQueryButton {


### PR DESCRIPTION
# PULL REQUEST

## Summary
Fixes #213 updating the empty state for query building

## Additional Information
### Redirect with full DB 
https://github.com/user-attachments/assets/933c8f71-c0ab-41cd-bea8-76669d4530af

### Redirect with empty DB 
https://github.com/user-attachments/assets/c747c81a-3903-4afb-9e68-e2fdcf360ff0

### For design
Make sure empty state matches [design](https://www.figma.com/design/Iuw9me6kYftBF4WTCEsCZz/Query-Connector?node-id=1523-25407&t=bjlK21jQmEbevahb-1). If you want to pull it up locally, will need to clear your db first by
1. Switching to [this branch](https://github.com/CDCgov/dibbs-query-connector/tree/bob/compose-empty-state-review)
2. Run `docker images` and take note of the image ID attached to postgres (311abe301881 in the below example)
<img width="565" alt="Screenshot 2025-01-06 at 10 06 06 AM" src="https://github.com/user-attachments/assets/956c2aa3-a970-4896-a375-541010a4748b" />
3. Run `docker compose down --volumes --remove-orphans` and then `docker image rm <IMAGE-ID from part 1>`
4. Restart your dev server and go to `/queryBuilding`

Here's a screenshot in case that's easier:
<img width="1430" alt="Screenshot 2025-01-06 at 10 03 17 AM" src="https://github.com/user-attachments/assets/cff2a9c0-d594-4c5b-9bd1-24cdc09cea4d" />

## Checklist

- [x] Descriptive Pull Request title
- [x] Link to relevant issues
- [x] Provide necessary context for design reviewers
- [ ] Update documentation

