### PR TITLE
Add basic auth to FHIR server configuration

### DIFF
--- a/query-connector/src/app/api/test-fhir-connection/route.ts
+++ b/query-connector/src/app/api/test-fhir-connection/route.ts
@@ -1,0 +1,30 @@
+import { NextRequest, NextResponse } from "next/server";
+import { testFhirServerConnection } from "../../query-service";
+
+/**
+ * Test FHIR connection
+ * @param request - Incoming request
+ * @returns Response with the result of the test
+ */
+export async function POST(request: NextRequest) {
+  try {
+    const body = await request.json();
+    const { url, bearerToken } = body;
+
+    if (!url) {
+      return NextResponse.json(
+        { success: false, error: "URL is required" },
+        { status: 400 },
+      );
+    }
+
+    const result = await testFhirServerConnection(url, bearerToken);
+    return NextResponse.json(result);
+  } catch (error) {
+    console.error("Error testing FHIR connection:", error);
+    return NextResponse.json(
+      { success: false, error: "Internal server error" },
+      { status: 500 },
+    );
+  }
+}

--- a/query-connector/src/app/database-service.ts
+++ b/query-connector/src/app/database-service.ts
@@ -766,31 +766,40 @@ export async function getFhirServerConfig(fhirServerName: string) {
  * @param name - The name of the FHIR server
  * @param hostname - The URL/hostname of the FHIR server
  * @param lastConnectionSuccessful - Optional boolean indicating if the last connection was successful
+ * @param bearerToken - Optional bearer token for authentication
  * @returns An object indicating success or failure with optional error message
  */
 export async function insertFhirServer(
   name: string,
   hostname: string,
   lastConnectionSuccessful?: boolean,
+  bearerToken?: string,
 ) {
   const insertQuery = `
     INSERT INTO fhir_servers (
       name,
       hostname, 
       last_connection_attempt,
-      last_connection_successful
+      last_connection_successful,
+      headers
     )
-    VALUES ($1, $2, $3, $4);
+    VALUES ($1, $2, $3, $4, $5);
   `;
 
   try {
     await dbClient.query("BEGIN");
+
+    // Create headers object if bearer token is provided
+    const headers = bearerToken
+      ? { Authorization: `Bearer ${bearerToken}` }
+      : {};
 
     const result = await dbClient.query(insertQuery, [
       name,
       hostname,
       new Date(),
       lastConnectionSuccessful,
+      headers,
     ]);
 
     // Clear the cache so the next getFhirServerConfigs call will fetch fresh data
@@ -818,6 +827,7 @@ export async function insertFhirServer(
  * @param name - The new name of the FHIR server
  * @param hostname - The new URL/hostname of the FHIR server
  * @param lastConnectionSuccessful - Optional boolean indicating if the last connection was successful
+ * @param bearerToken - Optional bearer token for authentication
  * @returns An object indicating success or failure with optional error message
  */
 export async function updateFhirServer(
@@ -825,6 +835,7 @@ export async function updateFhirServer(
   name: string,
   hostname: string,
   lastConnectionSuccessful?: boolean,
+  bearerToken?: string,
 ) {
   const updateQuery = `
     UPDATE fhir_servers 
@@ -832,7 +843,8 @@ export async function updateFhirServer(
       name = $2,
       hostname = $3,
       last_connection_attempt = CURRENT_TIMESTAMP,
-      last_connection_successful = $4
+      last_connection_successful = $4,
+      headers = $5
     WHERE id = $1
     RETURNING *;
   `;
@@ -840,11 +852,31 @@ export async function updateFhirServer(
   try {
     await dbClient.query("BEGIN");
 
+    // If updating with a bearer token, create new headers object
+    // If no bearer token provided, fetch existing headers first to preserve other headers
+    let headers = {};
+    if (bearerToken) {
+      headers = { Authorization: `Bearer ${bearerToken}` };
+    } else {
+      // Get existing headers if any
+      const existingServer = await dbClient.query(
+        "SELECT headers FROM fhir_servers WHERE id = $1",
+        [id],
+      );
+      if (existingServer.rows.length > 0) {
+        const existingHeaders = existingServer.rows[0].headers || {};
+        // Remove Authorization if it exists when switching to no auth
+        const { Authorization, ...restHeaders } = existingHeaders;
+        headers = restHeaders;
+      }
+    }
+
     const result = await dbClient.query(updateQuery, [
       id,
       name,
       hostname,
       lastConnectionSuccessful,
+      headers,
     ]);
 
     // Clear the cache so the next getFhirServerConfigs call will fetch fresh data

--- a/query-connector/src/app/query-service.ts
+++ b/query-connector/src/app/query-service.ts
@@ -1,5 +1,6 @@
 "use server";
 import fetch from "node-fetch";
+import https from "https";
 import { Bundle, DomainResource } from "fhir/r4";
 
 import FHIRClient from "./fhir-servers";
@@ -299,4 +300,127 @@ export async function createBundle(
   });
 
   return bundle;
+}
+
+/**
+ * Tests a connection to a FHIR server from the backend to avoid CORS issues
+ * @param url - The URL of the FHIR server to test
+ * @param bearerToken - Optional bearer token for authentication
+ * @returns Object indicating success/failure and any error messages
+ */
+export async function testFhirServerConnection(
+  url: string,
+  bearerToken?: string,
+) {
+  try {
+    const baseUrl = url.replace(/\/$/, "");
+    const searchParams = new URLSearchParams({
+      given: "Hyper",
+      family: "Unlucky",
+      birthdate: "1975-12-06",
+      identifier: "8692756",
+    });
+    const patientSearchUrl = `${baseUrl}/Patient?${searchParams.toString()}`;
+
+    const headers: HeadersInit = {
+      Accept: "application/fhir+json",
+    };
+
+    if (bearerToken) {
+      headers.Authorization = `Bearer ${bearerToken}`;
+    }
+
+    const httpsAgent = new https.Agent({
+      rejectUnauthorized: false,
+    });
+
+    try {
+      const response = await fetch(patientSearchUrl, {
+        method: "GET",
+        headers,
+        // @ts-ignore - Node's fetch types don't include agent, but it works
+        agent: httpsAgent,
+      });
+
+      const responseText = await response.text(); // Get raw response text
+
+      if (response.ok) {
+        try {
+          const data = JSON.parse(responseText);
+
+          if (data.resourceType === "Bundle" && data.type === "searchset") {
+            return { success: true };
+          } else {
+            console.log(
+              "Invalid response structure. Expected Bundle/searchset, got:",
+              {
+                resourceType: data.resourceType,
+                type: data.type,
+              },
+            );
+            return {
+              success: false,
+              error:
+                "Invalid FHIR server response: Server did not return a valid search Bundle",
+            };
+          }
+        } catch (parseError) {
+          console.error("Error parsing JSON response:", parseError);
+          return {
+            success: false,
+            error: "Failed to parse server response as JSON",
+          };
+        }
+      } else {
+        let errorMessage: string;
+        switch (response.status) {
+          case 401:
+            errorMessage =
+              "Connection failed: Authentication required. Please check your credentials.";
+            break;
+          case 403:
+            errorMessage =
+              "Connection failed: Access forbidden. You do not have permission to access this FHIR server.";
+            break;
+          case 404:
+            errorMessage =
+              "Connection failed: The FHIR server endpoint was not found. Please verify the URL.";
+            break;
+          case 408:
+            errorMessage =
+              "Connection failed: The request timed out. The FHIR server took too long to respond.";
+            break;
+          case 500:
+            errorMessage =
+              "Connection failed: Internal server error. The FHIR server encountered an unexpected condition.";
+            break;
+          case 502:
+            errorMessage =
+              "Connection failed: Bad gateway. The FHIR server received an invalid response from upstream.";
+            break;
+          case 503:
+            errorMessage =
+              "Connection failed: The FHIR server is temporarily unavailable or under maintenance.";
+            break;
+          case 504:
+            errorMessage =
+              "Connection failed: Gateway timeout. The upstream server did not respond in time.";
+            break;
+          default:
+            errorMessage = `Connection failed: The FHIR server returned an error. (${response.status} ${response.statusText})`;
+        }
+        return { success: false, error: errorMessage };
+      }
+    } catch (fetchError) {
+      console.error("Fetch error:", fetchError);
+      throw fetchError; // Re-throw to be caught by outer try-catch
+    }
+  } catch (error) {
+    console.error("Overall error in testFhirServerConnection:", error);
+    return {
+      success: false,
+      error:
+        "Connection failed: Unable to reach the FHIR server. Please check if the URL is correct and the server is accessible.",
+    };
+  }
 }

--- a/query-connector/src/styles/custom-styles.scss
+++ b/query-connector/src/styles/custom-styles.scss
@@ -545,7 +545,7 @@ ul.usa-sidenav
     .usa-modal__main {
       max-width: 34rem;
 
-      input {
+      input, select {
         max-width: 100%;
       }
     }


### PR DESCRIPTION
# PULL REQUEST

## Summary

Add a drop down to the FHIR server config modal for "auth method" with none and basic auth as options. If basic auth is selected, show a text field for a bearer token.

Had to disable cert validation to get "Test connection" to work against the iz gateway demo. We should definitely not keep that in production.

<img width="1755" alt="Screenshot 2025-01-14 at 3 51 11 PM" src="https://github.com/user-attachments/assets/07297576-ccc6-46df-8ed5-12322e805271" />

## Related Issue

https://linear.app/skylight-cdc/issue/QUE-137/add-basic-auth-to-fhir-server-configuration



