### PR TITLE
Remove JAVA_OPTS_APPEND from docker compose

### DIFF
--- a/query-connector/docker-compose-dev.yaml
+++ b/query-connector/docker-compose-dev.yaml
@@ -57,9 +57,6 @@ services:
       - 8081:8080
     volumes:
       - ./keycloak:/opt/keycloak/data/import
-    environment:
-      # For M4: https://github.com/keycloak/keycloak/issues/36008#issuecomment-2564871619
-      - JAVA_OPTS_APPEND=-XX:UseSVE=0
     restart: always
     command:
       - start-dev

--- a/query-connector/docker-compose.yaml
+++ b/query-connector/docker-compose.yaml
@@ -19,9 +19,6 @@ services:
     build:
       context: .
       dockerfile: Dockerfile.keycloak
-    environment:
-      # For M4: https://github.com/keycloak/keycloak/issues/36008#issuecomment-2564871619
-      - JAVA_OPTS_APPEND=-XX:UseSVE=0
     ports:
       - 8080:8080
     restart: always


### PR DESCRIPTION
# PULL REQUEST

## Summary

Removing arguments from docker-compose.yml that stop keycloak from starting up:

```
keycloak-1         | Appending additional Java properties to JAVA_OPTS
keycloak-1         | Unrecognized VM option 'UseSVE=0'
keycloak-1         | Error: Could not create the Java Virtual Machine.
keycloak-1         | Error: A fatal exception has occurred. Program will exit.
keycloak-1 exited with code 0
```

I _think_ the `select-realm.sh` assignment of `JAVA_OPTS_APPEND` if m4 should be sufficient, but I'm not entirely sure.

## Related Issue

Fixes #

## Additional Information

Anything else the review team should know?

## Checklist

- [ ] Descriptive Pull Request title
- [ ] Link to relevant issues
- [ ] Provide necessary context for design reviewers
- [ ] Update documentation

