### PR TITLE
Update base_url for Postman collection to demo.queryconnector.dev

### DIFF
--- a/query-connector/src/app/assets/DIBBs_Query_Connector_API.postman_collection.json
+++ b/query-connector/src/app/assets/DIBBs_Query_Connector_API.postman_collection.json
@@ -489,7 +489,7 @@
   "variable": [
     {
       "key": "base_url",
-      "value": "https://dibbs.cloud/query-connector",
+      "value": "https://demo.queryconnector.dev",
       "type": "string"
     }
   ]


### PR DESCRIPTION
# PULL REQUEST

## Summary

Updates the `base_url` in the Postman collection to use `demo.queryconnector.dev` instead of `dibbs.cloud` for the Connectathon

## Related Issue

Fixes #

## Additional Information

Anything else the review team should know?

## Checklist

- [ ] Descriptive Pull Request title
- [ ] Link to relevant issues
- [ ] Provide necessary context for design reviewers
- [ ] Update documentation

