### PR TITLE
fix for QUE-136 fix edit queries

### DIFF
--- a/query-connector/playwright.config.ts
+++ b/query-connector/playwright.config.ts
@@ -18,7 +18,7 @@ export default defineConfig({
   forbidOnly: !!process.env.CI,
   /* Retry on CI only */
   retries: process.env.CI ? 2 : 2,
-  workers: process.env.CI ? 2 : 2,
+  workers: 1,
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */
   reporter: "html",
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */

--- a/query-connector/src/app/(pages)/queryBuilding/buildFromTemplates/BuildFromTemplates.test.tsx
+++ b/query-connector/src/app/(pages)/queryBuilding/buildFromTemplates/BuildFromTemplates.test.tsx
@@ -266,13 +266,13 @@ describe("tests the valueset selection page interactions", () => {
       screen.getByTestId(`condition-drawer-added-${CANCER_ID}`),
     ).toBeInTheDocument();
     // click out of the drawer
-    await user.click(screen.getByTestId(`${CANCER_ID}-conditionCard`));
+    await user.click(screen.getByTestId(`${CANCER_ID}-conditionCard-active`));
 
     expect(
-      screen.getByTestId(`${CANCER_ID}-conditionCard`),
+      screen.getByTestId(`${CANCER_ID}-conditionCard-active`),
     ).toBeInTheDocument();
     expect(
-      screen.getByTestId(`${GONORREHEA_ID}-conditionCard-active`),
+      screen.getByTestId(`${GONORREHEA_ID}-conditionCard`),
     ).toBeInTheDocument();
   });
 

--- a/query-connector/src/app/(pages)/queryBuilding/components/ValueSetSelection.tsx
+++ b/query-connector/src/app/(pages)/queryBuilding/components/ValueSetSelection.tsx
@@ -64,7 +64,7 @@ export const ValueSetSelection: React.FC<ConditionSelectionProps> = ({
   useEffect(() => {
     // display the first condition's valuesets on render
     setActiveCondition(Object.keys(constructedQuery)[0]);
-  }, []);
+  }, [constructedQuery]);
 
   function generateConditionDrawerDisplay(
     categoryToConditionsMap: CategoryToConditionArrayMap,
@@ -85,6 +85,7 @@ export const ValueSetSelection: React.FC<ConditionSelectionProps> = ({
               <div
                 key={`update-${condition.id}`}
                 id={`update-${condition.id}`}
+                data-testid={`update-${condition.id}`}
                 className={styles.conditionItem}
               >
                 <span>
@@ -160,6 +161,7 @@ export const ValueSetSelection: React.FC<ConditionSelectionProps> = ({
               <div
                 className={styles.addCondition}
                 role="button"
+                data-testid={"add-condition-icon"}
                 onClick={() => setIsDrawerOpen(true)}
                 tabIndex={0}
               >
@@ -202,6 +204,7 @@ export const ValueSetSelection: React.FC<ConditionSelectionProps> = ({
                     className={classNames("usa-icon", styles.deleteIcon)}
                     size={5}
                     color="red"
+                    data-testid={`delete-condition-${conditionId}`}
                     aria-label="Trash icon indicating deletion of disease"
                     onClick={() => {
                       handleUpdateCondition(conditionId, true);

--- a/query-connector/src/app/(pages)/queryBuilding/querySelection/QueryLibrary.tsx
+++ b/query-connector/src/app/(pages)/queryBuilding/querySelection/QueryLibrary.tsx
@@ -60,7 +60,7 @@ export const MyQueriesDisplay: React.FC<UserQueriesDisplayProps> = ({
       queryName: queryName,
       queryId: queryId,
     });
-    setBuildStep("condition");
+    setBuildStep("valueset");
   };
 
   useEffect(() => {


### PR DESCRIPTION
## Summary

Addresses the extra page issue logged [here](https://linear.app/skylight-cdc/issue/QUE-136/editing-a-query-should-take-you-to-the-query-not-the-checklist) and removes the intermediary step before actually editing a query in a user's "my queries" page when logged in to QC. 

## Related Issue

Fixes #136 

## Checklist

- [x] Descriptive Pull Request title
- [x] Link to relevant issues
- [x] Provide necessary context for design reviewers
- [ ] Ensure test coverage is above agreed upon threshold
- [ ] Update documentation
