### PR TITLE
redirect user to `/query` if logged in

### DIFF
--- a/query-connector/src/app/ui/components/header/header.tsx
+++ b/query-connector/src/app/ui/components/header/header.tsx
@@ -59,7 +59,7 @@ const HeaderComponent: React.FC<{ authDisabled: boolean }> = ({
     setShowMenu(!showMenu);
   };
   // const isProduction = process.env.NODE_ENV === "production";
-  const landingPage = "/";
+  const landingPage = authDisabled || isLoggedIn ? "/query" : "/";
 
   return (
     <div className={styles.headerContainer}>

--- a/query-connector/src/app/ui/components/header/header.tsx
+++ b/query-connector/src/app/ui/components/header/header.tsx
@@ -2,7 +2,7 @@
 
 import React, { useEffect, useRef, useState } from "react";
 import { usePathname } from "next/navigation";
-import { useSession, signIn } from "next-auth/react";
+import { useSession, signIn, signOut } from "next-auth/react";
 import { Button, Icon } from "@trussworks/react-uswds";
 import styles from "./header.module.scss";
 import { metadata } from "@/app/shared/constants";
@@ -43,7 +43,6 @@ const HeaderComponent: React.FC<{ authDisabled: boolean }> = ({
 
   const path = usePathname();
 
-  // To readd this once we fix sign in
   const { data: session } = useSession();
   const isLoggedIn = session?.user != null;
 
@@ -52,6 +51,13 @@ const HeaderComponent: React.FC<{ authDisabled: boolean }> = ({
       router.push(`/query`);
     } else {
       signIn("keycloak", { redirectTo: "/query" });
+    }
+  };
+  const handleSignOut = async () => {
+    if (authDisabled) {
+      router.push(`/`);
+    } else {
+      await signOut({ redirectTo: "/" });
     }
   };
 
@@ -145,9 +151,15 @@ const HeaderComponent: React.FC<{ authDisabled: boolean }> = ({
                 </Link>
               </li>
               <li className={styles.subMenuItem}>
-                <Link className={styles.menuItem} href={landingPage}>
+                <button
+                  className={classNames(
+                    styles.menuItem,
+                    "usa-button--unstyled",
+                  )}
+                  onClick={async () => await handleSignOut()}
+                >
                   Log out
-                </Link>
+                </button>
               </li>
             </>
             {/* )} */}


### PR DESCRIPTION
# PULL REQUEST

## Summary
Adds a check to redirect users who click on the home Query Connector logo to `/query` rather than the landing page if they're logged in. 

## Related Issue

Fixes #303 

- [x] Descriptive Pull Request title
- [x] Link to relevant issues
- [x] Provide necessary context for design reviewers

