### PR TITLE
jd/202 setup test accounts for local an dev

### DIFF
--- a/query-connector/flyway/sql/V08_01__drop_user_management_table.sql
+++ b/query-connector/flyway/sql/V08_01__drop_user_management_table.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS user_management;

--- a/query-connector/keycloak/dev.json
+++ b/query-connector/keycloak/dev.json
@@ -473,6 +473,87 @@
   "webAuthnPolicyPasswordlessExtraOrigins": [],
   "users": [
     {
+      "id": "3295c949-ddd4-484c-b1ac-904484e72d7f",
+      "username": "mario",
+      "firstName": "Mario",
+      "lastName": "Mario",
+      "emailVerified": true,
+      "createdTimestamp": 1742398946534,
+      "enabled": true,
+      "totp": false,
+      "credentials": [
+        {
+          "id": "5ba5f7ee-b1ce-4969-814e-0c4b2dc5f3ec",
+          "type": "password",
+          "userLabel": "My password",
+          "createdDate": 1742398959892,
+          "secretData": "{\"value\":\"vHe/0T6rE+6tPtQaeWpbv0qMZJBqkiW4Dj9YtDsRS2g=\",\"salt\":\"+1StaWt5e8GT3b+sycysyw==\",\"additionalParameters\":{}}",
+          "credentialData": "{\"hashIterations\":5,\"algorithm\":\"argon2\",\"additionalParameters\":{\"hashLength\":[\"32\"],\"memory\":[\"7168\"],\"type\":[\"id\"],\"version\":[\"1.3\"],\"parallelism\":[\"1\"]}}"
+        }
+      ],
+      "disableableCredentialTypes": [],
+      "requiredActions": [],
+      "realmRoles": [
+        "default-roles-master"
+      ],
+      "notBefore": 0,
+      "groups": []
+    },
+    {
+      "id": "ab29205c-5a84-49ed-8f60-5b7c2cd1575c",
+      "username": "peach",
+      "firstName": "Princess",
+      "lastName": "Peach",
+      "emailVerified": true,
+      "createdTimestamp": 1742398897969,
+      "enabled": true,
+      "totp": false,
+      "credentials": [
+        {
+          "id": "3368ea8a-96ae-463f-ac94-f7d6063b1000",
+          "type": "password",
+          "userLabel": "My password",
+          "createdDate": 1742398909496,
+          "secretData": "{\"value\":\"WrWIzPPGQQD3OJhaH5UbhVbCBOlXuUx9wkzLKtjO2p8=\",\"salt\":\"OObODYLOFzabgRoCis3GkA==\",\"additionalParameters\":{}}",
+          "credentialData": "{\"hashIterations\":5,\"algorithm\":\"argon2\",\"additionalParameters\":{\"hashLength\":[\"32\"],\"memory\":[\"7168\"],\"type\":[\"id\"],\"version\":[\"1.3\"],\"parallelism\":[\"1\"]}}"
+        }
+      ],
+      "disableableCredentialTypes": [],
+      "requiredActions": [],
+      "realmRoles": [
+        "default-roles-master"
+      ],
+      "notBefore": 0,
+      "groups": []
+    },
+    {
+      "id": "fe1c1448-e555-4bcc-a0d7-13970503a705",
+      "username": "toad",
+      "firstName": "Captain",
+      "lastName": "Toad",
+      "emailVerified": true,
+      "createdTimestamp": 1742398923041,
+      "enabled": true,
+      "totp": false,
+      "credentials": [
+        {
+          "id": "f6451e2e-e1da-4439-a3ae-09fa27207fa0",
+          "type": "password",
+          "userLabel": "My password",
+          "createdDate": 1742398933723,
+          "secretData": "{\"value\":\"qcsrP+smMu2563eL7mEIeYTwUA68bK31YJy+ohOek8g=\",\"salt\":\"mlmPcb4YSPOA53lVzIKWWQ==\",\"additionalParameters\":{}}",
+          "credentialData": "{\"hashIterations\":5,\"algorithm\":\"argon2\",\"additionalParameters\":{\"hashLength\":[\"32\"],\"memory\":[\"7168\"],\"type\":[\"id\"],\"version\":[\"1.3\"],\"parallelism\":[\"1\"]}}"
+        }
+      ],
+      "disableableCredentialTypes": [],
+      "requiredActions": [],
+      "realmRoles": [
+        "default-roles-master"
+      ],
+      "notBefore": 0,
+      "groups": []
+    },
+    {
       "id": "1c3b6114-3c12-4ef7-95ba-a0091f506ed6",
       "username": "qc-admin",
       "firstName": "QC",

--- a/query-connector/keycloak/localhost.json
+++ b/query-connector/keycloak/localhost.json
@@ -473,6 +473,87 @@
   "webAuthnPolicyPasswordlessExtraOrigins": [],
   "users": [
     {
+      "id": "3295c949-ddd4-484c-b1ac-904484e72d7f",
+      "username": "mario",
+      "firstName": "Mario",
+      "lastName": "Mario",
+      "emailVerified": true,
+      "createdTimestamp": 1742398946534,
+      "enabled": true,
+      "totp": false,
+      "credentials": [
+        {
+          "id": "5ba5f7ee-b1ce-4969-814e-0c4b2dc5f3ec",
+          "type": "password",
+          "userLabel": "My password",
+          "createdDate": 1742398959892,
+          "secretData": "{\"value\":\"vHe/0T6rE+6tPtQaeWpbv0qMZJBqkiW4Dj9YtDsRS2g=\",\"salt\":\"+1StaWt5e8GT3b+sycysyw==\",\"additionalParameters\":{}}",
+          "credentialData": "{\"hashIterations\":5,\"algorithm\":\"argon2\",\"additionalParameters\":{\"hashLength\":[\"32\"],\"memory\":[\"7168\"],\"type\":[\"id\"],\"version\":[\"1.3\"],\"parallelism\":[\"1\"]}}"
+        }
+      ],
+      "disableableCredentialTypes": [],
+      "requiredActions": [],
+      "realmRoles": [
+        "default-roles-master"
+      ],
+      "notBefore": 0,
+      "groups": []
+    },
+    {
+      "id": "ab29205c-5a84-49ed-8f60-5b7c2cd1575c",
+      "username": "peach",
+      "firstName": "Princess",
+      "lastName": "Peach",
+      "emailVerified": true,
+      "createdTimestamp": 1742398897969,
+      "enabled": true,
+      "totp": false,
+      "credentials": [
+        {
+          "id": "3368ea8a-96ae-463f-ac94-f7d6063b1000",
+          "type": "password",
+          "userLabel": "My password",
+          "createdDate": 1742398909496,
+          "secretData": "{\"value\":\"WrWIzPPGQQD3OJhaH5UbhVbCBOlXuUx9wkzLKtjO2p8=\",\"salt\":\"OObODYLOFzabgRoCis3GkA==\",\"additionalParameters\":{}}",
+          "credentialData": "{\"hashIterations\":5,\"algorithm\":\"argon2\",\"additionalParameters\":{\"hashLength\":[\"32\"],\"memory\":[\"7168\"],\"type\":[\"id\"],\"version\":[\"1.3\"],\"parallelism\":[\"1\"]}}"
+        }
+      ],
+      "disableableCredentialTypes": [],
+      "requiredActions": [],
+      "realmRoles": [
+        "default-roles-master"
+      ],
+      "notBefore": 0,
+      "groups": []
+    },
+    {
+      "id": "fe1c1448-e555-4bcc-a0d7-13970503a705",
+      "username": "toad",
+      "firstName": "Captain",
+      "lastName": "Toad",
+      "emailVerified": true,
+      "createdTimestamp": 1742398923041,
+      "enabled": true,
+      "totp": false,
+      "credentials": [
+        {
+          "id": "f6451e2e-e1da-4439-a3ae-09fa27207fa0",
+          "type": "password",
+          "userLabel": "My password",
+          "createdDate": 1742398933723,
+          "secretData": "{\"value\":\"qcsrP+smMu2563eL7mEIeYTwUA68bK31YJy+ohOek8g=\",\"salt\":\"mlmPcb4YSPOA53lVzIKWWQ==\",\"additionalParameters\":{}}",
+          "credentialData": "{\"hashIterations\":5,\"algorithm\":\"argon2\",\"additionalParameters\":{\"hashLength\":[\"32\"],\"memory\":[\"7168\"],\"type\":[\"id\"],\"version\":[\"1.3\"],\"parallelism\":[\"1\"]}}"
+        }
+      ],
+      "disableableCredentialTypes": [],
+      "requiredActions": [],
+      "realmRoles": [
+        "default-roles-master"
+      ],
+      "notBefore": 0,
+      "groups": []
+    },
+    {
       "id": "1c3b6114-3c12-4ef7-95ba-a0091f506ed6",
       "username": "qc-admin",
       "firstName": "QC",

--- a/query-connector/src/app/backend/user-management.ts
+++ b/query-connector/src/app/backend/user-management.ts
@@ -48,16 +48,6 @@ export async function addUserIfNotExists(userToken: {
     let qc_role = UserRole.STANDARD;
     console.log("User not found. Proceeding to insert.");
 
-    if (process.env.NODE_ENV !== "production") {
-      // First registered user is set as Super Admin
-      const queryUserRecordCount = `SELECT COUNT(*) FROM users`;
-      const userCount = await dbClient.query(queryUserRecordCount);
-
-      if (userCount?.rows?.[0]?.count === "0") {
-        qc_role = UserRole.SUPER_ADMIN;
-      }
-    }
-
     const insertUserQuery = `
       INSERT INTO users (username, qc_role, first_name, last_name)
       VALUES ($1, $2, $3, $4)


### PR DESCRIPTION
# PULL REQUEST

## Summary

This PR will create user accounts in keycloak and the respective entries in the `users`, `groups` and join tables to provide three more test users and two user groups.

**Users**
Princess Peach | peach | foo123! | Admin 
Mario Mario | mario | foo123! | Standard 
Captain Toad | toad | foo123! | Standard 

**Groups**
Castle Team -> Peach and Mario
Mushroom Team -> Toad
 
Changes include:
- Adds Peach, Mario and Toad to the keycloak seeding file for local and dev.
- Updates the vs_dump.sql file to include the entries in all the tables related to user management.
- Removed the logic that set the first logged in user as super admin.

## Related Issue

Fixes [QUE-202](https://linear.app/skylight-cdc/issue/QUE-202/create-test-users-for-dev-and-local-development)

## Additional Information

I went with the Mario theme because the users were super easy to spell and remember :D. 

## Checklist

- [ ] Descriptive Pull Request title
- [ ] Link to relevant issues
- [ ] Provide necessary context for design reviewers
- [ ] Ensure test coverage is above agreed upon threshold
- [ ] Update documentation
