### PR TITLE
Updating input field length on Custom Query page

### DIFF
--- a/query-connector/src/app/queryBuilding/buildFromTemplates/BuildFromTemplates.tsx
+++ b/query-connector/src/app/queryBuilding/buildFromTemplates/BuildFromTemplates.tsx
@@ -321,7 +321,7 @@ const BuildFromTemplates: React.FC<BuildFromTemplatesProps> = ({
                 id="queryNameInput"
                 name="queryNameInput"
                 type="text"
-                className="width-card-lg"
+                className="width-mobile"
                 defaultValue={queryName ?? ""}
                 required
                 onChange={(event) => {

--- a/query-connector/src/app/queryBuilding/buildFromTemplates/BuildFromTemplates.tsx
+++ b/query-connector/src/app/queryBuilding/buildFromTemplates/BuildFromTemplates.tsx
@@ -321,7 +321,7 @@ const BuildFromTemplates: React.FC<BuildFromTemplatesProps> = ({
                 id="queryNameInput"
                 name="queryNameInput"
                 type="text"
-                className="maxw-mobile"
+                className="width-card-lg"
                 defaultValue={queryName ?? ""}
                 required
                 onChange={(event) => {

--- a/query-connector/src/app/queryBuilding/components/SelectionViewAccordionHeader.tsx
+++ b/query-connector/src/app/queryBuilding/components/SelectionViewAccordionHeader.tsx
@@ -29,9 +29,22 @@ const ConceptTypeAccordionHeader: React.FC<ConceptTypeAccordionBodyProps> = ({
   expanded,
   handleVsNameLevelUpdate,
 }) => {
-  const concepts = activeTypeValueSets[activeType].concepts;
-  const selectedCount = concepts.filter((c) => c.include).length;
-  const totalCount = concepts.length;
+  const selectedCount = Object.values(activeTypeValueSets).reduce(
+    (acc, curValueSet) => {
+      const curConceptsIncludedCount = curValueSet.concepts.filter(
+        (c) => c.include,
+      ).length;
+      return acc + curConceptsIncludedCount;
+    },
+    0,
+  );
+  const totalCount = Object.values(activeTypeValueSets).reduce(
+    (acc, curValueSet) => {
+      const curConceptsIncludedCount = curValueSet.concepts.length;
+      return acc + curConceptsIncludedCount;
+    },
+    0,
+  );
 
   function handleBulkToggle(
     e: ChangeEvent<HTMLInputElement>,


### PR DESCRIPTION
# PULL REQUEST

## Summary

Making the width of the input longer. 

Current:
<img width="326" alt="Screenshot 2025-01-14 at 11 51 42 AM" src="https://github.com/user-attachments/assets/990b82fe-3d64-489e-a7a3-da9cd5ba086f" />

New:
<img width="282" alt="Screenshot 2025-01-14 at 11 50 26 AM" src="https://github.com/user-attachments/assets/99d68f45-b62d-499b-a6d5-0221094f0352" />

Width updated from  `maxw-mobile` to `width-card-lg` with the out-the-box uswds widths. We can do a custom width, but figured it made sense to stick with the out-the-box where possible.

## Related Issue

Fixes #280

## Additional Information

Anything else the review team should know?

## Checklist

- [ ] Descriptive Pull Request title
- [ ] Link to relevant issues
- [ ] Provide necessary context for design reviewers
- [ ] Update documentation

