### PR TITLE
add loading skeletons to query execution flow

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -17,5 +17,5 @@ Anything else the review team should know?
 - [ ] Descriptive Pull Request title
 - [ ] Link to relevant issues
 - [ ] Provide necessary context for design reviewers
+- [ ] Ensure test coverage is above agreed upon threshold
 - [ ] Update documentation
-

--- a/query-connector/.gitignore
+++ b/query-connector/.gitignore
@@ -8,3 +8,4 @@ certificates
 /playwright/.cache/
 /coverage
 report.json
+.tool-versions

--- a/query-connector/package-lock.json
+++ b/query-connector/package-lock.json
@@ -30,6 +30,7 @@
         "react": "^18",
         "react-dom": "^18",
         "react-highlight-words": "^0.21.0",
+        "react-loading-skeleton": "^3.5.0",
         "react-toastify": "^10.0.5",
         "sharp": "^0.33.5"
       },
@@ -61,7 +62,7 @@
         "eslint-plugin-jsdoc": "^48.2.3",
         "eslint-plugin-jsx-a11y": "^6.10.2",
         "eslint-plugin-unused-imports": "^4.1.4",
-        "focus-trap-react": "^10.3.0",
+        "focus-trap-react": "^10.3.1",
         "jest": "^29.7.0",
         "jest-axe": "^8.0.0",
         "jest-environment-jsdom": "^29.7.0",
@@ -8316,9 +8317,10 @@
       "dev": true
     },
     "node_modules/focus-trap": {
-      "version": "7.6.2",
-      "resolved": "https://registry.npmjs.org/focus-trap/-/focus-trap-7.6.2.tgz",
-      "integrity": "sha512-9FhUxK1hVju2+AiQIDJ5Dd//9R2n2RAfJ0qfhF4IHGHgcoEUTMpbTeG/zbEuwaiYXfuAH6XE0/aCyxDdRM+W5w==",
+      "version": "7.6.4",
+      "resolved": "https://registry.npmjs.org/focus-trap/-/focus-trap-7.6.4.tgz",
+      "integrity": "sha512-xx560wGBk7seZ6y933idtjJQc1l+ck+pI3sKvhKozdBV1dRZoKhkW5xoCaFv9tQiX5RH1xfSxjuNu6g+lmN/gw==",
+      "license": "MIT",
       "dependencies": {
         "tabbable": "^6.2.0"
       }
@@ -8327,6 +8329,7 @@
       "version": "10.3.1",
       "resolved": "https://registry.npmjs.org/focus-trap-react/-/focus-trap-react-10.3.1.tgz",
       "integrity": "sha512-PN4Ya9xf9nyj/Nd9VxBNMuD7IrlRbmaG6POAQ8VLqgtc6IY/Ln1tYakow+UIq4fihYYYFM70/2oyidE6bbiPgw==",
+      "license": "MIT",
       "dependencies": {
         "focus-trap": "^7.6.1",
         "tabbable": "^6.2.0"
@@ -12279,6 +12282,15 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
     },
+    "node_modules/react-loading-skeleton": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/react-loading-skeleton/-/react-loading-skeleton-3.5.0.tgz",
+      "integrity": "sha512-gxxSyLbrEAdXTKgfbpBEFZCO/P153DnqSCQau2+o6lNy1jgMRr2MmRmOzMmyrwSaSYLRB8g7b0waYPmUjz7IhQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      }
+    },
     "node_modules/react-property": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/react-property/-/react-property-2.0.2.tgz",
@@ -13452,7 +13464,8 @@
     "node_modules/tabbable": {
       "version": "6.2.0",
       "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-6.2.0.tgz",
-      "integrity": "sha512-Cat63mxsVJlzYvN51JmVXIgNoUokrIaT2zLclCXjRd8boZ0004U4KCs/sToJ75C6sdlByWxpYnb5Boif1VSFew=="
+      "integrity": "sha512-Cat63mxsVJlzYvN51JmVXIgNoUokrIaT2zLclCXjRd8boZ0004U4KCs/sToJ75C6sdlByWxpYnb5Boif1VSFew==",
+      "license": "MIT"
     },
     "node_modules/tapable": {
       "version": "2.2.1",

--- a/query-connector/package.json
+++ b/query-connector/package.json
@@ -45,6 +45,7 @@
     "react": "^18",
     "react-dom": "^18",
     "react-highlight-words": "^0.21.0",
+    "react-loading-skeleton": "^3.5.0",
     "react-toastify": "^10.0.5",
     "sharp": "^0.33.5"
   },
@@ -76,7 +77,7 @@
     "eslint-plugin-jsdoc": "^48.2.3",
     "eslint-plugin-jsx-a11y": "^6.10.2",
     "eslint-plugin-unused-imports": "^4.1.4",
-    "focus-trap-react": "^10.3.0",
+    "focus-trap-react": "^10.3.1",
     "jest": "^29.7.0",
     "jest-axe": "^8.0.0",
     "jest-environment-jsdom": "^29.7.0",

