### PR TITLE
Dedupe FHIR Resources Parsed by Queries

### DIFF
--- a/query-connector/e2e/query_workflow.spec.ts
+++ b/query-connector/e2e/query_workflow.spec.ts
@@ -30,10 +30,10 @@ test.describe("querying with the Query Connector", () => {
 
     // Better luck next time, user!
     await expect(
-      page.getByRole("heading", { name: "No Records Found" }),
+      page.getByRole("heading", { name: "No Records Found" })
     ).toBeVisible();
     await expect(
-      page.getByText("No records were found for your search"),
+      page.getByText("No records were found for your search")
     ).toBeVisible();
     await page
       .getByRole("link", { name: "Revise your patient search" })
@@ -47,13 +47,13 @@ test.describe("querying with the Query Connector", () => {
     const alert = page.locator(".custom-alert");
     await expect(alert).toBeVisible();
     await expect(alert).toHaveText(
-      "This site is for demo purposes only. Please do not enter PII on this website.",
+      "This site is for demo purposes only. Please do not enter PII on this website."
     );
     await expect(
       page.getByRole("heading", {
         name: PAGE_TITLES["search"].title,
         exact: true,
-      }),
+      })
     ).toBeVisible();
 
     await page.getByRole("button", { name: "Fill fields" }).click();
@@ -68,7 +68,7 @@ test.describe("querying with the Query Connector", () => {
 
     await page.getByRole("link", { name: "Select patient" }).click();
     await expect(
-      page.getByRole("heading", { name: "Select a query" }),
+      page.getByRole("heading", { name: "Select a query" })
     ).toBeVisible();
     await page
       .getByTestId("Select")
@@ -82,10 +82,10 @@ test.describe("querying with the Query Connector", () => {
     // dev can have a note to help debug.
     await page.getByRole("button", { name: "Customize Query" }).click();
     await expect(
-      page.getByRole("heading", { name: "Customize Query" }),
+      page.getByRole("heading", { name: "Customize Query" })
     ).toBeVisible();
     await expect(
-      page.getByText("0 labs found, 0 medications found, 0 conditions found."),
+      page.getByText("0 labs found, 0 medications found, 0 conditions found.")
     ).not.toBeVisible();
     await page.getByText("Return to Select query").click();
 
@@ -95,27 +95,27 @@ test.describe("querying with the Query Connector", () => {
     // Make sure we have a results page with a single patient
     // Non-interactive 'div' elements in the table should be located by text
     await expect(
-      page.getByRole("heading", { name: "Patient Record" }),
+      page.getByRole("heading", { name: "Patient Record" })
     ).toBeVisible();
     await expect(page.getByText("Patient Name")).toBeVisible();
     await expect(page.getByText(TEST_PATIENT_NAME)).toBeVisible();
     await expect(page.getByText("Patient Identifiers")).toBeVisible();
     await expect(
-      page.getByText(`Medical Record Number: ${TEST_PATIENT.MRN}`),
+      page.getByText(`Medical Record Number: ${TEST_PATIENT.MRN}`)
     ).toBeVisible();
 
     // Check that the info alert is visible and has updated to the correct text
     const alert2 = page.locator(".custom-alert");
     await expect(alert2).toBeVisible();
     await expect(alert2).toHaveText(
-      `${CONTACT_US_DISCLAIMER_TEXT} ${CONTACT_US_DISCLAIMER_EMAIL}`,
+      `${CONTACT_US_DISCLAIMER_TEXT} ${CONTACT_US_DISCLAIMER_EMAIL}`
     );
 
     await expect(
-      page.getByRole("button", { name: "Observations", expanded: true }),
+      page.getByRole("button", { name: "Observations", expanded: true })
     ).toBeVisible();
     await expect(
-      page.getByRole("button", { name: "Medication Requests", expanded: true }),
+      page.getByRole("button", { name: "Medication Requests", expanded: true })
     ).toBeVisible();
 
     // We can also just directly ask the page to find us the number of rows
@@ -125,21 +125,21 @@ test.describe("querying with the Query Connector", () => {
       page
         .getByRole("table")
         .filter({ hasText: "Chlamydia trachomatis DNA" })
-        .getByRole("row"),
-    ).toHaveCount(18);
+        .getByRole("row")
+    ).toHaveCount(14);
     // Encounters
     await expect(
       page
         .getByRole("table")
         .filter({ hasText: "Sexual overexposure" })
-        .getByRole("row"),
+        .getByRole("row")
     ).toHaveCount(5);
     // Conditions + Medication Requests (Reason Code)
     await expect(
       page
         .getByRole("table")
         .filter({ hasText: "Chlamydial infection, unspecified" })
-        .getByRole("row"),
+        .getByRole("row")
     ).toHaveCount(10);
     // Diagnostic Reports
     await expect(
@@ -148,14 +148,14 @@ test.describe("querying with the Query Connector", () => {
         .filter({
           hasText: "Chlamydia trachomatis and Neisseria gonorrhoeae DNA panel",
         })
-        .getByRole("row"),
+        .getByRole("row")
     ).toHaveCount(4);
     // Medication Requests
     await expect(
       page
         .getByRole("table")
         .filter({ hasText: "azithromycin 1000 MG" })
-        .getByRole("row"),
+        .getByRole("row")
     ).toHaveCount(7);
 
     // Now let's use the return to search to go back to a blank form
@@ -164,7 +164,7 @@ test.describe("querying with the Query Connector", () => {
       page.getByRole("heading", {
         name: PAGE_TITLES["search"].title,
         exact: true,
-      }),
+      })
     ).toBeVisible();
   });
 });

--- a/query-connector/e2e/query_workflow.spec.ts
+++ b/query-connector/e2e/query_workflow.spec.ts
@@ -30,10 +30,10 @@ test.describe("querying with the Query Connector", () => {
 
     // Better luck next time, user!
     await expect(
-      page.getByRole("heading", { name: "No Records Found" })
+      page.getByRole("heading", { name: "No Records Found" }),
     ).toBeVisible();
     await expect(
-      page.getByText("No records were found for your search")
+      page.getByText("No records were found for your search"),
     ).toBeVisible();
     await page
       .getByRole("link", { name: "Revise your patient search" })
@@ -47,13 +47,13 @@ test.describe("querying with the Query Connector", () => {
     const alert = page.locator(".custom-alert");
     await expect(alert).toBeVisible();
     await expect(alert).toHaveText(
-      "This site is for demo purposes only. Please do not enter PII on this website."
+      "This site is for demo purposes only. Please do not enter PII on this website.",
     );
     await expect(
       page.getByRole("heading", {
         name: PAGE_TITLES["search"].title,
         exact: true,
-      })
+      }),
     ).toBeVisible();
 
     await page.getByRole("button", { name: "Fill fields" }).click();
@@ -68,7 +68,7 @@ test.describe("querying with the Query Connector", () => {
 
     await page.getByRole("link", { name: "Select patient" }).click();
     await expect(
-      page.getByRole("heading", { name: "Select a query" })
+      page.getByRole("heading", { name: "Select a query" }),
     ).toBeVisible();
     await page
       .getByTestId("Select")
@@ -82,10 +82,10 @@ test.describe("querying with the Query Connector", () => {
     // dev can have a note to help debug.
     await page.getByRole("button", { name: "Customize Query" }).click();
     await expect(
-      page.getByRole("heading", { name: "Customize Query" })
+      page.getByRole("heading", { name: "Customize Query" }),
     ).toBeVisible();
     await expect(
-      page.getByText("0 labs found, 0 medications found, 0 conditions found.")
+      page.getByText("0 labs found, 0 medications found, 0 conditions found."),
     ).not.toBeVisible();
     await page.getByText("Return to Select query").click();
 
@@ -95,27 +95,27 @@ test.describe("querying with the Query Connector", () => {
     // Make sure we have a results page with a single patient
     // Non-interactive 'div' elements in the table should be located by text
     await expect(
-      page.getByRole("heading", { name: "Patient Record" })
+      page.getByRole("heading", { name: "Patient Record" }),
     ).toBeVisible();
     await expect(page.getByText("Patient Name")).toBeVisible();
     await expect(page.getByText(TEST_PATIENT_NAME)).toBeVisible();
     await expect(page.getByText("Patient Identifiers")).toBeVisible();
     await expect(
-      page.getByText(`Medical Record Number: ${TEST_PATIENT.MRN}`)
+      page.getByText(`Medical Record Number: ${TEST_PATIENT.MRN}`),
     ).toBeVisible();
 
     // Check that the info alert is visible and has updated to the correct text
     const alert2 = page.locator(".custom-alert");
     await expect(alert2).toBeVisible();
     await expect(alert2).toHaveText(
-      `${CONTACT_US_DISCLAIMER_TEXT} ${CONTACT_US_DISCLAIMER_EMAIL}`
+      `${CONTACT_US_DISCLAIMER_TEXT} ${CONTACT_US_DISCLAIMER_EMAIL}`,
     );
 
     await expect(
-      page.getByRole("button", { name: "Observations", expanded: true })
+      page.getByRole("button", { name: "Observations", expanded: true }),
     ).toBeVisible();
     await expect(
-      page.getByRole("button", { name: "Medication Requests", expanded: true })
+      page.getByRole("button", { name: "Medication Requests", expanded: true }),
     ).toBeVisible();
 
     // We can also just directly ask the page to find us the number of rows
@@ -125,21 +125,21 @@ test.describe("querying with the Query Connector", () => {
       page
         .getByRole("table")
         .filter({ hasText: "Chlamydia trachomatis DNA" })
-        .getByRole("row")
+        .getByRole("row"),
     ).toHaveCount(14);
     // Encounters
     await expect(
       page
         .getByRole("table")
         .filter({ hasText: "Sexual overexposure" })
-        .getByRole("row")
+        .getByRole("row"),
     ).toHaveCount(5);
     // Conditions + Medication Requests (Reason Code)
     await expect(
       page
         .getByRole("table")
         .filter({ hasText: "Chlamydial infection, unspecified" })
-        .getByRole("row")
+        .getByRole("row"),
     ).toHaveCount(10);
     // Diagnostic Reports
     await expect(
@@ -148,14 +148,14 @@ test.describe("querying with the Query Connector", () => {
         .filter({
           hasText: "Chlamydia trachomatis and Neisseria gonorrhoeae DNA panel",
         })
-        .getByRole("row")
+        .getByRole("row"),
     ).toHaveCount(4);
     // Medication Requests
     await expect(
       page
         .getByRole("table")
         .filter({ hasText: "azithromycin 1000 MG" })
-        .getByRole("row")
+        .getByRole("row"),
     ).toHaveCount(7);
 
     // Now let's use the return to search to go back to a blank form
@@ -164,7 +164,7 @@ test.describe("querying with the Query Connector", () => {
       page.getByRole("heading", {
         name: PAGE_TITLES["search"].title,
         exact: true,
-      })
+      }),
     ).toBeVisible();
   });
 });

--- a/query-connector/src/app/constants.ts
+++ b/query-connector/src/app/constants.ts
@@ -56,16 +56,6 @@ export type DemoDataFields = {
   FhirServer: string;
 };
 
-/*Type to specify the different patient types*/
-export type PatientType =
-  | "cancer"
-  | "sti-chlamydia-positive"
-  | "sti-gonorrhea-positive"
-  | "newborn-screening-technical-fail"
-  | "newborn-screening-referral"
-  | "newborn-screening-pass"
-  | "sti-syphilis-positive";
-
 export const DEFAULT_DEMO_FHIR_SERVER = "Public HAPI: Direct";
 /*
  * Common "Hyper Unlucky" patient data used for all non-newborn screening use cases
@@ -83,43 +73,6 @@ export const hyperUnluckyPatient: DemoDataFields = {
 type Option = {
   value: string;
   label: string;
-};
-
-/* Labels and values for the patient options that are available based on the query option selected */
-export const patientOptions: Record<string, Option[]> = {
-  cancer: [{ value: "cancer", label: "A patient with leukemia" }],
-  chlamydia: [
-    {
-      value: "sti-chlamydia-positive",
-      label: "A male patient with a positive chlamydia lab test",
-    },
-  ],
-  gonorrhea: [
-    {
-      value: "sti-gonorrhea-positive",
-      label: "A male patient with a positive gonorrhea lab test",
-    },
-  ],
-  "newborn-screening": [
-    {
-      value: "newborn-screening-technical-fail",
-      label: "A newborn with a technical failure on screening",
-    },
-    {
-      value: "newborn-screening-referral",
-      label: "A newborn with a hearing referral & risk indicator",
-    },
-    {
-      value: "newborn-screening-pass",
-      label: "A newborn with a passed screening",
-    },
-  ],
-  syphilis: [
-    {
-      value: "sti-syphilis-positive",
-      label: "A patient with a positive syphilis lab test",
-    },
-  ],
 };
 
 /*Labels and values for the state options dropdown on the query page*/

--- a/query-connector/src/app/query-service.ts
+++ b/query-connector/src/app/query-service.ts
@@ -63,7 +63,7 @@ export type FhirQueryResponse = Awaited<ReturnType<typeof makeFhirQuery>>;
 async function queryEncounters(
   patientId: string,
   fhirClient: FHIRClient,
-  queryResponse: QueryResponse
+  queryResponse: QueryResponse,
 ): Promise<QueryResponse> {
   if (queryResponse.Condition && queryResponse.Condition.length > 0) {
     const conditionId = queryResponse.Condition[0].id;
@@ -85,7 +85,7 @@ async function queryEncounters(
 async function patientQuery(
   request: QueryRequest,
   fhirClient: FHIRClient,
-  queryResponse: QueryResponse
+  queryResponse: QueryResponse,
 ): Promise<void> {
   // Query for patient
   let query = "/Patient?";
@@ -125,7 +125,7 @@ async function patientQuery(
     console.error(
       `Patient search failed. Status: ${response.status} \n Body: ${
         response.text
-      } \n Headers: ${JSON.stringify(response.headers.raw())}`
+      } \n Headers: ${JSON.stringify(response.headers.raw())}`,
     );
   }
   queryResponse = await parseFhirSearch(response, queryResponse);
@@ -142,7 +142,7 @@ async function patientQuery(
 export async function makeFhirQuery(
   request: QueryRequest,
   queryValueSets: DibbsValueSet[],
-  queryResponse: QueryResponse = {}
+  queryResponse: QueryResponse = {},
 ): Promise<QueryResponse> {
   const fhirServerConfigs = await getFhirServerConfigs();
   const fhirClient = new FHIRClient(request.fhir_server, fhirServerConfigs);
@@ -162,7 +162,7 @@ export async function makeFhirQuery(
     queryValueSets,
     patientId,
     fhirClient,
-    queryResponse
+    queryResponse,
   );
 
   return queryResponse;
@@ -186,7 +186,7 @@ async function generalizedQuery(
   queryValueSets: DibbsValueSet[],
   patientId: string,
   fhirClient: FHIRClient,
-  queryResponse: QueryResponse
+  queryResponse: QueryResponse,
 ): Promise<QueryResponse> {
   const querySpec = await formatValueSetsAsQuerySpec(queryName, queryValueSets);
   const builtQuery = new CustomQuery(querySpec, patientId);
@@ -219,7 +219,7 @@ async function generalizedQuery(
  */
 export async function parseFhirSearch(
   response: fetch.Response | Array<fetch.Response>,
-  queryResponse: Record<string, FhirResource[]> = {}
+  queryResponse: Record<string, FhirResource[]> = {},
 ): Promise<QueryResponse> {
   let resourceArray: FhirResource[] = [];
   // let resourceIds: string[] = [];
@@ -258,7 +258,7 @@ export async function parseFhirSearch(
  * @returns - The array of resources from the response.
  */
 export async function processFhirResponse(
-  response: fetch.Response
+  response: fetch.Response,
 ): Promise<FhirResource[]> {
   let resourceArray: FhirResource[] = [];
   let resourceIds: string[] = [];
@@ -269,7 +269,7 @@ export async function processFhirResponse(
       for (const entry of body.entry) {
         if (!isFhirResource(entry.resource)) {
           console.error(
-            "Entry in FHIR resource response parsing was of unexpected shape"
+            "Entry in FHIR resource response parsing was of unexpected shape",
           );
         }
         // Add the resource only if the ID is unique to the resources being returned for the query
@@ -289,7 +289,7 @@ export async function processFhirResponse(
  * @returns - The FHIR Bundle of queried data.
  */
 export async function createBundle(
-  queryResponse: QueryResponse
+  queryResponse: QueryResponse,
 ): Promise<APIQueryResponse> {
   const bundle: Bundle = {
     resourceType: "Bundle",
@@ -318,7 +318,7 @@ export async function createBundle(
  */
 export async function testFhirServerConnection(
   url: string,
-  bearerToken?: string
+  bearerToken?: string,
 ) {
   try {
     const baseUrl = url.replace(/\/$/, "");
@@ -364,7 +364,7 @@ export async function testFhirServerConnection(
               {
                 resourceType: data.resourceType,
                 type: data.type,
-              }
+              },
             );
             return {
               success: false,

--- a/query-connector/src/app/query-service.ts
+++ b/query-connector/src/app/query-service.ts
@@ -222,7 +222,6 @@ export async function parseFhirSearch(
   queryResponse: Record<string, FhirResource[]> = {},
 ): Promise<QueryResponse> {
   let resourceArray: FhirResource[] = [];
-  // let resourceIds: string[] = [];
   const resourceIds = new Set<string>();
 
   // Process the responses and flatten them


### PR DESCRIPTION
# PULL REQUEST

## Summary

The PR also includes a bit of cleanup on constants that are no longer used (patientOptions and patientType). To dedupe resources added to the `QueryResponse` and then displayed to users, I modified `processFhirResponse` and `parseFhirSearch`.  

The modifications to `processFhirResponse` dedupe resources returned in a given query for a resource type. That is, when we query for Observations using a list of codes, these changes will only add Observations with unique IDs for that query. 

The modifications to `parseFhirSearch` dedupe resources across a whole query, e.g. "My STLT's Chlamydia Query". This is important if we end up pulling back resources of the same type (e.g., Observations) from separately executed queries because the resources would not be deduped by `processFhirResponse` alone. For example, if we query for Observations using a list of codes and then separately query for Observations using the `social-history` class, we could end up returning the same Observation resource in the two queries that would then need to be deduped.

This PR
**Sample Changes using Chlamydia ONE JMC**

Old (returning the same resource multiple times if queried for multiple ways or if the bundle somehow included multiples of the same resource)
![image](https://github.com/user-attachments/assets/139320c4-671c-4992-8f7e-b02486148659)

New (returning only 1 copy of each resource by resource id)
![image](https://github.com/user-attachments/assets/8a4183e2-9027-4b69-821e-71e9fd79f2ca)


## Related Issue

Fixes #301 

## Additional Information
I noticed that we are relying on `FhirResource` that is our own type and I believe we should switch over to using the one provided by `fhir/r4` as it is more robustly typed. As it stands, our `FhirResource` only refers to a handful of resource types, e.g., Observations, Medication Requests, etc. and we would need to manually update the list if we want to include other resource types in future queries, e.g., Practitioner. I suggest we removed the DIBBs `FhirResource` type and switch to using the one that is better typed.

## Checklist

- [x] Descriptive Pull Request title
- [x] Link to relevant issues
- [ ] Provide necessary context for design reviewers
- [ ] Update documentation

