### PR TITLE
Aidbox local hotfix

### DIFF
--- a/query-connector/docker-compose-dev.yaml
+++ b/query-connector/docker-compose-dev.yaml
@@ -80,7 +80,7 @@ services:
     depends_on:
       - aidbox_db
     ports:
-      - 8080:8080
+      - 8082:8082
     environment:
       AIDBOX_TERMINOLOGY_SERVICE_BASE_URL: https://tx.fhir.org/r4
       AIDBOX_FHIR_PACKAGES: hl7.fhir.r4.core#4.0.1
@@ -96,7 +96,7 @@ services:
       BOX_COMPATIBILITY_VALIDATION_JSON__SCHEMA_REGEX: "#{:fhir-datetime}"
       BOX_SEARCH_AUTHORIZE_INLINE_REQUESTS: true
       PGUSER: aidbox
-      AIDBOX_PORT: 8080
+      AIDBOX_PORT: 8082
       PGDATABASE: aidbox
       PGPASSWORD: gOxAmiyiz4
       PGPORT: "5432"

--- a/query-connector/src/app/shared/constants.ts
+++ b/query-connector/src/app/shared/constants.ts
@@ -46,7 +46,8 @@ export type DemoDataFields = {
   FhirServer: string;
 };
 
-export const DEFAULT_DEMO_FHIR_SERVER = "Aidbox";
+// TODO: switch this back after we add proper seeding for local
+export const DEFAULT_DEMO_FHIR_SERVER = "Public HAPI: Direct"; // "Aidbox";
 /*
  * Common "Hyper Unlucky" patient data used for all non-newborn screening use cases
  */


### PR DESCRIPTION
Hotfix for Aidbox port conflict issue until we can put together the local seeding script.

Temporarily
- Switches default back to Public HAPI
- Adds Aidbox to the dump file (without a functioning URL, so the Aidbox dropdown option won't work) as well as updates the dumpfile with the new user management tables
    - The seeding script should replace this once it's working properly 
- Swaps the port setup in local dev to 8082 to not conflict with Public HAPI / Keycloak