### PR TITLE
Use `FhirResource` from `fhir/r4`, not a DIBBS definition

### DIFF
--- a/query-connector/src/app/constants.ts
+++ b/query-connector/src/app/constants.ts
@@ -1,14 +1,4 @@
-import {
-  Patient,
-  Observation,
-  DiagnosticReport,
-  Condition,
-  Encounter,
-  Medication,
-  MedicationAdministration,
-  MedicationRequest,
-  Immunization,
-} from "fhir/r4";
+import { FhirResource } from "fhir/r4";
 
 export const USE_CASE_DETAILS = {
   "newborn-screening": {
@@ -200,19 +190,6 @@ export const ersdToDibbsConceptMap: {
   dxtc: "conditions",
   sdtc: "conditions",
 };
-
-// Define the type guard for FHIR resources
-// Define the FHIR Resource types
-export type FhirResource =
-  | Patient
-  | Observation
-  | DiagnosticReport
-  | Condition
-  | Encounter
-  | Medication
-  | MedicationAdministration
-  | MedicationRequest
-  | Immunization;
 
 /**
  * A type guard function that checks if the given resource is a valid FHIR resource.

--- a/query-connector/src/app/query-service.ts
+++ b/query-connector/src/app/query-service.ts
@@ -1,10 +1,10 @@
 "use server";
 import fetch from "node-fetch";
 import https from "https";
-import { Bundle, DomainResource } from "fhir/r4";
+import { Bundle, FhirResource } from "fhir/r4";
 
 import FHIRClient from "./fhir-servers";
-import { DibbsValueSet, isFhirResource, FhirResource } from "./constants";
+import { DibbsValueSet, isFhirResource } from "./constants";
 import { CustomQuery } from "./CustomQuery";
 import { GetPhoneQueryFormats } from "./format-service";
 import { formatValueSetsAsQuerySpec } from "./format-service";
@@ -15,12 +15,6 @@ import { getFhirServerConfigs } from "./database-service";
  */
 export type QueryResponse = {
   [R in FhirResource as R["resourceType"]]?: R[];
-};
-
-// workaround types to get around a typescript compilation issue
-type SuperSetFhirResource = DomainResource | FhirResource;
-type SuperSetQueryResponse = {
-  [R in SuperSetFhirResource as R["resourceType"]]?: R[];
 };
 
 export type APIQueryResponse = Bundle;


### PR DESCRIPTION
# PULL REQUEST

## Summary
This PR switches all instances of the DIBBs version of `FhirResource` to the one from `fhir/r4` for more robust typing and future proofing for additional resource queries.

## Related Issue

Fixes #310

## Additional Information

I thought we were using the DIBBs version in a lot more places and thought this would be a bigger PR 😆 

## Checklist

- [x] Descriptive Pull Request title
- [x] Link to relevant issues
- [ ] Provide necessary context for design reviewers
- [ ] Update documentation

