### PR TITLE
Setup session refresh in session provider

### DIFF
--- a/query-connector/src/app/(pages)/query/page.tsx
+++ b/query-connector/src/app/(pages)/query/page.tsx
@@ -13,6 +13,7 @@ import { DataContext } from "@/app/shared/DataProvider";
 import { Patient } from "fhir/r4";
 import { getFhirServerNames } from "@/app/backend/dbServices/fhir-servers";
 import { CustomUserQuery } from "@/app/models/entities/query";
+import WithAuth from "@/app/ui/components/withAuth/WithAuth";
 
 const blankUserQuery = {
   query_id: "",
@@ -69,7 +70,7 @@ const Query: React.FC = () => {
     results: "main-container__wide",
   };
   return (
-    <>
+    <WithAuth>
       {Object.keys(CUSTOMIZE_QUERY_STEPS).includes(mode) &&
         !showCustomizeQuery && (
           <StepIndicator
@@ -135,7 +136,7 @@ const Query: React.FC = () => {
           />
         )}
       </div>
-    </>
+    </WithAuth>
   );
 };
 

--- a/query-connector/src/app/shared/DataProvider.tsx
+++ b/query-connector/src/app/shared/DataProvider.tsx
@@ -6,6 +6,8 @@ import { PageType } from "./constants";
 import { ToastConfigOptions } from "../ui/designSystem/toast/Toast";
 import { Session } from "next-auth";
 
+const REFRESH_INTERVAL_MINS = 15;
+
 export interface DataContextValue {
   data: unknown; // You can define a specific data type here
   setData: (data: unknown) => void;
@@ -58,7 +60,12 @@ export function DataProvider({
         runtimeConfig,
       }}
     >
-      <SessionProvider session={session}>{children}</SessionProvider>
+      <SessionProvider
+        session={session}
+        refetchInterval={REFRESH_INTERVAL_MINS * 60000}
+      >
+        {children}
+      </SessionProvider>
     </DataContext.Provider>
   );
 }

--- a/query-connector/src/app/shared/DataProvider.tsx
+++ b/query-connector/src/app/shared/DataProvider.tsx
@@ -62,7 +62,7 @@ export function DataProvider({
     >
       <SessionProvider
         session={session}
-        refetchInterval={REFRESH_INTERVAL_MINS * 60000}
+        refetchInterval={REFRESH_INTERVAL_MINS * 60}
       >
         {children}
       </SessionProvider>

--- a/query-connector/src/auth.ts
+++ b/query-connector/src/auth.ts
@@ -67,18 +67,16 @@ export const { handlers, signIn, signOut, auth } = NextAuth({
           console.error("Something went wrong in generating user token", error);
         }
 
-        if (userToken.username !== "") {
-          if (isAuthDisabledServerCheck()) {
-            userToken.role = UserRole.SUPER_ADMIN;
-          } else {
-            const role = await getUserRole(
-              userToken.username as string,
-            ).catch();
-            userToken.role = role;
-          }
-        }
-
         return { ...token, ...userToken };
+      }
+
+      if (token.username !== "") {
+        if (isAuthDisabledServerCheck()) {
+          token.role = UserRole.SUPER_ADMIN;
+        } else {
+          const role = await getUserRole(token.username as string).catch();
+          token.role = role;
+        }
       }
 
       return token;
@@ -101,6 +99,7 @@ export const { handlers, signIn, signOut, auth } = NextAuth({
         emailVerified: null,
         role: typeof token.role === "string" ? token.role : "",
       };
+
       return session;
     },
   },


### PR DESCRIPTION
# PULL REQUEST

## Summary
One of the gaps identified in our current session implementation was that updates to a user's role were not propagated to the frontend pages. This is mainly due to the SPA nature of the query connector app in which the session object is retrieved from the server only on first load and then stored in the browser memory. All other access after that point are done towards the session copy in memory so updates to a user were not available by default.

This PR introduces code to keep the session object in the browser in sync with the server and it uses the `SessionProvider -> refetchInterval` feature available in `next-auth/react`. The library will make an HTTP request to the server in the interval defined (in our case it has been set to 15 mins) and will refresh the session object in the browser memory. This refresh will propagate to all the pages and components in the same way that any changes to a provider is handle in react. After the changes are propagated all pages and components will be updated to reflect the new user access level.

To ensure the role field in the session object  is current the `jwt` callback in the auth setup file  has been modified to access the role from the DB when responding to all requests to the API `/api/auth/session`.

## Related Issue

Fixes # 

## Additional Information

Remember that the DAL already has checks and blocks in place so at this moment a user that gets their privileges downgraded is unable to retrieve and modify data outside their auth boundaries. This work is tackling updates in the interfaces that right now try to obtain data but fail.

## Checklist

- [ ] Descriptive Pull Request title
- [ ] Link to relevant issues
- [ ] Provide necessary context for design reviewers
- [ ] Ensure test coverage is above agreed upon threshold
- [ ] Update documentation
