### PR TITLE
Update MRN and Identifier Formatting to include Assigner

### DIFF
--- a/query-connector/e2e/customize_query.spec.ts
+++ b/query-connector/e2e/customize_query.spec.ts
@@ -16,13 +16,13 @@ test.describe("querying with the Query Connector", () => {
     const alert = page.locator(".custom-alert");
     await expect(alert).toBeVisible();
     await expect(alert).toHaveText(
-      "This site is for demo purposes only. Please do not enter PII on this website."
+      "This site is for demo purposes only. Please do not enter PII on this website.",
     );
     await expect(
       page.getByRole("heading", {
         name: PAGE_TITLES["search"].title,
         exact: true,
-      })
+      }),
     ).toBeVisible();
 
     await page.getByRole("button", { name: "Fill fields" }).click();
@@ -37,7 +37,7 @@ test.describe("querying with the Query Connector", () => {
 
     await page.getByRole("link", { name: "Select patient" }).click();
     await expect(
-      page.getByRole("heading", { name: "Select a query" })
+      page.getByRole("heading", { name: "Select a query" }),
     ).toBeVisible();
     await page
       .getByTestId("Select")
@@ -45,7 +45,7 @@ test.describe("querying with the Query Connector", () => {
 
     await page.getByRole("button", { name: "Customize Query" }).click();
     await expect(
-      page.getByRole("heading", { name: "Customize Query" })
+      page.getByRole("heading", { name: "Customize Query" }),
     ).toBeVisible();
   });
 
@@ -53,8 +53,8 @@ test.describe("querying with the Query Connector", () => {
     test.slow();
     await expect(
       page.getByText(
-        "250 labs found, 4 medications found, 104 conditions found."
-      )
+        "250 labs found, 4 medications found, 104 conditions found.",
+      ),
     ).toBeVisible();
     await page.getByRole("button", { name: "Medications" }).click();
     await page.getByRole("button", { name: "Chlamydia Medication" }).click();
@@ -71,7 +71,7 @@ test.describe("querying with the Query Connector", () => {
     await expect(page.getByText("2 of 4 selected")).toBeVisible();
     await page.getByRole("button", { name: "Apply changes" }).click();
     await expect(
-      page.getByRole("alert").getByText("Query Customization Successful!")
+      page.getByRole("alert").getByText("Query Customization Successful!"),
     ).toBeVisible();
 
     await page.getByRole("button", { name: "Submit" }).click();
@@ -80,37 +80,37 @@ test.describe("querying with the Query Connector", () => {
     // Make sure we have a results page with a single patient
     // Non-interactive 'div' elements in the table should be located by text
     await expect(
-      page.getByRole("heading", { name: "Patient Record" })
+      page.getByRole("heading", { name: "Patient Record" }),
     ).toBeVisible();
     await expect(page.getByText("Patient Name")).toBeVisible();
     await expect(page.getByText(TEST_PATIENT_NAME)).toBeVisible();
     await expect(page.getByText("Patient Identifiers")).toBeVisible();
     await expect(
       page.getByText(
-        `Medical Record Number: St. Worrywart’s Hospital: ${TEST_PATIENT.MRN}`
-      )
+        `Medical Record Number: St. Worrywart’s Hospital: ${TEST_PATIENT.MRN}`,
+      ),
     ).toBeVisible();
 
     // Should now just be a single lonely medication request
     // No azithromycin or ceftriaxone should be visible
     await expect(
-      page.getByRole("button", { name: "Medication Requests", expanded: true })
+      page.getByRole("button", { name: "Medication Requests", expanded: true }),
     ).toBeVisible();
     await expect(
-      page.getByRole("row").filter({ hasText: "doxycycline hyclate 100 MG" })
+      page.getByRole("row").filter({ hasText: "doxycycline hyclate 100 MG" }),
     ).toBeVisible();
     await expect(
-      page.getByRole("row").filter({ hasText: "azithromycin 1000 MG" })
+      page.getByRole("row").filter({ hasText: "azithromycin 1000 MG" }),
     ).not.toBeVisible();
     await expect(
-      page.getByRole("row").filter({ hasText: "ceftriaxone 500 MG Injection" })
+      page.getByRole("row").filter({ hasText: "ceftriaxone 500 MG Injection" }),
     ).not.toBeVisible();
     // Count will be 2: the lonely med and the title row
     await expect(
       page
         .getByRole("table")
         .filter({ hasText: "doxycycline hyclate 100 MG" })
-        .getByRole("row")
+        .getByRole("row"),
     ).toHaveCount(2);
   });
 
@@ -136,7 +136,7 @@ test.describe("querying with the Query Connector", () => {
 
     await page.getByRole("button", { name: "Apply changes" }).click();
     await expect(
-      page.getByRole("alert").getByText("Query Customization Successful!")
+      page.getByRole("alert").getByText("Query Customization Successful!"),
     ).toBeVisible();
 
     await page.getByRole("button", { name: "Submit" }).click();
@@ -145,36 +145,36 @@ test.describe("querying with the Query Connector", () => {
     // Make sure we have a results page with a single patient
     // Non-interactive 'div' elements in the table should be located by text
     await expect(
-      page.getByRole("heading", { name: "Patient Record" })
+      page.getByRole("heading", { name: "Patient Record" }),
     ).toBeVisible();
     await expect(page.getByText("Patient Name")).toBeVisible();
     await expect(page.getByText(TEST_PATIENT_NAME)).toBeVisible();
     await expect(page.getByText("Patient Identifiers")).toBeVisible();
     await expect(
       page.getByText(
-        `Medical Record Number: St. Worrywart’s Hospital: ${TEST_PATIENT.MRN}`
-      )
+        `Medical Record Number: St. Worrywart’s Hospital: ${TEST_PATIENT.MRN}`,
+      ),
     ).toBeVisible();
 
     // Should be no medication requests available
     await expect(
-      page.getByRole("button", { name: "Medication Requests" })
+      page.getByRole("button", { name: "Medication Requests" }),
     ).not.toBeVisible();
 
     // Eliminating all value set labs should also remove diagnostic reports
     await expect(
-      page.getByRole("button", { name: "Diagnostic Reports" })
+      page.getByRole("button", { name: "Diagnostic Reports" }),
     ).not.toBeVisible();
 
     // Observations table should have 5 rows, all of which are SDoH factors rather than lab results
     await expect(
-      page.getByRole("button", { name: "Observations", expanded: true })
+      page.getByRole("button", { name: "Observations", expanded: true }),
     ).toBeVisible();
     await expect(
       page
         .getByRole("table")
         .filter({ hasText: "I do not have housing" })
-        .getByRole("row")
+        .getByRole("row"),
     ).toHaveCount(6);
     const acceptableSdohKeywords = [
       "history",
@@ -190,8 +190,8 @@ test.describe("querying with the Query Connector", () => {
     for (let i = 1; i < 6; i++) {
       const row = obsRows.nth(i);
       const typeText = await row.locator("td").nth(1).textContent();
-      const presentKey = acceptableSdohKeywords.find(
-        (key) => typeText?.toLowerCase().includes(key)
+      const presentKey = acceptableSdohKeywords.find((key) =>
+        typeText?.toLowerCase().includes(key),
       );
       expect(presentKey).toBeDefined();
       expect(typeText?.includes("chlamydia")).toBeFalsy();

--- a/query-connector/e2e/customize_query.spec.ts
+++ b/query-connector/e2e/customize_query.spec.ts
@@ -16,13 +16,13 @@ test.describe("querying with the Query Connector", () => {
     const alert = page.locator(".custom-alert");
     await expect(alert).toBeVisible();
     await expect(alert).toHaveText(
-      "This site is for demo purposes only. Please do not enter PII on this website.",
+      "This site is for demo purposes only. Please do not enter PII on this website."
     );
     await expect(
       page.getByRole("heading", {
         name: PAGE_TITLES["search"].title,
         exact: true,
-      }),
+      })
     ).toBeVisible();
 
     await page.getByRole("button", { name: "Fill fields" }).click();
@@ -37,7 +37,7 @@ test.describe("querying with the Query Connector", () => {
 
     await page.getByRole("link", { name: "Select patient" }).click();
     await expect(
-      page.getByRole("heading", { name: "Select a query" }),
+      page.getByRole("heading", { name: "Select a query" })
     ).toBeVisible();
     await page
       .getByTestId("Select")
@@ -45,7 +45,7 @@ test.describe("querying with the Query Connector", () => {
 
     await page.getByRole("button", { name: "Customize Query" }).click();
     await expect(
-      page.getByRole("heading", { name: "Customize Query" }),
+      page.getByRole("heading", { name: "Customize Query" })
     ).toBeVisible();
   });
 
@@ -53,8 +53,8 @@ test.describe("querying with the Query Connector", () => {
     test.slow();
     await expect(
       page.getByText(
-        "250 labs found, 4 medications found, 104 conditions found.",
-      ),
+        "250 labs found, 4 medications found, 104 conditions found."
+      )
     ).toBeVisible();
     await page.getByRole("button", { name: "Medications" }).click();
     await page.getByRole("button", { name: "Chlamydia Medication" }).click();
@@ -71,7 +71,7 @@ test.describe("querying with the Query Connector", () => {
     await expect(page.getByText("2 of 4 selected")).toBeVisible();
     await page.getByRole("button", { name: "Apply changes" }).click();
     await expect(
-      page.getByRole("alert").getByText("Query Customization Successful!"),
+      page.getByRole("alert").getByText("Query Customization Successful!")
     ).toBeVisible();
 
     await page.getByRole("button", { name: "Submit" }).click();
@@ -80,35 +80,37 @@ test.describe("querying with the Query Connector", () => {
     // Make sure we have a results page with a single patient
     // Non-interactive 'div' elements in the table should be located by text
     await expect(
-      page.getByRole("heading", { name: "Patient Record" }),
+      page.getByRole("heading", { name: "Patient Record" })
     ).toBeVisible();
     await expect(page.getByText("Patient Name")).toBeVisible();
     await expect(page.getByText(TEST_PATIENT_NAME)).toBeVisible();
     await expect(page.getByText("Patient Identifiers")).toBeVisible();
     await expect(
-      page.getByText(`Medical Record Number: ${TEST_PATIENT.MRN}`),
+      page.getByText(
+        `Medical Record Number: St. Worrywart’s Hospital: ${TEST_PATIENT.MRN}`
+      )
     ).toBeVisible();
 
     // Should now just be a single lonely medication request
     // No azithromycin or ceftriaxone should be visible
     await expect(
-      page.getByRole("button", { name: "Medication Requests", expanded: true }),
+      page.getByRole("button", { name: "Medication Requests", expanded: true })
     ).toBeVisible();
     await expect(
-      page.getByRole("row").filter({ hasText: "doxycycline hyclate 100 MG" }),
+      page.getByRole("row").filter({ hasText: "doxycycline hyclate 100 MG" })
     ).toBeVisible();
     await expect(
-      page.getByRole("row").filter({ hasText: "azithromycin 1000 MG" }),
+      page.getByRole("row").filter({ hasText: "azithromycin 1000 MG" })
     ).not.toBeVisible();
     await expect(
-      page.getByRole("row").filter({ hasText: "ceftriaxone 500 MG Injection" }),
+      page.getByRole("row").filter({ hasText: "ceftriaxone 500 MG Injection" })
     ).not.toBeVisible();
     // Count will be 2: the lonely med and the title row
     await expect(
       page
         .getByRole("table")
         .filter({ hasText: "doxycycline hyclate 100 MG" })
-        .getByRole("row"),
+        .getByRole("row")
     ).toHaveCount(2);
   });
 
@@ -134,7 +136,7 @@ test.describe("querying with the Query Connector", () => {
 
     await page.getByRole("button", { name: "Apply changes" }).click();
     await expect(
-      page.getByRole("alert").getByText("Query Customization Successful!"),
+      page.getByRole("alert").getByText("Query Customization Successful!")
     ).toBeVisible();
 
     await page.getByRole("button", { name: "Submit" }).click();
@@ -143,34 +145,36 @@ test.describe("querying with the Query Connector", () => {
     // Make sure we have a results page with a single patient
     // Non-interactive 'div' elements in the table should be located by text
     await expect(
-      page.getByRole("heading", { name: "Patient Record" }),
+      page.getByRole("heading", { name: "Patient Record" })
     ).toBeVisible();
     await expect(page.getByText("Patient Name")).toBeVisible();
     await expect(page.getByText(TEST_PATIENT_NAME)).toBeVisible();
     await expect(page.getByText("Patient Identifiers")).toBeVisible();
     await expect(
-      page.getByText(`Medical Record Number: ${TEST_PATIENT.MRN}`),
+      page.getByText(
+        `Medical Record Number: St. Worrywart’s Hospital: ${TEST_PATIENT.MRN}`
+      )
     ).toBeVisible();
 
     // Should be no medication requests available
     await expect(
-      page.getByRole("button", { name: "Medication Requests" }),
+      page.getByRole("button", { name: "Medication Requests" })
     ).not.toBeVisible();
 
     // Eliminating all value set labs should also remove diagnostic reports
     await expect(
-      page.getByRole("button", { name: "Diagnostic Reports" }),
+      page.getByRole("button", { name: "Diagnostic Reports" })
     ).not.toBeVisible();
 
     // Observations table should have 5 rows, all of which are SDoH factors rather than lab results
     await expect(
-      page.getByRole("button", { name: "Observations", expanded: true }),
+      page.getByRole("button", { name: "Observations", expanded: true })
     ).toBeVisible();
     await expect(
       page
         .getByRole("table")
         .filter({ hasText: "I do not have housing" })
-        .getByRole("row"),
+        .getByRole("row")
     ).toHaveCount(6);
     const acceptableSdohKeywords = [
       "history",
@@ -186,8 +190,8 @@ test.describe("querying with the Query Connector", () => {
     for (let i = 1; i < 6; i++) {
       const row = obsRows.nth(i);
       const typeText = await row.locator("td").nth(1).textContent();
-      const presentKey = acceptableSdohKeywords.find((key) =>
-        typeText?.toLowerCase().includes(key),
+      const presentKey = acceptableSdohKeywords.find(
+        (key) => typeText?.toLowerCase().includes(key)
       );
       expect(presentKey).toBeDefined();
       expect(typeText?.includes("chlamydia")).toBeFalsy();

--- a/query-connector/e2e/query_workflow.spec.ts
+++ b/query-connector/e2e/query_workflow.spec.ts
@@ -30,10 +30,10 @@ test.describe("querying with the Query Connector", () => {
 
     // Better luck next time, user!
     await expect(
-      page.getByRole("heading", { name: "No Records Found" }),
+      page.getByRole("heading", { name: "No Records Found" })
     ).toBeVisible();
     await expect(
-      page.getByText("No records were found for your search"),
+      page.getByText("No records were found for your search")
     ).toBeVisible();
     await page
       .getByRole("link", { name: "Revise your patient search" })
@@ -47,13 +47,13 @@ test.describe("querying with the Query Connector", () => {
     const alert = page.locator(".custom-alert");
     await expect(alert).toBeVisible();
     await expect(alert).toHaveText(
-      "This site is for demo purposes only. Please do not enter PII on this website.",
+      "This site is for demo purposes only. Please do not enter PII on this website."
     );
     await expect(
       page.getByRole("heading", {
         name: PAGE_TITLES["search"].title,
         exact: true,
-      }),
+      })
     ).toBeVisible();
 
     await page.getByRole("button", { name: "Fill fields" }).click();
@@ -68,7 +68,7 @@ test.describe("querying with the Query Connector", () => {
 
     await page.getByRole("link", { name: "Select patient" }).click();
     await expect(
-      page.getByRole("heading", { name: "Select a query" }),
+      page.getByRole("heading", { name: "Select a query" })
     ).toBeVisible();
     await page
       .getByTestId("Select")
@@ -82,10 +82,10 @@ test.describe("querying with the Query Connector", () => {
     // dev can have a note to help debug.
     await page.getByRole("button", { name: "Customize Query" }).click();
     await expect(
-      page.getByRole("heading", { name: "Customize Query" }),
+      page.getByRole("heading", { name: "Customize Query" })
     ).toBeVisible();
     await expect(
-      page.getByText("0 labs found, 0 medications found, 0 conditions found."),
+      page.getByText("0 labs found, 0 medications found, 0 conditions found.")
     ).not.toBeVisible();
     await page.getByText("Return to Select query").click();
 
@@ -95,27 +95,29 @@ test.describe("querying with the Query Connector", () => {
     // Make sure we have a results page with a single patient
     // Non-interactive 'div' elements in the table should be located by text
     await expect(
-      page.getByRole("heading", { name: "Patient Record" }),
+      page.getByRole("heading", { name: "Patient Record" })
     ).toBeVisible();
     await expect(page.getByText("Patient Name")).toBeVisible();
     await expect(page.getByText(TEST_PATIENT_NAME)).toBeVisible();
     await expect(page.getByText("Patient Identifiers")).toBeVisible();
     await expect(
-      page.getByText(`Medical Record Number: ${TEST_PATIENT.MRN}`),
+      page.getByText(
+        `Medical Record Number: St. Worrywart’s Hospital: ${TEST_PATIENT.MRN}`
+      )
     ).toBeVisible();
 
     // Check that the info alert is visible and has updated to the correct text
     const alert2 = page.locator(".custom-alert");
     await expect(alert2).toBeVisible();
     await expect(alert2).toHaveText(
-      `${CONTACT_US_DISCLAIMER_TEXT} ${CONTACT_US_DISCLAIMER_EMAIL}`,
+      `${CONTACT_US_DISCLAIMER_TEXT} ${CONTACT_US_DISCLAIMER_EMAIL}`
     );
 
     await expect(
-      page.getByRole("button", { name: "Observations", expanded: true }),
+      page.getByRole("button", { name: "Observations", expanded: true })
     ).toBeVisible();
     await expect(
-      page.getByRole("button", { name: "Medication Requests", expanded: true }),
+      page.getByRole("button", { name: "Medication Requests", expanded: true })
     ).toBeVisible();
 
     // We can also just directly ask the page to find us the number of rows
@@ -125,21 +127,21 @@ test.describe("querying with the Query Connector", () => {
       page
         .getByRole("table")
         .filter({ hasText: "Chlamydia trachomatis DNA" })
-        .getByRole("row"),
+        .getByRole("row")
     ).toHaveCount(14);
     // Encounters
     await expect(
       page
         .getByRole("table")
         .filter({ hasText: "Sexual overexposure" })
-        .getByRole("row"),
+        .getByRole("row")
     ).toHaveCount(5);
     // Conditions + Medication Requests (Reason Code)
     await expect(
       page
         .getByRole("table")
         .filter({ hasText: "Chlamydial infection, unspecified" })
-        .getByRole("row"),
+        .getByRole("row")
     ).toHaveCount(10);
     // Diagnostic Reports
     await expect(
@@ -148,14 +150,14 @@ test.describe("querying with the Query Connector", () => {
         .filter({
           hasText: "Chlamydia trachomatis and Neisseria gonorrhoeae DNA panel",
         })
-        .getByRole("row"),
+        .getByRole("row")
     ).toHaveCount(4);
     // Medication Requests
     await expect(
       page
         .getByRole("table")
         .filter({ hasText: "azithromycin 1000 MG" })
-        .getByRole("row"),
+        .getByRole("row")
     ).toHaveCount(7);
 
     // Now let's use the return to search to go back to a blank form
@@ -164,7 +166,7 @@ test.describe("querying with the Query Connector", () => {
       page.getByRole("heading", {
         name: PAGE_TITLES["search"].title,
         exact: true,
-      }),
+      })
     ).toBeVisible();
   });
 });

--- a/query-connector/e2e/query_workflow.spec.ts
+++ b/query-connector/e2e/query_workflow.spec.ts
@@ -30,10 +30,10 @@ test.describe("querying with the Query Connector", () => {
 
     // Better luck next time, user!
     await expect(
-      page.getByRole("heading", { name: "No Records Found" })
+      page.getByRole("heading", { name: "No Records Found" }),
     ).toBeVisible();
     await expect(
-      page.getByText("No records were found for your search")
+      page.getByText("No records were found for your search"),
     ).toBeVisible();
     await page
       .getByRole("link", { name: "Revise your patient search" })
@@ -47,13 +47,13 @@ test.describe("querying with the Query Connector", () => {
     const alert = page.locator(".custom-alert");
     await expect(alert).toBeVisible();
     await expect(alert).toHaveText(
-      "This site is for demo purposes only. Please do not enter PII on this website."
+      "This site is for demo purposes only. Please do not enter PII on this website.",
     );
     await expect(
       page.getByRole("heading", {
         name: PAGE_TITLES["search"].title,
         exact: true,
-      })
+      }),
     ).toBeVisible();
 
     await page.getByRole("button", { name: "Fill fields" }).click();
@@ -68,7 +68,7 @@ test.describe("querying with the Query Connector", () => {
 
     await page.getByRole("link", { name: "Select patient" }).click();
     await expect(
-      page.getByRole("heading", { name: "Select a query" })
+      page.getByRole("heading", { name: "Select a query" }),
     ).toBeVisible();
     await page
       .getByTestId("Select")
@@ -82,10 +82,10 @@ test.describe("querying with the Query Connector", () => {
     // dev can have a note to help debug.
     await page.getByRole("button", { name: "Customize Query" }).click();
     await expect(
-      page.getByRole("heading", { name: "Customize Query" })
+      page.getByRole("heading", { name: "Customize Query" }),
     ).toBeVisible();
     await expect(
-      page.getByText("0 labs found, 0 medications found, 0 conditions found.")
+      page.getByText("0 labs found, 0 medications found, 0 conditions found."),
     ).not.toBeVisible();
     await page.getByText("Return to Select query").click();
 
@@ -95,29 +95,29 @@ test.describe("querying with the Query Connector", () => {
     // Make sure we have a results page with a single patient
     // Non-interactive 'div' elements in the table should be located by text
     await expect(
-      page.getByRole("heading", { name: "Patient Record" })
+      page.getByRole("heading", { name: "Patient Record" }),
     ).toBeVisible();
     await expect(page.getByText("Patient Name")).toBeVisible();
     await expect(page.getByText(TEST_PATIENT_NAME)).toBeVisible();
     await expect(page.getByText("Patient Identifiers")).toBeVisible();
     await expect(
       page.getByText(
-        `Medical Record Number: St. Worrywart’s Hospital: ${TEST_PATIENT.MRN}`
-      )
+        `Medical Record Number: St. Worrywart’s Hospital: ${TEST_PATIENT.MRN}`,
+      ),
     ).toBeVisible();
 
     // Check that the info alert is visible and has updated to the correct text
     const alert2 = page.locator(".custom-alert");
     await expect(alert2).toBeVisible();
     await expect(alert2).toHaveText(
-      `${CONTACT_US_DISCLAIMER_TEXT} ${CONTACT_US_DISCLAIMER_EMAIL}`
+      `${CONTACT_US_DISCLAIMER_TEXT} ${CONTACT_US_DISCLAIMER_EMAIL}`,
     );
 
     await expect(
-      page.getByRole("button", { name: "Observations", expanded: true })
+      page.getByRole("button", { name: "Observations", expanded: true }),
     ).toBeVisible();
     await expect(
-      page.getByRole("button", { name: "Medication Requests", expanded: true })
+      page.getByRole("button", { name: "Medication Requests", expanded: true }),
     ).toBeVisible();
 
     // We can also just directly ask the page to find us the number of rows
@@ -127,21 +127,21 @@ test.describe("querying with the Query Connector", () => {
       page
         .getByRole("table")
         .filter({ hasText: "Chlamydia trachomatis DNA" })
-        .getByRole("row")
+        .getByRole("row"),
     ).toHaveCount(14);
     // Encounters
     await expect(
       page
         .getByRole("table")
         .filter({ hasText: "Sexual overexposure" })
-        .getByRole("row")
+        .getByRole("row"),
     ).toHaveCount(5);
     // Conditions + Medication Requests (Reason Code)
     await expect(
       page
         .getByRole("table")
         .filter({ hasText: "Chlamydial infection, unspecified" })
-        .getByRole("row")
+        .getByRole("row"),
     ).toHaveCount(10);
     // Diagnostic Reports
     await expect(
@@ -150,14 +150,14 @@ test.describe("querying with the Query Connector", () => {
         .filter({
           hasText: "Chlamydia trachomatis and Neisseria gonorrhoeae DNA panel",
         })
-        .getByRole("row")
+        .getByRole("row"),
     ).toHaveCount(4);
     // Medication Requests
     await expect(
       page
         .getByRole("table")
         .filter({ hasText: "azithromycin 1000 MG" })
-        .getByRole("row")
+        .getByRole("row"),
     ).toHaveCount(7);
 
     // Now let's use the return to search to go back to a blank form
@@ -166,7 +166,7 @@ test.describe("querying with the Query Connector", () => {
       page.getByRole("heading", {
         name: PAGE_TITLES["search"].title,
         exact: true,
-      })
+      }),
     ).toBeVisible();
   });
 });

--- a/query-connector/src/app/shared/format-service.tsx
+++ b/query-connector/src/app/shared/format-service.tsx
@@ -268,7 +268,7 @@ export async function GetPhoneQueryFormats(phone: string) {
  */
 export const formatValueSetsAsQuerySpec = async (
   queryName: string,
-  valueSets: DibbsValueSet[]
+  valueSets: DibbsValueSet[],
 ) => {
   let secondEncounter: boolean = false;
   if (["cancer", "chlamydia", "gonorrhea", "syphilis"].includes(queryName)) {
@@ -312,7 +312,7 @@ export const formatImmunizationRoute = (immunization: Immunization): string => {
   const initial = immunization.route?.coding?.[0].display ?? "";
   const readable = immunization.route?.coding?.filter(
     (code: Coding) =>
-      code.system === "http://terminology.hl7.org/CodeSystem/v2-0162"
+      code.system === "http://terminology.hl7.org/CodeSystem/v2-0162",
   );
   return readable?.[0].display ?? initial;
 };

--- a/query-connector/src/app/shared/format-service.tsx
+++ b/query-connector/src/app/shared/format-service.tsx
@@ -139,17 +139,19 @@ export function formatIdentifier(identifier: Identifier[]): JSX.Element {
   return (
     <>
       {identifier.map((id) => {
-        let idType = id.type?.coding?.[0].display ?? "";
-        if (idType === "") {
-          idType = id.type?.text ?? "";
-        }
+        let idType = id.type?.coding?.[0]?.display || id.type?.text || "";
+        let idAssigner = id.assigner?.display || "";
+        let idValue = id.value || "";
 
-        return (
-          <div key={id.value}>
-            {" "}
-            {idType}: {id.value} <br />{" "}
-          </div>
-        );
+        let formattedId =
+          idType && idAssigner
+            ? `${idType}: ${idAssigner}: ${idValue}`
+            : idType
+              ? `${idType}: ${idValue}`
+              : idAssigner
+                ? `${idAssigner}: ${idValue}`
+                : idValue;
+        return <div key={idValue}>{formattedId}</div>;
       })}
     </>
   );
@@ -164,22 +166,17 @@ export function formatMRN(identifier: Identifier[]): JSX.Element {
   return (
     <>
       {identifier.map((id) => {
-        let mrnFlag = false;
-        id.type?.coding?.forEach((code) => {
-          if (code.code === "MR") {
-            mrnFlag = true;
-          }
-        });
-        if (mrnFlag) {
-          return (
-            <div key={id.value}>
-              {" "}
-              {id.value} <br />{" "}
-            </div>
-          );
-        }
+        const isMRN = id.type?.coding?.some((code) => code.code === "MR");
+        if (!isMRN) return null;
 
-        return null;
+        const idAssigner = id.assigner?.display || "";
+        const idValue = id.value || "";
+
+        return (
+          <div key={idValue}>
+            {idAssigner ? `${idAssigner}: ${idValue}` : idValue}
+          </div>
+        );
       })}
     </>
   );
@@ -271,7 +268,7 @@ export async function GetPhoneQueryFormats(phone: string) {
  */
 export const formatValueSetsAsQuerySpec = async (
   queryName: string,
-  valueSets: DibbsValueSet[],
+  valueSets: DibbsValueSet[]
 ) => {
   let secondEncounter: boolean = false;
   if (["cancer", "chlamydia", "gonorrhea", "syphilis"].includes(queryName)) {
@@ -315,7 +312,7 @@ export const formatImmunizationRoute = (immunization: Immunization): string => {
   const initial = immunization.route?.coding?.[0].display ?? "";
   const readable = immunization.route?.coding?.filter(
     (code: Coding) =>
-      code.system === "http://terminology.hl7.org/CodeSystem/v2-0162",
+      code.system === "http://terminology.hl7.org/CodeSystem/v2-0162"
   );
   return readable?.[0].display ?? initial;
 };

--- a/query-connector/src/app/tests/assets/GoldenSickPatient.json
+++ b/query-connector/src/app/tests/assets/GoldenSickPatient.json
@@ -82,8 +82,29 @@
               ],
               "text": "Medical Record Number"
             },
+            "assigner": {
+              "display": "St. Worrywart’s Hospital"
+            },
             "system": "http://hospital.smarthealthit.org",
             "value": "8692756"
+          },
+          {
+            "use": "usual",
+            "type": {
+              "coding": [
+                {
+                  "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
+                  "code": "DL",
+                  "display": "Driver's License"
+                }
+              ],
+              "text": "Driver's License"
+            },
+            "assigner": {
+              "display": "Michigan"
+            },
+            "system": "http://dmv.gov",
+            "value": "DL12345"
           }
         ],
         "active": true,

--- a/query-connector/src/app/tests/unit/format-service.test.tsx
+++ b/query-connector/src/app/tests/unit/format-service.test.tsx
@@ -150,6 +150,27 @@ describe("formatMRN", () => {
     const { container } = render(formatMRN(identifiers));
     expect(container).toBeEmptyDOMElement();
   });
+
+  it("should display assigner if available", () => {
+    const identifiers: Identifier[] = [
+      {
+        value: "67890",
+        type: {
+          coding: [
+            {
+              code: "MR",
+            },
+          ],
+        },
+        assigner: {
+          display: "Test Hospital",
+        },
+      },
+    ];
+
+    const { getByText } = render(formatMRN(identifiers));
+    expect(getByText("Test Hospital: 67890")).toBeInTheDocument();
+  });
 });
 
 describe("formatIdentifier", () => {
@@ -179,18 +200,30 @@ describe("formatIdentifier", () => {
           ],
         },
       },
+      {
+        value: "0123456789",
+        type: {
+          coding: [
+            {
+              code: "DL",
+              system: "urn:ietf:rfc:3987",
+              display: "Driver's License Number",
+            },
+          ],
+        },
+        assigner: { display: "Some State" },
+      },
     ];
 
     const { getByText } = render(formatIdentifier(identifiers));
-    // Turn off exact matching because the presence of the id_type breaks
-    // the value across multiple elements
-    expect(getByText("999-99-9999", { exact: false })).toBeInTheDocument();
     expect(
-      getByText("Social Security Number", { exact: false }),
+      getByText("Social Security Number: 999-99-9999")
     ).toBeInTheDocument();
-    expect(getByText("0123456789", { exact: false })).toBeInTheDocument();
     expect(
-      getByText("Internal Reference Identifier", { exact: false }),
+      getByText("Internal Reference Identifier: 0123456789")
+    ).toBeInTheDocument();
+    expect(
+      getByText("Driver's License Number: Some State: 0123456789")
     ).toBeInTheDocument();
   });
 
@@ -219,7 +252,7 @@ describe("formatIdentifier", () => {
     ];
 
     render(formatIdentifier(identifiers));
-    expect(screen.getByText(": 999-99-9999")).toBeInTheDocument();
+    expect(screen.getByText("999-99-9999")).toBeInTheDocument();
   });
 
   it("should handle an empty identifier array without breaking", () => {

--- a/query-connector/src/app/tests/unit/format-service.test.tsx
+++ b/query-connector/src/app/tests/unit/format-service.test.tsx
@@ -201,7 +201,7 @@ describe("formatIdentifier", () => {
         },
       },
       {
-        value: "0123456789",
+        value: "456",
         type: {
           coding: [
             {
@@ -223,7 +223,7 @@ describe("formatIdentifier", () => {
       getByText("Internal Reference Identifier: 0123456789")
     ).toBeInTheDocument();
     expect(
-      getByText("Driver's License Number: Some State: 0123456789")
+      getByText("Driver's License Number: Some State: 456")
     ).toBeInTheDocument();
   });
 

--- a/query-connector/src/app/tests/unit/format-service.test.tsx
+++ b/query-connector/src/app/tests/unit/format-service.test.tsx
@@ -217,13 +217,13 @@ describe("formatIdentifier", () => {
 
     const { getByText } = render(formatIdentifier(identifiers));
     expect(
-      getByText("Social Security Number: 999-99-9999")
+      getByText("Social Security Number: 999-99-9999"),
     ).toBeInTheDocument();
     expect(
-      getByText("Internal Reference Identifier: 0123456789")
+      getByText("Internal Reference Identifier: 0123456789"),
     ).toBeInTheDocument();
     expect(
-      getByText("Driver's License Number: Some State: 456")
+      getByText("Driver's License Number: Some State: 456"),
     ).toBeInTheDocument();
   });
 


### PR DESCRIPTION
# PULL REQUEST

## Summary

This PR updates the formatters for MRN and Identifiers more broadly to include `assigner`, where applicable. That is, if you have an MRN with an assigner, e.g., a hospital name, it will now be displayed in the Patient Search results page and the final results page. Previously, MRN would just display the number such as `1234` but now it will display `St. Worrywart’s Medical Center: 1234` under MRN in the patient search result page and `Medical Record Number: St. Worrywart’s Medical Center: 1234` under Patient Identifiers on the results page.

I also updated Hyper Unlucky's data to include an assigner and a Driver's License to show what happens when you have multiple identifiers.

![image](https://github.com/user-attachments/assets/9ce71f51-0ed0-46b9-bd49-0f74969ef045)

![image](https://github.com/user-attachments/assets/107f3a33-0fb2-40b9-b69e-3e1b2e92cd57)

## Related Issue

Fixes #296 

## Additional Information
I intentionally did not include a new search field for the Assigner. We have another ticket in the backlog that would switch to using `$match` for returning patients which would render the search field irrelevant. 


## Checklist

- [x] Descriptive Pull Request title
- [x] Link to relevant issues
- [x] Provide necessary context for design reviewers
- [x] Update documentation