--- a/query-connector/src/app/(pages)/query/components/PatientSearchResults.tsx
+++ b/query-connector/src/app/(pages)/query/components/PatientSearchResults.tsx
@@ -27,6 +27,7 @@ export interface PatientSearchResultsProps {
  * @param root0.setMode - Redirect function to handle results view routing
  * @param root0.setPatientForQueryResponse - Callback function to update the
  * patient being searched for
+ * @param root0.loading
  * @returns - The PatientSearchResults component.
  */
 const PatientSearchResults: React.FC<PatientSearchResultsProps> = ({

--- a/query-connector/src/app/(pages)/query/components/PatientSearchResults.tsx
+++ b/query-connector/src/app/(pages)/query/components/PatientSearchResults.tsx
@@ -27,7 +27,7 @@ export interface PatientSearchResultsProps {
  * @param root0.setMode - Redirect function to handle results view routing
  * @param root0.setPatientForQueryResponse - Callback function to update the
  * patient being searched for
- * @param root0.loading
+ * @param root0.loading - whether the component is in a loading state
  * @returns - The PatientSearchResults component.
  */
 const PatientSearchResults: React.FC<PatientSearchResultsProps> = ({

--- a/query-connector/src/app/(pages)/query/components/PatientSearchResults.tsx
+++ b/query-connector/src/app/(pages)/query/components/PatientSearchResults.tsx
@@ -6,6 +6,7 @@ import Backlink from "../../../ui/designSystem/backLink/Backlink";
 import PatientSearchResultsTable from "./patientSearchResults/PatientSearchResultsTable";
 import NoPatientsFound from "./patientSearchResults/NoPatientsFound";
 import { RETURN_LABEL } from "@/app/(pages)/query/components/stepIndicator/StepIndicator";
+import TitleBox from "./stepIndicator/TitleBox";
 
 /**
  * The props for the PatientSearchResults component.
@@ -15,6 +16,7 @@ export interface PatientSearchResultsProps {
   goBack: () => void;
   setMode: (mode: Mode) => void;
   setPatientForQueryResponse: (patient: Patient) => void;
+  loading: boolean;
 }
 
 /**
@@ -32,6 +34,7 @@ const PatientSearchResults: React.FC<PatientSearchResultsProps> = ({
   goBack,
   setPatientForQueryResponse,
   setMode,
+  loading,
 }) => {
   useEffect(() => {
     window.scrollTo(0, 0);
@@ -44,7 +47,21 @@ const PatientSearchResults: React.FC<PatientSearchResultsProps> = ({
 
   return (
     <>
-      {patients.length === 0 && (
+      {(loading || patients.length > 0) && (
+        <>
+          <Backlink onClick={goBack} label={RETURN_LABEL["patient-results"]} />
+
+          <TitleBox step="patient-results" />
+
+          <PatientSearchResultsTable
+            patients={patients}
+            handlePatientSelect={handlePatientSelect}
+            loading={loading}
+          />
+        </>
+      )}
+
+      {!loading && patients.length === 0 && (
         <>
           <NoPatientsFound />
           <a
@@ -54,16 +71,6 @@ const PatientSearchResults: React.FC<PatientSearchResultsProps> = ({
           >
             Revise your patient search
           </a>
-        </>
-      )}
-      {patients.length > 0 && (
-        <>
-          <Backlink onClick={goBack} label={RETURN_LABEL["patient-results"]} />
-
-          <PatientSearchResultsTable
-            patients={patients}
-            handlePatientSelect={handlePatientSelect}
-          />
         </>
       )}
     </>

--- a/query-connector/src/app/(pages)/query/components/ResultsView.tsx
+++ b/query-connector/src/app/(pages)/query/components/ResultsView.tsx
@@ -16,12 +16,14 @@ import { RETURN_LABEL } from "@/app/(pages)/query/components/stepIndicator/StepI
 import TitleBox from "./stepIndicator/TitleBox";
 import ImmunizationTable from "./resultsView/tableComponents/ImmunizationTable";
 import { CustomUserQuery } from "@/app/shared/constants";
+import Skeleton from "react-loading-skeleton";
 
 type ResultsViewProps = {
   fhirQueryResponse: FhirQueryResponse;
   selectedQuery: CustomUserQuery;
   goBack: () => void;
   goToBeginning: () => void;
+  loading: boolean;
 };
 
 export type ResultsViewAccordionItem = {
@@ -44,6 +46,7 @@ const ResultsView: React.FC<ResultsViewProps> = ({
   selectedQuery,
   goBack,
   goToBeginning,
+  loading,
 }) => {
   useEffect(() => {
     window.scrollTo(0, 0);
@@ -63,28 +66,40 @@ const ResultsView: React.FC<ResultsViewProps> = ({
   return (
     <>
       <div className={`${styles.resultsBannerContent}`}>
-        <Backlink onClick={() => goBack()} label={RETURN_LABEL["results"]} />
-        <button
-          className="usa-button usa-button--outline margin-left-auto"
-          onClick={() => goToBeginning()}
-        >
-          New patient search
-        </button>
+        {loading ? (
+          <>
+            <Skeleton width={150} />
+            <Skeleton width={200} height={50} />
+          </>
+        ) : (
+          <>
+            <Backlink
+              onClick={() => goBack()}
+              label={RETURN_LABEL["results"]}
+            />
+            <button
+              className="usa-button usa-button--outline"
+              onClick={() => goToBeginning()}
+            >
+              New patient search
+            </button>
+          </>
+        )}
       </div>
       <TitleBox step="results" />
       <h2 className="page-explainer margin-bottom-3-important margin-top-0-important">
         <strong>Query: </strong>
         <span className="text-normal display-inline-block">
-          {selectedQuery.query_name}
+          {loading ? <Skeleton width={250} /> : selectedQuery.query_name}
         </span>
       </h2>
 
       <div className=" grid-container grid-row grid-gap-md padding-0 ">
         <div className="tablet:grid-col-3">
-          <ResultsViewSideNav items={sideNavContent} />
+          <ResultsViewSideNav items={sideNavContent} loading={loading} />
         </div>
         <div className="tablet:grid-col-9 ecr-content">
-          <ResultsViewTable accordionItems={accordionItems} />
+          <ResultsViewTable accordionItems={accordionItems} loading={loading} />
         </div>
       </div>
     </>

--- a/query-connector/src/app/(pages)/query/components/ResultsView.tsx
+++ b/query-connector/src/app/(pages)/query/components/ResultsView.tsx
@@ -91,7 +91,7 @@ const ResultsView: React.FC<ResultsViewProps> = ({
       <h2 className="page-explainer margin-bottom-3-important margin-top-0-important">
         <strong>Query: </strong>
         <span className="text-normal display-inline-block">
-          {loading ? <Skeleton width={250} /> : selectedQuery.query_name}
+          {selectedQuery.query_name}
         </span>
       </h2>
 

--- a/query-connector/src/app/(pages)/query/components/ResultsView.tsx
+++ b/query-connector/src/app/(pages)/query/components/ResultsView.tsx
@@ -39,6 +39,7 @@ export type ResultsViewAccordionItem = {
  * @param props.goBack - The function to go back to the previous page.
  * @param props.goToBeginning - Function to return to patient discover
  * @param props.selectedQuery - query that's been selected to view for results
+ * @param props.loading
  * @returns The QueryView component.
  */
 const ResultsView: React.FC<ResultsViewProps> = ({

--- a/query-connector/src/app/(pages)/query/components/ResultsView.tsx
+++ b/query-connector/src/app/(pages)/query/components/ResultsView.tsx
@@ -39,7 +39,7 @@ export type ResultsViewAccordionItem = {
  * @param props.goBack - The function to go back to the previous page.
  * @param props.goToBeginning - Function to return to patient discover
  * @param props.selectedQuery - query that's been selected to view for results
- * @param props.loading
+ * @param props.loading -  whether the component is in a loading state
  * @returns The QueryView component.
  */
 const ResultsView: React.FC<ResultsViewProps> = ({

--- a/query-connector/src/app/(pages)/query/components/SelectQuery.tsx
+++ b/query-connector/src/app/(pages)/query/components/SelectQuery.tsx
@@ -43,6 +43,7 @@ interface SelectQueryProps {
  * show customize query
  * @param root0.fhirServer - the FHIR server that we're running the query against
  * @param root0.setFhirServer - callback function to update the FHIR server
+ * @param root0.setLoading
  * @returns - The selectQuery component.
  */
 const SelectQuery: React.FC<SelectQueryProps> = ({

--- a/query-connector/src/app/(pages)/query/components/SelectQuery.tsx
+++ b/query-connector/src/app/(pages)/query/components/SelectQuery.tsx
@@ -43,7 +43,7 @@ interface SelectQueryProps {
  * show customize query
  * @param root0.fhirServer - the FHIR server that we're running the query against
  * @param root0.setFhirServer - callback function to update the FHIR server
- * @param root0.setLoading
+ * @param root0.setLoading - callback to set the loading state
  * @returns - The selectQuery component.
  */
 const SelectQuery: React.FC<SelectQueryProps> = ({

--- a/query-connector/src/app/(pages)/query/components/SelectQuery.tsx
+++ b/query-connector/src/app/(pages)/query/components/SelectQuery.tsx
@@ -57,6 +57,7 @@ const SelectQuery: React.FC<SelectQueryProps> = ({
   setShowCustomizeQuery,
   selectedQuery,
   setSelectedQuery,
+  setLoading,
 }) => {
   const [queryValueSets, setQueryValueSets] = useState<DibbsValueSet[]>(
     [] as DibbsValueSet[],
@@ -94,6 +95,8 @@ const SelectQuery: React.FC<SelectQueryProps> = ({
   }, [selectedQuery]);
 
   async function onSubmit() {
+    setLoading(true);
+    goForward();
     await fetchQueryResponse({
       queryName: selectedQuery.query_name,
       patientForQuery: patientForQuery,
@@ -103,7 +106,7 @@ const SelectQuery: React.FC<SelectQueryProps> = ({
       queryResponseStateCallback: setResultsQueryResponse,
       setIsLoading: setLoadingResultResponse,
     }).catch(console.error);
-    goForward();
+    setLoading(false);
   }
 
   const displayLoading = loadingResultResponse || loadingQueryValueSets;

--- a/query-connector/src/app/(pages)/query/components/patientSearchResults/NoPatientsFound.tsx
+++ b/query-connector/src/app/(pages)/query/components/patientSearchResults/NoPatientsFound.tsx
@@ -10,9 +10,9 @@ const NoPatientsFound: React.FC = () => {
   }, []);
   return (
     <>
-      <h1 className="font-sans-2xl text-bold margin-top-205">
+      <h2 className="font-sans-xl text-bold margin-top-205">
         No Records Found
-      </h1>
+      </h2>
       <p className="font-sans-lg text-light margin-top-0 margin-bottom-205">
         No records were found for your search
       </p>

--- a/query-connector/src/app/(pages)/query/components/patientSearchResults/PatientSearchResultsTable.tsx
+++ b/query-connector/src/app/(pages)/query/components/patientSearchResults/PatientSearchResultsTable.tsx
@@ -89,27 +89,13 @@ export default PatientSearchResultsTable;
 const LoadingTableHeader: React.FC = () => {
   return (
     <tr>
-      <th>
-        <Skeleton />
-      </th>
-      <th>
-        <Skeleton />
-      </th>
-      <th>
-        <Skeleton />
-      </th>
-      <th>
-        <Skeleton />
-      </th>
-      <th>
-        <Skeleton />
-      </th>
-      <th>
-        <Skeleton />
-      </th>
-      <th>
-        <Skeleton />
-      </th>
+      {Array.from(Array(8).keys()).map((_) => {
+        return (
+          <th>
+            <Skeleton />
+          </th>
+        );
+      })}
     </tr>
   );
 };
@@ -117,27 +103,13 @@ const LoadingTableHeader: React.FC = () => {
 const LoadingTableBody: React.FC = () => {
   return (
     <tr className={classNames("tableRowWithHover_clickable")}>
-      <td>
-        <Skeleton />
-      </td>
-      <td>
-        <Skeleton />
-      </td>
-      <td>
-        <Skeleton />
-      </td>
-      <td>
-        <Skeleton />
-      </td>
-      <td>
-        <Skeleton />
-      </td>
-      <td>
-        <Skeleton />
-      </td>
-      <td>
-        <Skeleton />
-      </td>
+      {Array.from(Array(7).keys()).map((_) => {
+        return (
+          <td>
+            <Skeleton />
+          </td>
+        );
+      })}
     </tr>
   );
 };

--- a/query-connector/src/app/(pages)/query/components/patientSearchResults/PatientSearchResultsTable.tsx
+++ b/query-connector/src/app/(pages)/query/components/patientSearchResults/PatientSearchResultsTable.tsx
@@ -22,7 +22,7 @@ type PatientSearchResultsTableProps = {
  * @param param0.patients - Patient[] from the FHIR spec to display as rows
  * @param param0.handlePatientSelect - state setter function to redirect
  * to the results view
- * @param param0.loading
+ * @param param0.loading -  whether the component is in a loading state
  * @returns The patient search results view
  */
 const PatientSearchResultsTable: React.FC<PatientSearchResultsTableProps> = ({

--- a/query-connector/src/app/(pages)/query/components/patientSearchResults/PatientSearchResultsTable.tsx
+++ b/query-connector/src/app/(pages)/query/components/patientSearchResults/PatientSearchResultsTable.tsx
@@ -7,8 +7,6 @@ import {
   formatName,
 } from "@/app/shared/format-service";
 import classNames from "classnames";
-import TitleBox from "../stepIndicator/TitleBox";
-import NoPatientsFound from "./NoPatientsFound";
 import Skeleton from "react-loading-skeleton";
 
 type PatientSearchResultsTableProps = {
@@ -24,6 +22,7 @@ type PatientSearchResultsTableProps = {
  * @param param0.patients - Patient[] from the FHIR spec to display as rows
  * @param param0.handlePatientSelect - state setter function to redirect
  * to the results view
+ * @param param0.loading
  * @returns The patient search results view
  */
 const PatientSearchResultsTable: React.FC<PatientSearchResultsTableProps> = ({

--- a/query-connector/src/app/(pages)/query/components/patientSearchResults/PatientSearchResultsTable.tsx
+++ b/query-connector/src/app/(pages)/query/components/patientSearchResults/PatientSearchResultsTable.tsx
@@ -89,7 +89,7 @@ export default PatientSearchResultsTable;
 const LoadingTableHeader: React.FC = () => {
   return (
     <tr>
-      {Array.from(Array(8).keys()).map((_) => {
+      {Array.from(Array(7).keys()).map((_) => {
         return (
           <th>
             <Skeleton />

--- a/query-connector/src/app/(pages)/query/components/patientSearchResults/PatientSearchResultsTable.tsx
+++ b/query-connector/src/app/(pages)/query/components/patientSearchResults/PatientSearchResultsTable.tsx
@@ -8,10 +8,13 @@ import {
 } from "@/app/shared/format-service";
 import classNames from "classnames";
 import TitleBox from "../stepIndicator/TitleBox";
+import NoPatientsFound from "./NoPatientsFound";
+import Skeleton from "react-loading-skeleton";
 
 type PatientSearchResultsTableProps = {
   patients: Patient[];
   handlePatientSelect: (patient: Patient) => void;
+  loading: boolean;
 };
 
 /**
@@ -26,45 +29,56 @@ type PatientSearchResultsTableProps = {
 const PatientSearchResultsTable: React.FC<PatientSearchResultsTableProps> = ({
   patients,
   handlePatientSelect: setPatientForQueryResponse,
+  loading,
 }) => {
   return (
     <>
-      <TitleBox step="patient-results" />
-      <h2 className="page-explainer">The following record(s) match.</h2>
+      <h2 className="page-explainer">
+        {loading ? <Skeleton width={250} /> : "The following record(s) match."}
+      </h2>
+
       <Table className={classNames("margin-top-4")}>
         <thead>
-          <tr>
-            <th>Name</th>
-            <th>DOB</th>
-            <th>Contact</th>
-            <th>Address</th>
-            <th>MRN</th>
-            <th>Actions</th>
-          </tr>
+          {loading ? (
+            <LoadingTableHeader />
+          ) : (
+            <tr>
+              <th>Name</th>
+              <th>DOB</th>
+              <th>Contact</th>
+              <th>Address</th>
+              <th>MRN</th>
+              <th>Actions</th>
+            </tr>
+          )}
         </thead>
         <tbody>
-          {patients.map((patient) => (
-            <tr
-              key={patient.id}
-              className={classNames("tableRowWithHover_clickable")}
-              onClick={() => setPatientForQueryResponse(patient)}
-            >
-              <td>{formatName(patient.name ?? [])}</td>
-              <td width={120}>{patient.birthDate ?? ""}</td>
-              <td>{formatContact(patient.telecom ?? [])}</td>
-              <td>{formatAddress(patient.address ?? [])}</td>
-              <td width={150}>{formatMRN(patient.identifier ?? [])}</td>
-              <td width={100}>
-                <a
-                  href="#"
-                  className="unchanged-color-on-visit"
-                  onClick={() => setPatientForQueryResponse(patient)}
-                >
-                  Select patient
-                </a>
-              </td>
-            </tr>
-          ))}
+          {loading ? (
+            <LoadingTableBody />
+          ) : (
+            patients.map((patient) => (
+              <tr
+                key={patient.id}
+                className={classNames("tableRowWithHover_clickable")}
+                onClick={() => setPatientForQueryResponse(patient)}
+              >
+                <td>{formatName(patient.name ?? [])}</td>
+                <td width={120}>{patient.birthDate ?? ""}</td>
+                <td>{formatContact(patient.telecom ?? [])}</td>
+                <td>{formatAddress(patient.address ?? [])}</td>
+                <td width={150}>{formatMRN(patient.identifier ?? [])}</td>
+                <td width={100}>
+                  <a
+                    href="#"
+                    className="unchanged-color-on-visit"
+                    onClick={() => setPatientForQueryResponse(patient)}
+                  >
+                    Select patient
+                  </a>
+                </td>
+              </tr>
+            ))
+          )}
         </tbody>
       </Table>
     </>
@@ -72,3 +86,59 @@ const PatientSearchResultsTable: React.FC<PatientSearchResultsTableProps> = ({
 };
 
 export default PatientSearchResultsTable;
+
+const LoadingTableHeader: React.FC = () => {
+  return (
+    <tr>
+      <th>
+        <Skeleton />
+      </th>
+      <th>
+        <Skeleton />
+      </th>
+      <th>
+        <Skeleton />
+      </th>
+      <th>
+        <Skeleton />
+      </th>
+      <th>
+        <Skeleton />
+      </th>
+      <th>
+        <Skeleton />
+      </th>
+      <th>
+        <Skeleton />
+      </th>
+    </tr>
+  );
+};
+
+const LoadingTableBody: React.FC = () => {
+  return (
+    <tr className={classNames("tableRowWithHover_clickable")}>
+      <td>
+        <Skeleton />
+      </td>
+      <td>
+        <Skeleton />
+      </td>
+      <td>
+        <Skeleton />
+      </td>
+      <td>
+        <Skeleton />
+      </td>
+      <td>
+        <Skeleton />
+      </td>
+      <td>
+        <Skeleton />
+      </td>
+      <td>
+        <Skeleton />
+      </td>
+    </tr>
+  );
+};

--- a/query-connector/src/app/(pages)/query/components/resultsView/ResultsViewAccordionBody.tsx
+++ b/query-connector/src/app/(pages)/query/components/resultsView/ResultsViewAccordionBody.tsx
@@ -1,7 +1,7 @@
 import styles from "./resultsView.module.scss";
 
 type ResultsViewAccordionBodyProps = {
-  title: string;
+  title: string | React.ReactNode;
   id?: string;
   content: React.ReactNode;
 };

--- a/query-connector/src/app/(pages)/query/components/resultsView/ResultsViewSideNav.tsx
+++ b/query-connector/src/app/(pages)/query/components/resultsView/ResultsViewSideNav.tsx
@@ -1,6 +1,8 @@
 import React, { useCallback, useEffect, useState } from "react";
 import { formatIdForAnchorTag } from "./ResultsViewTable";
 import SideNav, { NavItem } from "../../../../ui/components/sideNav/SideNav";
+import { SideNav as UswdsSideNav } from "@trussworks/react-uswds";
+import Skeleton from "react-loading-skeleton";
 
 export type NavSection = {
   title: string;
@@ -9,6 +11,7 @@ export type NavSection = {
 
 type ResultsViewSideNavProps = {
   items: NavSection[];
+  loading: boolean;
 };
 /**
  * ResultsViewSideNav component
@@ -16,19 +19,23 @@ type ResultsViewSideNavProps = {
  * @param root0.items - a list of nav items to display in the sidenav
  * @returns - The ResultsViewSideNav component
  */
-const ResultsViewSideNav: React.FC<ResultsViewSideNavProps> = ({ items }) => {
+const ResultsViewSideNav: React.FC<ResultsViewSideNavProps> = ({
+  items,
+  loading,
+}) => {
   const [activeItem, setActiveItem] = useState(
     window.location.hash || formatIdForAnchorTag(items[0]?.title),
   );
-  const hashChangeHandler = useCallback(() => {
-    setActiveItem(window.location.hash);
-  }, [window.location.hash]);
-  useEffect(() => {
-    window.addEventListener("hashchange", hashChangeHandler);
-    return () => {
-      window.removeEventListener("hashchange", hashChangeHandler);
-    };
-  }, []);
+  // const hashChangeHandler = useCallback(() => {
+  //   setActiveItem(window.location.hash);
+  // }, [window.location.hash]);
+
+  // useEffect(() => {
+  //   window.addEventListener("hashchange", hashChangeHandler);
+  //   return () => {
+  //     window.removeEventListener("hashchange", hashChangeHandler);
+  //   };
+  // }, []);
 
   const sideNavItems: NavItem[] = items.flatMap((item) => {
     const sectionId = formatIdForAnchorTag(item.title);
@@ -37,23 +44,35 @@ const ResultsViewSideNav: React.FC<ResultsViewSideNavProps> = ({ items }) => {
       return [
         {
           title: item.title,
-          activeItem: activeItem.includes(sectionId),
+          activeItem: activeItem?.includes(sectionId),
         },
         {
           title: item.subtitle,
-          activeItem: activeItem.includes(subSectionId),
+          activeItem: activeItem?.includes(subSectionId),
           isSubNav: true,
         },
       ];
     } else {
       return {
         ...item,
-        activeItem: activeItem.includes(sectionId),
+        activeItem: activeItem?.includes(sectionId),
       };
     }
   });
 
-  return (
+  return loading ? (
+    <UswdsSideNav
+      items={Array.from(Array(5).keys()).map((_) => {
+        return (
+          <li className="usa-sidenav__item">
+            <div className="padding-1">
+              <Skeleton height={25} />
+            </div>
+          </li>
+        );
+      })}
+    />
+  ) : (
     <SideNav
       items={sideNavItems}
       containerClassName="resultsViewSideNav"

--- a/query-connector/src/app/(pages)/query/components/resultsView/ResultsViewSideNav.tsx
+++ b/query-connector/src/app/(pages)/query/components/resultsView/ResultsViewSideNav.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useCallback, useEffect, useState } from "react";
 import { formatIdForAnchorTag } from "./ResultsViewTable";
 import SideNav, { NavItem } from "../../../../ui/components/sideNav/SideNav";
 import { SideNav as UswdsSideNav } from "@trussworks/react-uswds";
@@ -27,16 +27,16 @@ const ResultsViewSideNav: React.FC<ResultsViewSideNavProps> = ({
   const [activeItem, setActiveItem] = useState(
     window.location.hash || formatIdForAnchorTag(items[0]?.title),
   );
-  // const hashChangeHandler = useCallback(() => {
-  //   setActiveItem(window.location.hash);
-  // }, [window.location.hash]);
+  const hashChangeHandler = useCallback(() => {
+    setActiveItem(window.location.hash);
+  }, [window.location.hash]);
 
-  // useEffect(() => {
-  //   window.addEventListener("hashchange", hashChangeHandler);
-  //   return () => {
-  //     window.removeEventListener("hashchange", hashChangeHandler);
-  //   };
-  // }, []);
+  useEffect(() => {
+    window.addEventListener("hashchange", hashChangeHandler);
+    return () => {
+      window.removeEventListener("hashchange", hashChangeHandler);
+    };
+  }, []);
 
   const sideNavItems: NavItem[] = items.flatMap((item) => {
     const sectionId = formatIdForAnchorTag(item.title);

--- a/query-connector/src/app/(pages)/query/components/resultsView/ResultsViewSideNav.tsx
+++ b/query-connector/src/app/(pages)/query/components/resultsView/ResultsViewSideNav.tsx
@@ -17,7 +17,7 @@ type ResultsViewSideNavProps = {
  * ResultsViewSideNav component
  * @param root0 - params
  * @param root0.items - a list of nav items to display in the sidenav
- * @param root0.loading
+ * @param root0.loading -  whether the component is in a loading state
  * @returns - The ResultsViewSideNav component
  */
 const ResultsViewSideNav: React.FC<ResultsViewSideNavProps> = ({

--- a/query-connector/src/app/(pages)/query/components/resultsView/ResultsViewSideNav.tsx
+++ b/query-connector/src/app/(pages)/query/components/resultsView/ResultsViewSideNav.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useState } from "react";
+import React, { useState } from "react";
 import { formatIdForAnchorTag } from "./ResultsViewTable";
 import SideNav, { NavItem } from "../../../../ui/components/sideNav/SideNav";
 import { SideNav as UswdsSideNav } from "@trussworks/react-uswds";
@@ -17,6 +17,7 @@ type ResultsViewSideNavProps = {
  * ResultsViewSideNav component
  * @param root0 - params
  * @param root0.items - a list of nav items to display in the sidenav
+ * @param root0.loading
  * @returns - The ResultsViewSideNav component
  */
 const ResultsViewSideNav: React.FC<ResultsViewSideNavProps> = ({

--- a/query-connector/src/app/(pages)/query/components/resultsView/ResultsViewTable.tsx
+++ b/query-connector/src/app/(pages)/query/components/resultsView/ResultsViewTable.tsx
@@ -3,9 +3,12 @@ import Accordion from "../../../../ui/designSystem/Accordion";
 import styles from "./resultsView.module.scss";
 import ResultsViewAccordionBody from "./ResultsViewAccordionBody";
 import { ResultsViewAccordionItem } from "../ResultsView";
+import Skeleton from "react-loading-skeleton";
+import Table from "@/app/ui/designSystem/table/Table";
 
 type ResultsViewTable = {
   accordionItems: ResultsViewAccordionItem[];
+  loading: boolean;
 };
 
 /**
@@ -15,34 +18,44 @@ type ResultsViewTable = {
  * group of type ResultsViewAccordionItem
  * @returns The ResultsViewTable component.
  */
-const ResultsViewTable: React.FC<ResultsViewTable> = ({ accordionItems }) => {
+const ResultsViewTable: React.FC<ResultsViewTable> = ({
+  accordionItems,
+  loading,
+}) => {
   return (
     <div data-testid="accordion">
-      {accordionItems.map((item) => {
-        const titleId = formatIdForAnchorTag(item.title);
-        return (
-          item.content && (
-            <div className={styles.accordionInstance} key={item.title}>
-              <Accordion
-                title={item.title}
-                content={
-                  <ResultsViewAccordionBody
-                    title={item.subtitle ?? ""}
-                    content={item.content}
-                    id={formatIdForAnchorTag(item.subtitle ?? "")}
-                  />
-                }
-                expanded={true}
-                id={titleId}
-                key={titleId}
-                headingLevel={"h3"}
-                accordionClassName={styles.accordionWrapper}
-                containerClassName={styles.accordionContainer}
-              />
-            </div>
-          )
-        );
-      })}
+      {loading ? (
+        <>
+          <LoadingAccordion />
+          <LoadingAccordion />
+        </>
+      ) : (
+        accordionItems.map((item) => {
+          const titleId = formatIdForAnchorTag(item.title);
+          return (
+            item.content && (
+              <div className={styles.accordionInstance} key={item.title}>
+                <Accordion
+                  title={item.title}
+                  content={
+                    <ResultsViewAccordionBody
+                      title={item.subtitle ?? ""}
+                      content={item.content}
+                      id={formatIdForAnchorTag(item.subtitle ?? "")}
+                    />
+                  }
+                  expanded
+                  id={titleId}
+                  key={titleId}
+                  headingLevel={"h3"}
+                  accordionClassName={styles.accordionWrapper}
+                  containerClassName={styles.accordionContainer}
+                />
+              </div>
+            )
+          );
+        })
+      )}
     </div>
   );
 };
@@ -59,3 +72,45 @@ export default ResultsViewTable;
 export function formatIdForAnchorTag(title: string) {
   return title?.toLocaleLowerCase().replace(" ", "-");
 }
+
+const LoadingAccordion: React.FC = () => {
+  return (
+    <Accordion
+      title={<Skeleton />}
+      content={
+        <ResultsViewAccordionBody
+          title={<Skeleton />}
+          content={
+            <Table contained={false}>
+              <thead className="usa-sr-only">
+                <tr>
+                  <th colSpan={2} scope="col">
+                    <Skeleton />
+                  </th>
+                </tr>
+              </thead>
+              <tbody>
+                {Array.from(Array(7).keys()).map((item) => (
+                  <tr key={item}>
+                    <td scope="row">
+                      <strong>
+                        <Skeleton />
+                      </strong>
+                    </td>
+                    <td>
+                      <Skeleton />
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </Table>
+          }
+          id={"skeleton-body"}
+        />
+      }
+      expanded
+      id={"skeleton-accordion"}
+      containerClassName="margin-bottom-4"
+    ></Accordion>
+  );
+};

--- a/query-connector/src/app/(pages)/query/components/resultsView/ResultsViewTable.tsx
+++ b/query-connector/src/app/(pages)/query/components/resultsView/ResultsViewTable.tsx
@@ -16,7 +16,7 @@ type ResultsViewTable = {
  * @param root0 - The props for the AccordionContainer component.
  * @param root0.accordionItems - an array of items to render as an accordion
  * group of type ResultsViewAccordionItem
- * @param root0.loading
+ * @param root0.loading -  whether the component is in a loading state
  * @returns The ResultsViewTable component.
  */
 const ResultsViewTable: React.FC<ResultsViewTable> = ({

--- a/query-connector/src/app/(pages)/query/components/resultsView/ResultsViewTable.tsx
+++ b/query-connector/src/app/(pages)/query/components/resultsView/ResultsViewTable.tsx
@@ -16,6 +16,7 @@ type ResultsViewTable = {
  * @param root0 - The props for the AccordionContainer component.
  * @param root0.accordionItems - an array of items to render as an accordion
  * group of type ResultsViewAccordionItem
+ * @param root0.loading
  * @returns The ResultsViewTable component.
  */
 const ResultsViewTable: React.FC<ResultsViewTable> = ({

--- a/query-connector/src/app/(pages)/query/components/resultsView/resultsView.module.scss
+++ b/query-connector/src/app/(pages)/query/components/resultsView/resultsView.module.scss
@@ -18,7 +18,7 @@
   margin: 0.1rem 0rem;
   padding: 0;
 
-  h4[id="demographics"]{
+  h4[id="demographics"] {
     margin: 1.25rem;
   }
 }
@@ -36,7 +36,8 @@
 }
 
 .accordionHeading {
-  font-family: "Source Sans Pro Web", "Helvetica Neue", "Helvetica", "Roboto", "Arial", "sans-serif" !important;
+  font-family: "Source Sans Pro Web", "Helvetica Neue", "Helvetica", "Roboto",
+    "Arial", "sans-serif" !important;
   font-size: 1.25rem !important;
   line-height: 1.1 !important;
 }
@@ -44,4 +45,5 @@
 .resultsBannerContent {
   display: flex;
   align-items: center;
+  justify-content: space-between;
 }

--- a/query-connector/src/app/(pages)/query/components/searchForm/SearchForm.tsx
+++ b/query-connector/src/app/(pages)/query/components/searchForm/SearchForm.tsx
@@ -82,6 +82,7 @@ const SearchForm: React.FC<SearchFormProps> = function SearchForm({
       return;
     }
     setLoading(true);
+    setMode("patient-results");
 
     const originalRequest: QueryRequest = {
       first_name: firstName,
@@ -98,7 +99,6 @@ const SearchForm: React.FC<SearchFormProps> = function SearchForm({
     const queryResponse = await makeFhirQuery(originalRequest);
     setPatientDiscoveryQueryResponse(queryResponse);
 
-    setMode("patient-results");
     setLoading(false);
   }
   useEffect(() => {

--- a/query-connector/src/app/(pages)/query/page.tsx
+++ b/query-connector/src/app/(pages)/query/page.tsx
@@ -6,7 +6,6 @@ import PatientSearchResults from "./components/PatientSearchResults";
 import SearchForm from "./components/searchForm/SearchForm";
 import SelectQuery from "./components/SelectQuery";
 import { DEFAULT_DEMO_FHIR_SERVER, Mode } from "../../shared/constants";
-import LoadingView from "../../ui/designSystem/LoadingView";
 import StepIndicator, {
   CUSTOMIZE_QUERY_STEPS,
 } from "./components/stepIndicator/StepIndicator";

--- a/query-connector/src/app/(pages)/query/page.tsx
+++ b/query-connector/src/app/(pages)/query/page.tsx
@@ -96,6 +96,7 @@ const Query: React.FC = () => {
             goBack={() => setMode("search")}
             setMode={setMode}
             setPatientForQueryResponse={setPatientForQueryResponse}
+            loading={loading}
           />
         )}
 
@@ -118,7 +119,7 @@ const Query: React.FC = () => {
         )}
 
         {/* Step 4 */}
-        {mode === "results" && resultsQueryResponse && selectedQuery && (
+        {mode === "results" && (
           <ResultsView
             selectedQuery={selectedQuery}
             fhirQueryResponse={resultsQueryResponse}
@@ -128,9 +129,9 @@ const Query: React.FC = () => {
             goToBeginning={() => {
               setMode("search");
             }}
+            loading={loading}
           />
         )}
-        {loading && <LoadingView loading={loading} />}
       </div>
     </>
   );

--- a/query-connector/src/app/(pages)/queryBuilding/querySelection/QueryLibrary.tsx
+++ b/query-connector/src/app/(pages)/queryBuilding/querySelection/QueryLibrary.tsx
@@ -21,7 +21,6 @@ import {
   handleCopy,
   SelectedQueryDetails,
 } from "./utils";
-import LoadingView from "@/app/ui/designSystem/LoadingView";
 import { DataContext } from "@/app/shared/DataProvider";
 import classNames from "classnames";
 import { getConditionsData } from "@/app/shared/database-service";

--- a/query-connector/src/app/(pages)/queryBuilding/querySelection/QueryLibrary.tsx
+++ b/query-connector/src/app/(pages)/queryBuilding/querySelection/QueryLibrary.tsx
@@ -52,7 +52,6 @@ export const MyQueriesDisplay: React.FC<UserQueriesDisplayProps> = ({
 }) => {
   const queriesContext = useContext(DataContext);
   const [queries, setQueries] = useState<CustomUserQuery[]>(initialQueries);
-  const [loading, setLoading] = useState(false);
   const [conditionIdToDetailsMap, setConditionIdToDetailsMap] =
     useState<ConditionsMap>();
 
@@ -84,7 +83,6 @@ export const MyQueriesDisplay: React.FC<UserQueriesDisplayProps> = ({
 
   return (
     <div>
-      {<LoadingView loading={loading} />}
       {queriesContext &&
         renderModal(
           modalRef,

--- a/query-connector/src/app/(pages)/queryBuilding/querySelection/QueryLibrary.tsx
+++ b/query-connector/src/app/(pages)/queryBuilding/querySelection/QueryLibrary.tsx
@@ -17,7 +17,6 @@ import {
   SelectedQueryState,
   renderModal,
   handleDelete,
-  handleCreationConfirmation,
   confirmDelete,
   handleCopy,
   SelectedQueryDetails,
@@ -100,12 +99,7 @@ export const MyQueriesDisplay: React.FC<UserQueriesDisplayProps> = ({
         <h1 className="flex-align-center">Query Library</h1>
         <div className="margin-left-auto">
           <Button
-            onClick={() =>
-              handleCreationConfirmation(
-                () => setBuildStep("condition"),
-                setLoading,
-              )
-            }
+            onClick={() => setBuildStep("condition")}
             className={styles.createQueryButton}
             type="button"
           >

--- a/query-connector/src/app/(pages)/queryBuilding/querySelection/utils.tsx
+++ b/query-connector/src/app/(pages)/queryBuilding/querySelection/utils.tsx
@@ -89,7 +89,6 @@ export const handleCopy = (queryName: string, queryId: string) => {
 /**
  * Handles the creation of a new query by redirecting to the query building page.
  * @param goForward - method to progress the page to the next step
- * @param setLoading - Function to set the loading state.
  */
 export const handleCreationConfirmation = async (goForward: () => void) => {
   // Redirect to query updating/editing page

--- a/query-connector/src/app/(pages)/queryBuilding/querySelection/utils.tsx
+++ b/query-connector/src/app/(pages)/queryBuilding/querySelection/utils.tsx
@@ -91,11 +91,7 @@ export const handleCopy = (queryName: string, queryId: string) => {
  * @param goForward - method to progress the page to the next step
  * @param setLoading - Function to set the loading state.
  */
-export const handleCreationConfirmation = async (
-  goForward: () => void,
-  setLoading: React.Dispatch<React.SetStateAction<boolean>>,
-) => {
-  setLoading(true);
+export const handleCreationConfirmation = async (goForward: () => void) => {
   // Redirect to query updating/editing page
   goForward();
 };

--- a/query-connector/src/app/(pages)/queryBuilding/querySelection/utils.tsx
+++ b/query-connector/src/app/(pages)/queryBuilding/querySelection/utils.tsx
@@ -87,15 +87,6 @@ export const handleCopy = (queryName: string, queryId: string) => {
 };
 
 /**
- * Handles the creation of a new query by redirecting to the query building page.
- * @param goForward - method to progress the page to the next step
- */
-export const handleCreationConfirmation = async (goForward: () => void) => {
-  // Redirect to query updating/editing page
-  goForward();
-};
-
-/**
  *  Renders a modal to confirm the deletion of a user query.
  * @param modalRef - Reference to the modal component.
  * @param selectedQuery - The currently selected query for deletion.

--- a/query-connector/src/app/(pages)/userManagement/page.tsx
+++ b/query-connector/src/app/(pages)/userManagement/page.tsx
@@ -33,7 +33,7 @@ const UserManagement: React.FC = () => {
     try {
       const userList: QCResponse<User> = await getUsers();
       setUsers(userList.items);
-    } catch (e) {
+    } catch {
       showToastConfirmation({
         body: "Unable to retrieve users. Please try again.",
         variant: "error",

--- a/query-connector/src/app/ui/components/page/page.tsx
+++ b/query-connector/src/app/ui/components/page/page.tsx
@@ -6,6 +6,7 @@ import { AppProgressBar as ProgressBar } from "next-nprogress-bar";
 import { DataContext } from "@/app/shared/DataProvider";
 import SiteAlert from "../../designSystem/SiteAlert";
 import { ToastConfigOptions } from "../../designSystem/toast/Toast";
+import "react-loading-skeleton/dist/skeleton.css";
 
 export type PageProps = {
   children: React.ReactNode;

--- a/query-connector/src/app/ui/designSystem/table/Table.tsx
+++ b/query-connector/src/app/ui/designSystem/table/Table.tsx
@@ -10,6 +10,7 @@ type TableProps = {
   striped?: boolean;
   fullWidth?: boolean;
   fixed?: boolean;
+  loading?: boolean;
 };
 
 /**


### PR DESCRIPTION
# PULL REQUEST

## Summary
Adds loading skeletons to the query execution flow in accordance to [best-practice guidance on loading states](https://www.nngroup.com/articles/skeleton-screens/).

https://github.com/user-attachments/assets/d97373b9-ad25-4a0b-b10f-afeab8087c8b

Elected not to add the loading UI to the query building flow since the page transitions are under 2 seconds and [guidance suggests skeletons aren't necessary in those cases](https://www.nngroup.com/articles/skeleton-screens/#:~:text=If%20a%20page%20takes%20less%20than%201%20second%20to%20load%2C%20skeleton%20screens%20or%20spinners%20aren%E2%80%99t%20necessary%2C). The execution flow has a few steps where the wait time is a bit longer (ie the query out to FHIR servers), so decided to add those accordingly.

## Related Issue
Fixes #51 

## Checklist

- [x] Descriptive Pull Request title
- [x] Link to relevant issues
- [ ] Provide necessary context for design reviewers
- [ ] Update documentation

