### PR TITLE
Initializing Query drawer backend for User group work

### DIFF
--- a/query-connector/src/app/backend/usergroup-management.ts
+++ b/query-connector/src/app/backend/usergroup-management.ts
@@ -1,6 +1,6 @@
 "use server";
 import { User, Query } from "../models/entities/user-management";
-import { superAdminAccessCheck } from "../utils/auth";
+import { adminAccessCheck, superAdminAccessCheck } from "../utils/auth";
 import { getDbClient } from "./dbClient";
 const dbClient = getDbClient();
 
@@ -170,7 +170,7 @@ export async function saveUserGroupMembership(
 export async function getQueriesWithGroupStatus(
   groupId: string,
 ): Promise<Query[]> {
-  if (!(await superAdminAccessCheck())) {
+  if (!(await adminAccessCheck())) {
     throw new Error("Unauthorized");
   }
 
@@ -279,7 +279,7 @@ export async function saveQueryGroupMembership(
   groupId: string,
   selectedQueries: string[],
 ): Promise<Query[]> {
-  if (!(await superAdminAccessCheck())) {
+  if (!(await adminAccessCheck())) {
     throw new Error("Unauthorized");
   }
 

--- a/query-connector/src/app/backend/usergroup-management.ts
+++ b/query-connector/src/app/backend/usergroup-management.ts
@@ -1,5 +1,5 @@
 "use server";
-import { User } from "../models/entities/user-management";
+import { User, Query } from "../models/entities/user-management";
 import { superAdminAccessCheck } from "../utils/auth";
 import { getDbClient } from "./dbClient";
 const dbClient = getDbClient();
@@ -156,6 +156,163 @@ export async function saveUserGroupMembership(
     const updatedUsers = await getUsersWithGroupStatus(groupId);
     await dbClient.query("COMMIT");
     return updatedUsers;
+  } catch (error) {
+    await dbClient.query("ROLLBACK");
+    throw error;
+  }
+}
+
+/**
+ * Retrieves the query group membership for a specific user group.
+ * @param groupId - The unique identifier of the user group.
+ * @returns A list of queries associated with the specified group.
+ */
+export async function getQueriesWithGroupStatus(
+  groupId: string,
+): Promise<Query[]> {
+  if (!(await superAdminAccessCheck())) {
+    throw new Error("Unauthorized");
+  }
+
+  const groupCheckQuery = {
+    text: `SELECT id FROM usergroup WHERE id = $1;`,
+    values: [groupId],
+  };
+  const groupCheckResult = await dbClient.query(groupCheckQuery);
+  if (groupCheckResult.rows.length === 0) {
+    return [];
+  }
+
+  const query = {
+    text: `
+      SELECT q.id, q.query_name, g.name AS group_name,
+             COALESCE(qg.id, '') AS membership_id,
+             CASE 
+               WHEN qg.query_id IS NOT NULL THEN TRUE
+               ELSE FALSE
+             END AS is_member
+      FROM query q
+      LEFT JOIN usergroup_to_query qg 
+        ON q.id = qg.query_id AND qg.usergroup_id = $1
+      LEFT JOIN usergroup g 
+        ON qg.usergroup_id = g.id
+      ORDER BY q.query_name;
+    `,
+    values: [groupId],
+  };
+
+  const result = await dbClient.query(query);
+
+  return result.rows.map((row) => ({
+    id: row.id,
+    name: row.query_name,
+    userGroupMemberships: [
+      {
+        id: row.membership_id,
+        usergroup_id: groupId,
+        group_name: row.group_name,
+        is_member: row.is_member,
+      },
+    ],
+  }));
+}
+
+/**
+ * Adds queries to a user group.
+ * @param groupId - The unique identifier of the user group.
+ * @param queryIds - The unique identifiers of the queries to add.
+ * @returns The query IDs of the queries added to the group.
+ */
+export async function addQueriesToGroup(
+  groupId: string,
+  queryIds: string[],
+): Promise<Query[]> {
+  if (queryIds.length === 0) return [];
+
+  const ids = queryIds.map((queryId) => `${queryId}_${groupId}`);
+  const insertQuery = {
+    text: `
+      INSERT INTO usergroup_to_query (id, query_id, usergroup_id)
+      SELECT * FROM unnest($1::text[], $2::uuid[], $3::uuid[])
+      ON CONFLICT DO NOTHING
+      RETURNING query_id;
+    `,
+    values: [ids, queryIds, new Array(queryIds.length).fill(groupId)],
+  };
+
+  const result = await dbClient.query(insertQuery);
+  return result.rows.map((row) => row.query_id);
+}
+
+/**
+ * Removes queries from a user group.
+ * @param groupId - The unique identifier of the user group.
+ * @param queryIds - The unique identifiers of the queries to remove.
+ * @returns The query IDs of the queries removed from the group.
+ */
+export async function removeQueriesFromGroup(
+  groupId: string,
+  queryIds: string[],
+): Promise<Query[]> {
+  if (queryIds.length === 0) return [];
+
+  const query = {
+    text: `
+      DELETE FROM usergroup_to_query 
+      WHERE usergroup_id = $1 AND query_id = ANY($2)
+      RETURNING query_id;
+    `,
+    values: [groupId, queryIds],
+  };
+
+  const result = await dbClient.query(query);
+  return result.rows.map((row) => row.query_id);
+}
+
+/**
+ * Saves the query group membership for a specific user group.
+ * @param groupId - The unique identifier of the user group.
+ * @param selectedQueries - The unique identifiers of the queries to add to the group.
+ * @returns A list of queries associated with the specified group.
+ */
+export async function saveQueryGroupMembership(
+  groupId: string,
+  selectedQueries: string[],
+): Promise<Query[]> {
+  if (!(await superAdminAccessCheck())) {
+    throw new Error("Unauthorized");
+  }
+
+  await dbClient.query("BEGIN");
+
+  try {
+    const existingMemberships = await getQueriesWithGroupStatus(groupId);
+    const existingQueryIds = new Set(
+      existingMemberships.flatMap(
+        (query) =>
+          query.userGroupMemberships
+            ?.filter((m) => m.is_member)
+            .map((m) => query.id) || [],
+      ),
+    );
+
+    const queriesToAdd = selectedQueries.filter(
+      (id) => !existingQueryIds.has(id),
+    );
+    const queriesToRemove = existingMemberships.flatMap(
+      (query) =>
+        query.userGroupMemberships
+          ?.filter((m) => m.is_member && !selectedQueries.includes(query.id))
+          .map((m) => query.id) || [],
+    );
+
+    if (queriesToRemove.length)
+      await removeQueriesFromGroup(groupId, queriesToRemove);
+    if (queriesToAdd.length) await addQueriesToGroup(groupId, queriesToAdd);
+
+    const updatedQueries = await getQueriesWithGroupStatus(groupId);
+    await dbClient.query("COMMIT");
+    return updatedQueries;
   } catch (error) {
     await dbClient.query("ROLLBACK");
     throw error;

--- a/query-connector/src/app/models/entities/user-management.ts
+++ b/query-connector/src/app/models/entities/user-management.ts
@@ -30,3 +30,9 @@ export interface UserGroupMembership {
   usergroup_id: string;
   is_member: boolean;
 }
+
+export interface Query {
+  id: string;
+  name: string;
+  userGroupMemberships?: UserGroupMembership[];
+}

--- a/query-connector/src/app/tests/integration/usergroup-management.test.ts
+++ b/query-connector/src/app/tests/integration/usergroup-management.test.ts
@@ -117,6 +117,12 @@ describe("User Group and Query Membership Tests", () => {
     expect(members.some((user) => user.id === TEST_USER_2_ID)).toBe(true);
   });
 
+  test("should not add duplicate users to a group", async () => {
+    await addUsersToGroup(TEST_GROUP_ID, [TEST_USER_1_ID]);
+    const result = await addUsersToGroup(TEST_GROUP_ID, [TEST_USER_1_ID]);
+    expect(result).toEqual([]);
+  });
+
   /**
    * Tests removing users from a user group.
    */
@@ -148,6 +154,11 @@ describe("User Group and Query Membership Tests", () => {
           user.userGroupMemberships?.some((m) => m.is_member),
       ),
     ).toBe(false);
+  });
+
+  test("should not remove a user that is not in the group", async () => {
+    const result = await removeUsersFromGroup(TEST_GROUP_ID, [TEST_USER_1_ID]);
+    expect(result).toEqual([]);
   });
 
   /**
@@ -198,6 +209,12 @@ describe("User Group and Query Membership Tests", () => {
     expect(members.some((query) => query.name === "Test Query")).toBe(true);
   });
 
+  test("should not add duplicate queries to a group", async () => {
+    await addQueriesToGroup(TEST_GROUP_ID, [TEST_QUERY_ID]);
+    const result = await addQueriesToGroup(TEST_GROUP_ID, [TEST_QUERY_ID]);
+    expect(result).toEqual([]);
+  });
+
   /**
    * Tests removing queries from a user group.
    */
@@ -211,6 +228,11 @@ describe("User Group and Query Membership Tests", () => {
     );
 
     expect(members.length).toBe(0);
+  });
+
+  test("should not remove a query that is not in the group", async () => {
+    const result = await removeQueriesFromGroup(TEST_GROUP_ID, [TEST_QUERY_ID]);
+    expect(result).toEqual([]);
   });
 
   /**

--- a/query-connector/src/app/tests/integration/usergroup-management.test.ts
+++ b/query-connector/src/app/tests/integration/usergroup-management.test.ts
@@ -3,9 +3,13 @@ import {
   addUsersToGroup,
   removeUsersFromGroup,
   saveUserGroupMembership,
+  getQueriesWithGroupStatus,
+  addQueriesToGroup,
+  removeQueriesFromGroup,
+  saveQueryGroupMembership,
 } from "@/app/backend/usergroup-management";
 import { getDbClient } from "@/app/backend/dbClient";
-import { User } from "@/app/models/entities/user-management";
+import { User, Query } from "@/app/models/entities/user-management";
 
 const dbClient = getDbClient();
 
@@ -16,8 +20,9 @@ jest.mock("@/app/utils/auth", () => ({
 const TEST_GROUP_ID = "00000000-0000-0000-0000-000000000000";
 const TEST_USER_1_ID = "00000000-0000-0000-0000-000000000001";
 const TEST_USER_2_ID = "00000000-0000-0000-0000-000000000002";
+const TEST_QUERY_ID = "00000000-0000-0000-0000-000000000003";
 
-describe("User Group Membership Tests", () => {
+describe("User Group and Query Membership Tests", () => {
   beforeAll(async () => {
     await dbClient.query("BEGIN");
 
@@ -36,12 +41,23 @@ describe("User Group Membership Tests", () => {
       VALUES ($1, 'Test Group');
     `;
     await dbClient.query(insertGroupQuery, [TEST_GROUP_ID]);
+
+    // Insert test query
+    const insertQueryQuery = `
+      INSERT INTO query (id, query_name)
+      VALUES ($1, 'Test Query');
+    `;
+    await dbClient.query(insertQueryQuery, [TEST_QUERY_ID]);
   });
 
   afterAll(async () => {
     try {
       await dbClient.query(
         "DELETE FROM usergroup_to_users WHERE usergroup_id = $1;",
+        [TEST_GROUP_ID],
+      );
+      await dbClient.query(
+        "DELETE FROM usergroup_to_query WHERE usergroup_id = $1;",
         [TEST_GROUP_ID],
       );
       await dbClient.query("DELETE FROM usergroup WHERE id = $1;", [
@@ -51,6 +67,7 @@ describe("User Group Membership Tests", () => {
         TEST_USER_1_ID,
         TEST_USER_2_ID,
       ]);
+      await dbClient.query("DELETE FROM query WHERE id = $1;", [TEST_QUERY_ID]);
       await dbClient.query("ROLLBACK");
     } catch (error) {
       console.error("Rollback failed:", error);
@@ -162,26 +179,82 @@ describe("User Group Membership Tests", () => {
     ).toBe(false);
   });
 
-  test("should return empty array when adding users with empty list", async () => {
-    const result = await addUsersToGroup(TEST_GROUP_ID, []);
+  /**
+   * Tests adding queries to a user group.
+   */
+  test("should add queries to a group", async () => {
+    const result = await addQueriesToGroup(TEST_GROUP_ID, [TEST_QUERY_ID]);
+    expect(result).toContain(TEST_QUERY_ID);
+    expect(result.length).toBe(1);
+
+    const updatedQueries: Query[] =
+      await getQueriesWithGroupStatus(TEST_GROUP_ID);
+    const members = updatedQueries.filter((query) =>
+      query.userGroupMemberships?.some((m) => m.is_member),
+    );
+
+    expect(members.length).toBe(1);
+    expect(members.some((query) => query.id === TEST_QUERY_ID)).toBe(true);
+    expect(members.some((query) => query.name === "Test Query")).toBe(true);
+  });
+
+  /**
+   * Tests removing queries from a user group.
+   */
+  test("should remove queries from a group", async () => {
+    const result = await removeQueriesFromGroup(TEST_GROUP_ID, [TEST_QUERY_ID]);
+    expect(result).toContain(TEST_QUERY_ID);
+
+    const updatedQueries = await getQueriesWithGroupStatus(TEST_GROUP_ID);
+    const members = updatedQueries.filter((query) =>
+      query.userGroupMemberships?.some((m) => m.is_member),
+    );
+
+    expect(members.length).toBe(0);
+  });
+
+  /**
+   * Tests saving query group memberships.
+   */
+  test("should correctly update query group memberships", async () => {
+    const selectedQueries = [TEST_QUERY_ID];
+
+    const updatedQueries = await saveQueryGroupMembership(
+      TEST_GROUP_ID,
+      selectedQueries,
+    );
+
+    expect(
+      updatedQueries.some(
+        (query) =>
+          query.id === TEST_QUERY_ID &&
+          query.userGroupMemberships?.some((m) => m.is_member),
+      ),
+    ).toBe(true);
+  });
+
+  test("should return empty array when adding queries with empty list", async () => {
+    const result = await addQueriesToGroup(TEST_GROUP_ID, []);
     expect(result).toEqual([]);
   });
 
-  test("should return empty array when removing users with empty list", async () => {
-    const result = await removeUsersFromGroup(TEST_GROUP_ID, []);
+  test("should return empty array when removing queries with empty list", async () => {
+    const result = await removeQueriesFromGroup(TEST_GROUP_ID, []);
     expect(result).toEqual([]);
   });
 
-  test("should not remove non-existent user from group", async () => {
-    const INVALID_USER_ID = "99999999-9999-9999-9999-999999999999";
-    const result = await removeUsersFromGroup(TEST_GROUP_ID, [INVALID_USER_ID]);
+  test("should not remove non-existent query from group", async () => {
+    const INVALID_QUERY_ID = "99999999-9999-9999-9999-999999999999";
+    const result = await removeQueriesFromGroup(TEST_GROUP_ID, [
+      INVALID_QUERY_ID,
+    ]);
 
     expect(result).toEqual([]);
   });
 
   test("should return empty result when querying a non-existent group", async () => {
     const INVALID_GROUP_ID = "99999999-9999-9999-9999-999999999999";
-    const result = await getUsersWithGroupStatus(INVALID_GROUP_ID);
+    const result = await getQueriesWithGroupStatus(INVALID_GROUP_ID);
 
     expect(result).toEqual([]);
   });

--- a/query-connector/src/app/tests/integration/usergroup-management.test.ts
+++ b/query-connector/src/app/tests/integration/usergroup-management.test.ts
@@ -15,6 +15,7 @@ const dbClient = getDbClient();
 
 jest.mock("@/app/utils/auth", () => ({
   superAdminAccessCheck: jest.fn(() => Promise.resolve(true)),
+  adminAccessCheck: jest.fn(() => Promise.resolve(true)),
 }));
 
 const TEST_GROUP_ID = "00000000-0000-0000-0000-000000000000";

--- a/query-connector/src/app/tests/integration/usergroup-management.test.ts
+++ b/query-connector/src/app/tests/integration/usergroup-management.test.ts
@@ -239,12 +239,9 @@ describe("User Group and Query Membership Tests", () => {
    * Tests saving query group memberships.
    */
   test("should correctly update query group memberships", async () => {
-    const selectedQueries = [TEST_QUERY_ID];
-
-    const updatedQueries = await saveQueryGroupMembership(
-      TEST_GROUP_ID,
-      selectedQueries,
-    );
+    const updatedQueries = await saveQueryGroupMembership(TEST_GROUP_ID, [
+      TEST_QUERY_ID,
+    ]);
 
     expect(
       updatedQueries.some(

--- a/query-connector/src/app/utils/auth.test.ts
+++ b/query-connector/src/app/utils/auth.test.ts
@@ -1,0 +1,154 @@
+import { auth } from "@/auth";
+import { User } from "next-auth";
+import { getUserRole } from "@/app/backend/user-management";
+import { RoleTypeValues } from "@/app/models/entities/user-management";
+import {
+  isDemoMode,
+  isAuthDisabledClientCheck,
+  isAuthDisabledServerCheck,
+  getLoggedInUser,
+  superAdminAccessCheck,
+  adminAccessCheck,
+} from "@/app/utils/auth";
+
+jest.mock("@/auth", () => ({
+  auth: jest.fn(),
+}));
+
+jest.mock("@/app/backend/user-management", () => ({
+  getUserRole: jest.fn(),
+}));
+
+const TEST_USER: User = {
+  id: "test-user-id",
+  username: "testuser",
+  email: "testuser@example.com",
+  name: "Test User",
+};
+
+/**
+ * Tests for environment-based authentication settings
+ */
+describe("Authentication Utilities", () => {
+  afterEach(() => {
+    jest.resetModules();
+    delete process.env.DEMO_MODE;
+    delete process.env.AUTH_DISABLED;
+  });
+
+  /**
+   * Tests for isDemoMode()
+   */
+  test("should return true if DEMO_MODE is enabled", () => {
+    process.env.DEMO_MODE = "true";
+    expect(isDemoMode()).toBe(true);
+  });
+
+  test("should return false if DEMO_MODE is not set", () => {
+    expect(isDemoMode()).toBe(false);
+  });
+
+  /**
+   * Tests for isAuthDisabledClientCheck()
+   */
+  test("should return true if AUTH_DISABLED is enabled on the client", () => {
+    const runtimeConfig = { AUTH_DISABLED: "true" };
+    expect(isAuthDisabledClientCheck(runtimeConfig)).toBe(true);
+  });
+
+  test("should return false if AUTH_DISABLED is not set on the client", () => {
+    expect(isAuthDisabledClientCheck(undefined)).toBe(false);
+  });
+
+  /**
+   * Tests for isAuthDisabledServerCheck()
+   */
+  test("should return true if AUTH_DISABLED is enabled on the server", () => {
+    process.env.AUTH_DISABLED = "true";
+    expect(isAuthDisabledServerCheck()).toBe(true);
+  });
+
+  test("should return false if AUTH_DISABLED is not set on the server", () => {
+    expect(isAuthDisabledServerCheck()).toBe(false);
+  });
+
+  /**
+   * Tests for getLoggedInUser()
+   */
+  test("should return user object if user is authenticated", async () => {
+    (auth as jest.Mock).mockResolvedValue({ user: TEST_USER });
+    const user = await getLoggedInUser();
+    expect(user).toEqual(TEST_USER);
+  });
+
+  test("should return undefined if no user is authenticated", async () => {
+    (auth as jest.Mock).mockResolvedValue(null);
+    const user = await getLoggedInUser();
+    expect(user).toBeUndefined();
+  });
+
+  /**
+   * Tests for superAdminAccessCheck()
+   */
+  describe("superAdminAccessCheck", () => {
+    test("should return true if AUTH_DISABLED is enabled", async () => {
+      process.env.AUTH_DISABLED = "true";
+      expect(await superAdminAccessCheck()).toBe(true);
+    });
+
+    test("should return true if user is a super admin", async () => {
+      (auth as jest.Mock).mockResolvedValue({ user: TEST_USER });
+      (getUserRole as jest.Mock).mockResolvedValue(RoleTypeValues.SuperAdmin);
+
+      expect(await superAdminAccessCheck()).toBe(true);
+    });
+
+    test("should return false if user is not a super admin", async () => {
+      (auth as jest.Mock).mockResolvedValue({ user: TEST_USER });
+      (getUserRole as jest.Mock).mockResolvedValue(RoleTypeValues.Standard);
+
+      expect(await superAdminAccessCheck()).toBe(false);
+    });
+
+    test("should return false if no user is logged in", async () => {
+      (auth as jest.Mock).mockResolvedValue(null);
+      expect(await superAdminAccessCheck()).toBe(false);
+    });
+  });
+
+  /**
+   * Tests for adminAccessCheck()
+   */
+  describe("adminAccessCheck", () => {
+    test("should return true if AUTH_DISABLED is enabled", async () => {
+      process.env.AUTH_DISABLED = "true";
+      expect(await adminAccessCheck()).toBe(true);
+    });
+
+    test("should return true if user is an admin", async () => {
+      (auth as jest.Mock).mockResolvedValue({ user: TEST_USER });
+      (getUserRole as jest.Mock).mockResolvedValue(RoleTypeValues.Admin);
+
+      expect(await adminAccessCheck()).toBe(true);
+    });
+
+    test("should return true if user is a super admin", async () => {
+      (auth as jest.Mock).mockResolvedValue({ user: TEST_USER });
+      (getUserRole as jest.Mock).mockResolvedValue(RoleTypeValues.SuperAdmin);
+
+      expect(await adminAccessCheck()).toBe(true);
+    });
+
+    test("should return false if user is not an admin or super admin", async () => {
+      (auth as jest.Mock).mockResolvedValue({ user: TEST_USER });
+      (getUserRole as jest.Mock).mockResolvedValue(RoleTypeValues.Standard);
+
+      expect(await adminAccessCheck()).toBe(false);
+    });
+
+    test("should return false if no user is logged in", async () => {
+      (auth as jest.Mock).mockResolvedValue(null);
+      expect(await adminAccessCheck()).toBe(false);
+    });
+  });
+});


### PR DESCRIPTION
# PULL REQUEST

## Summary

This adds the functions for adding/deleting queries from a user group. It follows the same structure as the work to add/remove Users. Also adds some additional tests.

## Related Issue

Fixes #374 

## Additional Information
Having some trouble addressing the issues raised in the testing suite; I added tests for admin and superadmin tests, thinking that that should suppress/remove the need for us to constantly check for each unauthorized test. Not sure if there's a better way to do this, or if it's just easier to add a test for each of these functions.

I'm not sure if that's what it's all treating the get status functions as untested? I wish there was a little more guidance as to what was wrong here 😕 .

## Checklist

- [ ] Descriptive Pull Request title
- [ ] Link to relevant issues
- [ ] Provide necessary context for design reviewers
- [ ] Ensure test coverage is above agreed upon threshold
- [ ] Update documentation
