### PR TITLE
Adding help text to category and condition data

### DIFF
--- a/query-connector/src/app/(pages)/queryBuilding/buildFromTemplates/ConditionColumnDisplay.tsx
+++ b/query-connector/src/app/(pages)/queryBuilding/buildFromTemplates/ConditionColumnDisplay.tsx
@@ -3,6 +3,7 @@ import {
   CategoryToConditionArrayMap,
   NestedQuery,
   filterSearchByCategoryAndCondition,
+  formatCategoryDisplay,
 } from "../utils";
 import styles from "./conditionTemplateSelection.module.scss";
 import ConditionOption from "./ConditionOption";
@@ -43,10 +44,6 @@ export const ConditionColumnDisplay: React.FC<ConditionColumnDisplayProps> = ({
     categoryToConditionsMap,
   );
 
-  const categoryDisplayMap: Record<string, string> = {
-    "Sexually Transmitted Diseases": "Sexually Transmitted Diseases (STI)",
-  };
-
   useEffect(() => {
     if (searchFilter === "") {
       setConditionsToDisplay(categoryToConditionsMap);
@@ -55,7 +52,6 @@ export const ConditionColumnDisplay: React.FC<ConditionColumnDisplayProps> = ({
       const filteredDisplay = filterSearchByCategoryAndCondition(
         searchFilter,
         categoryToConditionsMap,
-        categoryDisplayMap,
       );
       setConditionsToDisplay(filteredDisplay);
     }
@@ -97,7 +93,7 @@ export const ConditionColumnDisplay: React.FC<ConditionColumnDisplayProps> = ({
                   <div key={category}>
                     <h3 className={styles.categoryHeading}>
                       {" "}
-                      {categoryDisplayMap[category] || category}
+                      {formatCategoryDisplay(category)}
                     </h3>
                     {arr.map((c) => {
                       return (

--- a/query-connector/src/app/(pages)/queryBuilding/buildFromTemplates/ConditionColumnDisplay.tsx
+++ b/query-connector/src/app/(pages)/queryBuilding/buildFromTemplates/ConditionColumnDisplay.tsx
@@ -43,6 +43,10 @@ export const ConditionColumnDisplay: React.FC<ConditionColumnDisplayProps> = ({
     categoryToConditionsMap,
   );
 
+  const categoryDisplayMap: Record<string, string> = {
+    "Sexually Transmitted Diseases": "Sexually Transmitted Diseases (STI)",
+  };
+
   useEffect(() => {
     if (searchFilter === "") {
       setConditionsToDisplay(categoryToConditionsMap);
@@ -51,6 +55,7 @@ export const ConditionColumnDisplay: React.FC<ConditionColumnDisplayProps> = ({
       const filteredDisplay = filterSearchByCategoryAndCondition(
         searchFilter,
         categoryToConditionsMap,
+        categoryDisplayMap,
       );
       setConditionsToDisplay(filteredDisplay);
     }
@@ -90,7 +95,10 @@ export const ConditionColumnDisplay: React.FC<ConditionColumnDisplayProps> = ({
               {colsToDisplay.map(([category, arr]) => {
                 return (
                   <div key={category}>
-                    <h3 className={styles.categoryHeading}>{category}</h3>
+                    <h3 className={styles.categoryHeading}>
+                      {" "}
+                      {categoryDisplayMap[category] || category}
+                    </h3>
                     {arr.map((c) => {
                       return (
                         <ConditionOption

--- a/query-connector/src/app/(pages)/queryBuilding/components/ValueSetSelection.tsx
+++ b/query-connector/src/app/(pages)/queryBuilding/components/ValueSetSelection.tsx
@@ -9,6 +9,7 @@ import {
   ConditionsMap,
   filterSearchByCategoryAndCondition,
   formatDiseaseDisplay,
+  formatCategoryDisplay,
   NestedQuery,
 } from "../utils";
 import { ConceptTypeSelectionTable } from "./SelectionTable";
@@ -77,7 +78,7 @@ export const ValueSetSelection: React.FC<ConditionSelectionProps> = ({
               highlightClassName="searchHighlight"
               searchWords={[conditionSearchFilter]}
               autoEscape={true}
-              textToHighlight={category}
+              textToHighlight={formatCategoryDisplay(category)}
             ></Highlighter>
           </div>
           <div>

--- a/query-connector/src/app/(pages)/queryBuilding/utils.ts
+++ b/query-connector/src/app/(pages)/queryBuilding/utils.ts
@@ -52,24 +52,44 @@ export const EMPTY_CONCEPT_TYPE = {
 };
 
 /**
+ * Utility method to get a display name for a category (if overridden),
+ * or fall back to the raw name.
+ * @param categoryName - raw category name from backend
+ * @returns display name to show in UI
+ */
+export function formatCategoryDisplay(categoryName: string): string {
+  const categoryDisplayMap: Record<string, string> = {
+    "Sexually Transmitted Diseases": "Sexually Transmitted Diseases (STI)",
+  };
+  // Add more mappings as needed
+  return categoryDisplayMap[categoryName] || categoryName;
+}
+
+/**
  * Filtering function that checks filtering at the category and the condition level
  * @param filterString - string to filter by
  * @param fetchedConditions - unfiltered list of conditions fetched from the backend
  * @param categoryDisplayMap - display names for categories
  * @returns - The subset of fetched conditions that contain the filter string
  */
+/**
+ * Filtering function that checks filtering at the category and the condition level
+ * @param filterString - string to filter by
+ * @param fetchedConditions - unfiltered list of conditions fetched from the backend
+ * @returns - The subset of fetched conditions that contain the filter string
+ */
 export function filterSearchByCategoryAndCondition(
   filterString: string,
   fetchedConditions: CategoryToConditionArrayMap,
-  categoryDisplayMap: Record<string, string>,
 ): CategoryToConditionArrayMap {
   const result: CategoryToConditionArrayMap = {};
   const unfilteredConditions = structuredClone(fetchedConditions);
 
   Object.entries(unfilteredConditions).forEach(
     ([categoryName, conditionArray]) => {
-      const displayCategory = categoryDisplayMap[categoryName] || categoryName;
+      const displayCategory = formatCategoryDisplay(categoryName);
       const filter = filterString.toLowerCase();
+
       if (
         categoryName.toLowerCase().includes(filter) ||
         displayCategory.toLowerCase().includes(filter)

--- a/query-connector/src/app/(pages)/queryBuilding/utils.ts
+++ b/query-connector/src/app/(pages)/queryBuilding/utils.ts
@@ -55,26 +55,29 @@ export const EMPTY_CONCEPT_TYPE = {
  * Filtering function that checks filtering at the category and the condition level
  * @param filterString - string to filter by
  * @param fetchedConditions - unfiltered list of conditions fetched from the backend
+ * @param categoryDisplayMap - display names for categories
  * @returns - The subset of fetched conditions that contain the filter string
  */
 export function filterSearchByCategoryAndCondition(
   filterString: string,
   fetchedConditions: CategoryToConditionArrayMap,
+  categoryDisplayMap: Record<string, string>,
 ): CategoryToConditionArrayMap {
   const result: CategoryToConditionArrayMap = {};
   const unfilteredConditions = structuredClone(fetchedConditions);
 
   Object.entries(unfilteredConditions).forEach(
     ([categoryName, conditionArray]) => {
+      const displayCategory = categoryDisplayMap[categoryName] || categoryName;
+      const filter = filterString.toLowerCase();
       if (
-        categoryName
-          .toLocaleLowerCase()
-          .includes(filterString.toLocaleLowerCase())
+        categoryName.toLowerCase().includes(filter) ||
+        displayCategory.toLowerCase().includes(filter)
       ) {
-        result[categoryName] = unfilteredConditions[categoryName];
+        result[categoryName] = conditionArray;
       } else {
         const matches = conditionArray.filter((c) =>
-          c.name.toLocaleLowerCase().includes(filterString.toLocaleLowerCase()),
+          formatDiseaseDisplay(c.name).toLowerCase().includes(filter),
         );
         if (matches.length > 0) {
           result[categoryName] = matches;
@@ -93,6 +96,9 @@ export function filterSearchByCategoryAndCondition(
  * @returns A disease display string for display
  */
 export function formatDiseaseDisplay(diseaseName: string) {
+  if (diseaseName === "Human immunodeficiency virus infection (disorder)") {
+    return "Human immunodeficiency virus infection (HIV)";
+  }
   return diseaseName.replace("(disorder)", "").trim();
 }
 

--- a/query-connector/src/app/(pages)/queryBuilding/utils.ts
+++ b/query-connector/src/app/(pages)/queryBuilding/utils.ts
@@ -108,11 +108,15 @@ export function filterSearchByCategoryAndCondition(
  * @param diseaseName - name of the disease
  * @returns A disease display string for display
  */
-export function formatDiseaseDisplay(diseaseName: string) {
-  if (diseaseName === "Human immunodeficiency virus infection (disorder)") {
-    return "Human immunodeficiency virus infection (HIV)";
-  }
-  return diseaseName.replace("(disorder)", "").trim();
+export function formatDiseaseDisplay(diseaseName: string): string {
+  const diseaseDisplayMap: Record<string, string> = {
+    "Human immunodeficiency virus infection (disorder)":
+      "Human immunodeficiency virus infection (HIV)",
+  };
+  return (
+    diseaseDisplayMap[diseaseName] ||
+    diseaseName.replace("(disorder)", "").trim()
+  );
 }
 
 /**

--- a/query-connector/src/app/(pages)/queryBuilding/utils.ts
+++ b/query-connector/src/app/(pages)/queryBuilding/utils.ts
@@ -65,13 +65,7 @@ export function formatCategoryDisplay(categoryName: string): string {
   return categoryDisplayMap[categoryName] || categoryName;
 }
 
-/**
- * Filtering function that checks filtering at the category and the condition level
- * @param filterString - string to filter by
- * @param fetchedConditions - unfiltered list of conditions fetched from the backend
- * @param categoryDisplayMap - display names for categories
- * @returns - The subset of fetched conditions that contain the filter string
- */
+
 /**
  * Filtering function that checks filtering at the category and the condition level
  * @param filterString - string to filter by

--- a/query-connector/src/app/(pages)/queryBuilding/utils.ts
+++ b/query-connector/src/app/(pages)/queryBuilding/utils.ts
@@ -65,7 +65,6 @@ export function formatCategoryDisplay(categoryName: string): string {
   return categoryDisplayMap[categoryName] || categoryName;
 }
 
-
 /**
  * Filtering function that checks filtering at the category and the condition level
  * @param filterString - string to filter by


### PR DESCRIPTION
# PULL REQUEST

## Summary

Adds commonly-used abbreviations for category and condition names. 

For categories, this is done by adding `formatCategoryDisplay` to allow us to extend the names beyond those received by APHL with a new mapping.

For conditions, this is done by extending `formatDiseaseDisplay` to make specific changes based on need. Right now, this is just HIV.

This also uncovered a baby bug with our search, which was being done on the raw condition name. Many of the condition names in our data have a `(disorder)` appended to them, which we visually removed with `formatDiseaseDisplay`. However, when someone still searched "disorder", many results were still hit.

<img width="1040" alt="Screenshot 2025-04-04 at 9 58 30 AM" src="https://github.com/user-attachments/assets/a7aaf09b-37b7-4c14-96ec-f61f02d7d8f8" />
<img width="953" alt="Screenshot 2025-04-04 at 9 58 47 AM" src="https://github.com/user-attachments/assets/d88ddcf2-1249-4fe2-a64b-55ceeefa934d" />


## Related Issue

Fixes #479 

## Additional Information

Anything else the review team should know?

## Checklist

- [ ] Descriptive Pull Request title
- [ ] Link to relevant issues
- [ ] Provide necessary context for design reviewers
- [ ] Ensure test coverage is above agreed upon threshold
- [ ] Update documentation
