### PR TITLE
Initialize UserGroup insert/update/delete work

### DIFF
--- a/query-connector/jest.config.js
+++ b/query-connector/jest.config.js
@@ -14,7 +14,14 @@ const customJestConfig = {
   setupFilesAfterEnv: ["<rootDir>/jest.setup.ts"],
   testEnvironment: "jest-fixed-jsdom",
   modulePathIgnorePatterns: ["<rootDir>/.next/"],
+  moduleNameMapper: { "^@/(.*)$": "<rootDir>/src/$1" },
 };
 
 // createJestConfig is exported this way to ensure that next/jest can load the Next.js config which is async
-module.exports = createJestConfig(customJestConfig);
+/**
+ * Creates and exports Jest configuration.
+ * @returns The Jest configuration object.
+ */
+module.exports = async () => ({
+  ...(await createJestConfig(customJestConfig)()),
+});

--- a/query-connector/package-lock.json
+++ b/query-connector/package-lock.json
@@ -1106,9 +1106,9 @@
       }
     },
     "node_modules/@babel/compat-data": {
-      "version": "7.26.2",
-      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.26.2.tgz",
-      "integrity": "sha512-Z0WgzSEa+aUcdiJuCIqgujCshpMWgUpgOxXotrYPSA53hA3qopNaqcJpyr0hVb1FeWdnqFA35/fUtXgBK8srQg==",
+      "version": "7.26.8",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.26.8.tgz",
+      "integrity": "sha512-oH5UPLMWR3L2wEFLnFJ1TZXqHufiTKAiLfqw5zkhS4dKXLJ10yVztfil/twG8EDTA4F/tvVNw9nOl4ZMslB8rQ==",
       "dev": true,
       "engines": {
         "node": ">=6.9.0"
@@ -1145,13 +1145,13 @@
       }
     },
     "node_modules/@babel/generator": {
-      "version": "7.26.2",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.26.2.tgz",
-      "integrity": "sha512-zevQbhbau95nkoxSq3f/DC/SC+EEOUZd3DYqfSkMhY2/wfSeaHV1Ew4vk8e+x8lja31IbyuUa2uQ3JONqKbysw==",
+      "version": "7.26.9",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.26.9.tgz",
+      "integrity": "sha512-kEWdzjOAUMW4hAyrzJ0ZaTOu9OmpyDIQicIh0zg0EEcEkYXZb2TjtBhnHi2ViX7PKwZqF4xwqfAm299/QMP3lg==",
       "dev": true,
       "dependencies": {
-        "@babel/parser": "^7.26.2",
-        "@babel/types": "^7.26.0",
+        "@babel/parser": "^7.26.9",
+        "@babel/types": "^7.26.9",
         "@jridgewell/gen-mapping": "^0.3.5",
         "@jridgewell/trace-mapping": "^0.3.25",
         "jsesc": "^3.0.2"
@@ -1161,12 +1161,12 @@
       }
     },
     "node_modules/@babel/helper-compilation-targets": {
-      "version": "7.25.9",
-      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.25.9.tgz",
-      "integrity": "sha512-j9Db8Suy6yV/VHa4qzrj9yZfZxhLWQdVnRlXxmKLYlhWUVB1sB2G5sxuWYXk/whHD9iW76PmNzxZ4UCnTQTVEQ==",
+      "version": "7.26.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.26.5.tgz",
+      "integrity": "sha512-IXuyn5EkouFJscIDuFF5EsiSolseme1s0CZB+QxVugqJLYmKdxI1VfIBOst0SUu4rnk2Z7kqTwmoO1lp3HIfnA==",
       "dev": true,
       "dependencies": {
-        "@babel/compat-data": "^7.25.9",
+        "@babel/compat-data": "^7.26.5",
         "@babel/helper-validator-option": "^7.25.9",
         "browserslist": "^4.24.0",
         "lru-cache": "^5.1.1",
@@ -1207,9 +1207,9 @@
       }
     },
     "node_modules/@babel/helper-plugin-utils": {
-      "version": "7.25.9",
-      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.25.9.tgz",
-      "integrity": "sha512-kSMlyUVdWe25rEsRGviIgOWnoT/nfABVWlqt9N19/dIPWViAOW2s9wznP5tURbs/IDuNk4gPy3YdYRgH3uxhBw==",
+      "version": "7.26.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.26.5.tgz",
+      "integrity": "sha512-RS+jZcRdZdRFzMyr+wcsaqOmld1/EqTghfaBGQQd/WnRdzdlvSZ//kF7U8VQTxf1ynZ4cjUcYgjVGx13ewNPMg==",
       "dev": true,
       "engines": {
         "node": ">=6.9.0"
@@ -1256,12 +1256,12 @@
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.26.2",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.26.2.tgz",
-      "integrity": "sha512-DWMCZH9WA4Maitz2q21SRKHo9QXZxkDsbNZoVD62gusNtNBBqDg9i7uOhASfTfIGNzW+O+r7+jAlM8dwphcJKQ==",
+      "version": "7.26.9",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.26.9.tgz",
+      "integrity": "sha512-81NWa1njQblgZbQHxWHpxxCzNsa3ZwvFqpUg7P+NNUU6f3UU2jBEg4OlF/J6rl8+PQGh1q6/zWScd001YwcA5A==",
       "dev": true,
       "dependencies": {
-        "@babel/types": "^7.26.0"
+        "@babel/types": "^7.26.9"
       },
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -1505,30 +1505,30 @@
       }
     },
     "node_modules/@babel/template": {
-      "version": "7.25.9",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.25.9.tgz",
-      "integrity": "sha512-9DGttpmPvIxBb/2uwpVo3dqJ+O6RooAFOS+lB+xDqoE2PVCE8nfoHMdZLpfCQRLwvohzXISPZcgxt80xLfsuwg==",
+      "version": "7.26.9",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.26.9.tgz",
+      "integrity": "sha512-qyRplbeIpNZhmzOysF/wFMuP9sctmh2cFzRAZOn1YapxBsE1i9bJIY586R/WBLfLcmcBlM8ROBiQURnnNy+zfA==",
       "dev": true,
       "dependencies": {
-        "@babel/code-frame": "^7.25.9",
-        "@babel/parser": "^7.25.9",
-        "@babel/types": "^7.25.9"
+        "@babel/code-frame": "^7.26.2",
+        "@babel/parser": "^7.26.9",
+        "@babel/types": "^7.26.9"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.25.9",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.25.9.tgz",
-      "integrity": "sha512-ZCuvfwOwlz/bawvAuvcj8rrithP2/N55Tzz342AkTvq4qaWbGfmCk/tKhNaV2cthijKrPAA8SRJV5WWe7IBMJw==",
+      "version": "7.26.9",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.26.9.tgz",
+      "integrity": "sha512-ZYW7L+pL8ahU5fXmNbPF+iZFHCv5scFak7MZ9bwaRPLUhHh7QQEMjZUg0HevihoqCM5iSYHN61EyCoZvqC+bxg==",
       "dev": true,
       "dependencies": {
-        "@babel/code-frame": "^7.25.9",
-        "@babel/generator": "^7.25.9",
-        "@babel/parser": "^7.25.9",
-        "@babel/template": "^7.25.9",
-        "@babel/types": "^7.25.9",
+        "@babel/code-frame": "^7.26.2",
+        "@babel/generator": "^7.26.9",
+        "@babel/parser": "^7.26.9",
+        "@babel/template": "^7.26.9",
+        "@babel/types": "^7.26.9",
         "debug": "^4.3.1",
         "globals": "^11.1.0"
       },
@@ -1537,9 +1537,9 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.26.0",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.26.0.tgz",
-      "integrity": "sha512-Z/yiTPj+lDVnF7lWeKCIJzaIkI0vYO87dMpZ4bg4TDrFe4XXLFWL1TbXU27gBP3QccxV9mZICCrnjnYlJjXHOA==",
+      "version": "7.26.9",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.26.9.tgz",
+      "integrity": "sha512-Y3IR1cRnOxOCDvMmNiym7XpXQ93iGDDPHx+Zj+NM+rg0fBaShfQLkg+hKPaZCEvg5N/LeCo4+Rj/i3FuJsIQaw==",
       "dev": true,
       "dependencies": {
         "@babel/helper-string-parser": "^7.25.9",
@@ -6149,9 +6149,9 @@
       }
     },
     "node_modules/browserslist": {
-      "version": "4.24.2",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.24.2.tgz",
-      "integrity": "sha512-ZIc+Q62revdMcqC6aChtW4jz3My3klmCO1fEmINZY/8J3EpBg5/A/D0AKmBveUh6pgoeycoMkVMko84tuYS+Gg==",
+      "version": "4.24.4",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.24.4.tgz",
+      "integrity": "sha512-KDi1Ny1gSePi1vm0q4oxSF8b4DR44GF4BbmS2YdhPLOEqd8pDviZOGH/GsmRwoWJ2+5Lr085X7naowMwKHDG1A==",
       "dev": true,
       "funding": [
         {
@@ -6168,9 +6168,9 @@
         }
       ],
       "dependencies": {
-        "caniuse-lite": "^1.0.30001669",
-        "electron-to-chromium": "^1.5.41",
-        "node-releases": "^2.0.18",
+        "caniuse-lite": "^1.0.30001688",
+        "electron-to-chromium": "^1.5.73",
+        "node-releases": "^2.0.19",
         "update-browserslist-db": "^1.1.1"
       },
       "bin": {
@@ -6296,9 +6296,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001683",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001683.tgz",
-      "integrity": "sha512-iqmNnThZ0n70mNwvxpEC2nBJ037ZHZUoBI5Gorh1Mw6IlEAZujEoU1tXA628iZfzm7R9FvFzxbfdgml82a3k8Q==",
+      "version": "1.0.30001700",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001700.tgz",
+      "integrity": "sha512-2S6XIXwaE7K7erT8dY+kLQcpa5ms63XlRkMkReXjle+kf6c5g38vyMl+Z5y8dSxOFDhcFe+nxnn261PLxBSQsQ==",
       "funding": [
         {
           "type": "opencollective",
@@ -7370,9 +7370,9 @@
       "dev": true
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.64",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.64.tgz",
-      "integrity": "sha512-IXEuxU+5ClW2IGEYFC2T7szbyVgehupCWQe5GNh+H065CD6U6IFN0s4KeAMFGNmQolRU4IV7zGBWSYMmZ8uuqQ==",
+      "version": "1.5.102",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.102.tgz",
+      "integrity": "sha512-eHhqaja8tE/FNpIiBrvBjFV/SSKpyWHLvxuR9dPTdo+3V9ppdLmFB7ZZQ98qNovcngPLYIz0oOBF9P0FfZef5Q==",
       "dev": true
     },
     "node_modules/element-closest": {
@@ -11519,9 +11519,9 @@
       "dev": true
     },
     "node_modules/node-releases": {
-      "version": "2.0.18",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.18.tgz",
-      "integrity": "sha512-d9VeXT4SJ7ZeOqGX6R5EM022wpL+eWPooLI+5UpWn2jCT1aosUQEhQP214x33Wkwx3JQMvIm+tIoVOdodFS40g==",
+      "version": "2.0.19",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.19.tgz",
+      "integrity": "sha512-xxOWJsBKtzAq7DY0J+DTzuz58K8e7sJbdgwkbMWQe8UYB6ekmsQ45q0M/tJDsGaZmbC+l7n57UV8Hl5tHxO9uw==",
       "dev": true
     },
     "node_modules/normalize-path": {

--- a/query-connector/src/app/tests/integration/user_management.test.ts
+++ b/query-connector/src/app/tests/integration/user_management.test.ts
@@ -1,0 +1,177 @@
+import {
+  createUserGroup,
+  getUserGroups,
+  updateUserGroup,
+  deleteUserGroup,
+  addUserIfNotExists,
+  updateUserRole,
+  getUsers,
+  getUserRole,
+} from "@/app/backend/user-management";
+import { getDbClient } from "@/app/backend/dbClient";
+import { auth } from "@/auth";
+import { RoleTypeValues } from "@/app/models/entities/user-management";
+
+const dbClient = getDbClient();
+jest.mock("@/auth", () => ({
+  auth: jest.fn(),
+}));
+
+jest.mock("@/app/utils/auth", () => {
+  return {
+    superAdminAccessCheck: jest.fn(() => Promise.resolve(true)),
+    adminAccessCheck: jest.fn(() => Promise.resolve(true)),
+  };
+});
+
+const TEST_USER = {
+  id: "13e1efb2-5889-4157-8f34-78d7f02dbf84",
+  username: "Ima User",
+  email: "ima.user@example.com",
+  firstName: "Ima",
+  lastName: "User",
+};
+
+(auth as jest.Mock).mockResolvedValue(TEST_USER);
+
+describe("User Management Integration Tests", () => {
+  let createdUserId: string;
+
+  beforeAll(async () => {
+    await dbClient.query("BEGIN");
+  });
+
+  afterAll(async () => {
+    await dbClient.query("ROLLBACK");
+  });
+
+  /**
+   * Tests adding a new user if they do not already exist.
+   */
+  test("should add a user if they do not exist", async () => {
+    const result = await addUserIfNotExists(TEST_USER);
+
+    expect(result).toHaveProperty("id");
+    expect(result).toHaveProperty("username", TEST_USER.username);
+    expect(result).toHaveProperty("qc_role", RoleTypeValues.Standard);
+    createdUserId = result.id;
+  });
+
+  /**
+   * Tests updating the role of an existing user.
+   */
+  test("should update a user's role", async () => {
+    const result = await updateUserRole(
+      createdUserId,
+      RoleTypeValues.SuperAdmin,
+    );
+    expect(result.items).not.toBeNull();
+    expect(result.items![0]).toHaveProperty(
+      "qc_role",
+      RoleTypeValues.SuperAdmin,
+    );
+  });
+
+  /**
+   * Tests retrieving all registered users.
+   */
+  test("should retrieve all users", async () => {
+    const result = await getUsers();
+    expect(result.totalItems).toBeGreaterThan(0);
+  });
+
+  /**
+   * Tests retrieving a user's role by username.
+   */
+  test("should retrieve user role by username", async () => {
+    const result = await getUserRole(TEST_USER.username);
+    expect(result).toBe(RoleTypeValues.SuperAdmin);
+  });
+});
+
+describe("User Group Integration Tests", () => {
+  let testGroupId: string;
+
+  beforeAll(async () => {
+    await dbClient.query("BEGIN");
+  });
+
+  afterAll(async () => {
+    await dbClient.query("ROLLBACK");
+  });
+
+  /**
+   * Tests creating a new user group.
+   */
+  test("should create a new user group", async () => {
+    const groupName = "Test Group";
+    const result = await createUserGroup(groupName);
+
+    expect(result).toHaveProperty("id");
+    expect(result).toHaveProperty("name", groupName);
+    expect(result).toHaveProperty("memberSize", 0);
+    expect(result).toHaveProperty("querySize", 0);
+
+    if (typeof result === "string") {
+      throw new Error(`Failed to create test group: ${result}`);
+    }
+
+    expect(result).toHaveProperty("id");
+    expect(result).toHaveProperty("name", groupName);
+    testGroupId = result.id;
+  });
+
+  /**
+   * Tests preventing duplicate user group creation.
+   */
+  test("should not create duplicate user group", async () => {
+    const result = await createUserGroup("Test Group");
+    expect(typeof result).toBe("string"); // It should return a string error
+    expect(result).toBe(`Group 'Test Group' already exists.`);
+  });
+
+  /**
+   * Tests retrieving all user groups.
+   */
+  test("should retrieve user groups", async () => {
+    const result = await getUserGroups();
+    expect(result.items).not.toBeNull();
+    expect(result.items!.length).toBeGreaterThanOrEqual(1);
+  });
+
+  /**
+   * Tests updating a user group's name.
+   */
+  test("should update a user group name", async () => {
+    const result = await updateUserGroup(testGroupId, "Updated Group Name");
+    expect(result).toHaveProperty("id", testGroupId);
+    expect(result).toHaveProperty("name", "Updated Group Name");
+  });
+
+  /**
+   * Tests deleting a user group.
+   */
+  test("should delete a user group", async () => {
+    const result = await deleteUserGroup(testGroupId);
+    expect(result).toHaveProperty("id", testGroupId);
+  });
+
+  const NON_EXISTENT_UUID = "00000000-0000-0000-0000-000000000000";
+  /**
+   * Tests preventing updates to a non-existent user group.
+   */
+  test("should not update a non-existent user group", async () => {
+    await expect(
+      updateUserGroup(NON_EXISTENT_UUID, "New Name"),
+    ).rejects.toThrow(`User group with ID '${NON_EXISTENT_UUID}' not found.`);
+  });
+
+  /**
+   * Tests preventing deletion of a non-existent user group.
+   */
+  test("should not delete a non-existent user group", async () => {
+    await expect(deleteUserGroup(NON_EXISTENT_UUID)).rejects.toThrow(
+      `User group with ID '${NON_EXISTENT_UUID}' not found.`,
+    );
+  });
+});

--- a/query-connector/src/app/utils/auth.ts
+++ b/query-connector/src/app/utils/auth.ts
@@ -47,3 +47,23 @@ export async function superAdminAccessCheck(): Promise<boolean> {
 
   return false;
 }
+
+/**
+ * Performs admin role check
+ * @returns true if there is an session and the user has an admin or super-admin role
+ */
+export async function adminAccessCheck(): Promise<boolean> {
+  const user = await getLoggedInUser();
+
+  if (
+    isAuthDisabled() ||
+    (user &&
+      [RoleTypeValues.Admin, RoleTypeValues.SuperAdmin].includes(
+        (await getUserRole(user.username as string)) as RoleTypeValues,
+      ))
+  ) {
+    return true;
+  }
+
+  return false;
+}

--- a/query-connector/src/app/utils/auth.ts
+++ b/query-connector/src/app/utils/auth.ts
@@ -25,7 +25,6 @@ export function isAuthDisabled(): boolean {
  */
 export async function getLoggedInUser(): Promise<User | undefined> {
   const session = await auth();
-
   return session ? session.user : undefined;
 }
 


### PR DESCRIPTION
# PULL REQUEST

## Summary

This adds the initial work to get usergroup data, create new entries, update entries, and delete entries. This leverages the existing `UserGroup` work.

Future tickets will address creating/updating/deleting the connective tables for the respective userGroup -> users and userGroup -> queries. 

Per the ERD write-up, it sounds as though admins will also need to have permission to do update user groups (https://docs.google.com/document/d/1b319fzLJ1vJFfdyokelbBR7GyiSpQBe_dBICBseVRRU/edit?tab=t.0), so I just added a new function to do that, as well. 

## Related Issue

Fixes #371 

## Additional Information

Anything else the review team should know?


## Checklist

- [ ] Descriptive Pull Request title
- [ ] Link to relevant issues
- [ ] Provide necessary context for design reviewers
- [ ] Update documentation

