### PR TITLE
turn off next auth debug mode

### DIFF
--- a/query-connector/src/auth.ts
+++ b/query-connector/src/auth.ts
@@ -87,5 +87,8 @@ export const { handlers, signIn, signOut, auth } = NextAuth({
       return session;
     },
   },
+  // WARNING: Turning this on will log out session info (which in all likelihood)
+  // will contain PII into the system logs whenever users log in/out. Proceed
+  // with caution
   debug: false,
 });

--- a/query-connector/src/auth.ts
+++ b/query-connector/src/auth.ts
@@ -87,5 +87,5 @@ export const { handlers, signIn, signOut, auth } = NextAuth({
       return session;
     },
   },
-  debug: true,
+  debug: false,
 });


### PR DESCRIPTION
# PULL REQUEST

## Summary
Noticed that the debug logs for Next Auth will log out session information that has PII  into the system logs. Turning them off before we accidentally ship something that will cause an incident.

![Screenshot 2025-02-13 at 2 41 04 PM](https://github.com/user-attachments/assets/c743dd39-2bb2-4f64-9b0c-ee5f22cfb852)

## Additional Information
Happy also to pull this into an env var if we want, but haven't heard that we've really used this so electing to be more conservative in this case

## Checklist
- [x] Descriptive Pull Request title

