### PR TITLE
Moving from edge Aidboxone to stable Aidboxone

### DIFF
--- a/query-connector/.env.sample
+++ b/query-connector/.env.sample
@@ -11,3 +11,5 @@ NAMED_KEYCLOAK=http://localhost:8081
 ERSD_API_KEY=
 UMLS_API_KEY=
 AIDBOX_LICENSE=
+AIDBOX_BASE_URL=http://localhost:8080
+JAVA_TOOL_OPTIONS=-XX:UseSVE=0 # Leave empty is using M3, include for M1/4

--- a/query-connector/.env.sample
+++ b/query-connector/.env.sample
@@ -12,4 +12,4 @@ ERSD_API_KEY=
 UMLS_API_KEY=
 AIDBOX_LICENSE=
 AIDBOX_BASE_URL=http://localhost:8080
-JAVA_TOOL_OPTIONS=-XX:UseSVE=0 # Leave empty is using M3, include for M1/4
+JAVA_TOOL_OPTIONS=-XX:UseSVE=0 # Leave empty if using M3, include for M1/4

--- a/query-connector/docker-compose-dev.yaml
+++ b/query-connector/docker-compose-dev.yaml
@@ -59,7 +59,7 @@ services:
       POSTGRES_PASSWORD: gOxAmiyiz4
 
   aidbox:
-    image: healthsamurai/aidboxone:edge
+    image: healthsamurai/aidboxone:stable
     pull_policy: always
     depends_on:
       - aidbox_db
@@ -85,7 +85,7 @@ services:
       PGPASSWORD: gOxAmiyiz4
       PGPORT: "5432"
       BOX_SEARCH_INCLUDE_CONFORMANT: true
-      JAVA_TOOL_OPTIONS: "-XX:UseSVE=0"
+      JAVA_TOOL_OPTIONS: ${JAVA_TOOL_OPTIONS:-}
     env_file:
       - .env
   aidbox-seeder:

--- a/query-connector/docker-compose-e2e.yaml
+++ b/query-connector/docker-compose-e2e.yaml
@@ -38,7 +38,7 @@ services:
       POSTGRES_PASSWORD: gOxAmiyiz4
 
   aidbox:
-    image: healthsamurai/aidboxone:edge
+    image: healthsamurai/aidboxone:stable
     pull_policy: always
     depends_on:
       - aidbox_db

--- a/query-connector/docker-compose-integration.yaml
+++ b/query-connector/docker-compose-integration.yaml
@@ -41,7 +41,7 @@ services:
       POSTGRES_PASSWORD: gOxAmiyiz4
 
   aidbox:
-    image: healthsamurai/aidboxone:edge
+    image: healthsamurai/aidboxone:stable
     pull_policy: always
     depends_on:
       - aidbox_db


### PR DESCRIPTION
# PULL REQUEST

## Summary

M3 still has an issue where a fatal error will occur with `JAVA_TOOL_OPTIONS=-XX:UseSVE=0`. There was also an issue with my machine building the edge version of the image, but did not have any with stable. So I rolled back the images to stable for...stability.

The main update to confirm for M1 and M4 users is that adding this: `JAVA_TOOL_OPTIONS=-XX:UseSVE=0` to your `.env` file should be sufficient to still start up `npm run dev` with Aidbox available.

Please let me know if this works.

## Related Issue

Fixes #

## Additional Information

Anything else the review team should know?

## Checklist

- [ ] Descriptive Pull Request title
- [ ] Link to relevant issues
- [ ] Provide necessary context for design reviewers
- [ ] Ensure test coverage is above agreed upon threshold
- [ ] Update documentation
