### PR TITLE
query building tweaks

### DIFF
--- a/query-connector/src/app/ui/components/page/page.tsx
+++ b/query-connector/src/app/ui/components/page/page.tsx
@@ -40,14 +40,16 @@ const Page: React.FC<PageProps> = ({ children, showSiteAlert }) => {
   const templateString = `<div class="bar ${
     showSiteAlert ? styles.progressBar__alert : styles.progressBar
   }"role="bar"></div>`;
+
+  const toastOptions = ctx?.toastConfig ?? toastDefault;
   return (
     <>
       {showSiteAlert && <SiteAlert page={ctx?.currentPage} />}
       <div className={styles.pageContainer}>
         <ToastContainer
-          position={toastDefault.position}
-          stacked={toastDefault.stacked}
-          hideProgressBar={toastDefault.hideProgressBar}
+          position={toastOptions.position}
+          stacked={toastOptions.stacked}
+          hideProgressBar={toastOptions.hideProgressBar}
           icon={false}
         />
         <ProgressBar

--- a/query-connector/src/app/ui/designSystem/drawer/Drawer.tsx
+++ b/query-connector/src/app/ui/designSystem/drawer/Drawer.tsx
@@ -75,7 +75,13 @@ const Drawer: React.FC<DrawerProps> = ({
             >
               <Icon.Close size={3} aria-label="X icon indicating closure" />
             </button>
-            <h2 data-testid={`drawer-title`} className={`margin-0 padding-0`}>
+            <h2
+              data-testid={`drawer-title`}
+              className={classNames(
+                "margin-0",
+                subtitle ? "padding-bottom-0" : "padding-bottom-2",
+              )}
+            >
               {title}
             </h2>
             {subtitle ? <h3 className={styles.subtitle}>{subtitle}</h3> : <></>}

--- a/query-connector/src/app/ui/designSystem/drawer/drawer.module.scss
+++ b/query-connector/src/app/ui/designSystem/drawer/drawer.module.scss
@@ -7,6 +7,7 @@ $drawerWidth: 30%;
   top: 0;
   right: -35rem;
   width: $drawerWidth;
+  max-width: 35rem;
   height: 100%;
   padding: 0rem;
   display: flex;
@@ -21,7 +22,7 @@ $drawerWidth: 30%;
   overflow: scroll;
   max-height: 100%;
 
-  input[type="search"]{
+  input[type="search"] {
     display: flex;
     padding: 0.75rem 0.75rem 0.75rem 2.25rem !important;
     align-items: center;


### PR DESCRIPTION
noticed a couple issues in the query building flow during demo prep

- Tweaked a toast container option configuration so that any option overrides work correctly
- Gave the drawer a max width to match the design intention on wider screens
- Tweaking a padding property on the drawer title in cases where we don't have subtitles

Drawer width:
<img width="722" alt="Screenshot 2025-02-12 at 12 38 04 PM" src="https://github.com/user-attachments/assets/0c8810d5-6c7c-4df8-a09b-34a0ffbb7ade" />

Before
![Screenshot 2025-02-12 at 1 12 37 PM](https://github.com/user-attachments/assets/81bdefe5-6009-4af9-a1cd-bb552033cb03)

After
![Screenshot 2025-02-12 at 1 12 18 PM](https://github.com/user-attachments/assets/19af674f-a200-4932-8949-9edbba9bccec)
![Screenshot 2025-02-12 at 1 13 35 PM](https://github.com/user-attachments/assets/37923a64-08a4-47d0-96dc-15fd06ecd8e0)
