### PR TITLE
Adding audit log hash update

### DIFF
--- a/query-connector/src/app/tests/integration/audit-logging.test.ts
+++ b/query-connector/src/app/tests/integration/audit-logging.test.ts
@@ -164,7 +164,5 @@ describe("audit log", () => {
       parsedMessage,
       new Date(latestAudit.created_at).toISOString(),
     );
-
-    expect(latestAudit.audit_checksum).toBe(recomputedChecksum);
   });
 });

--- a/query-connector/src/app/tests/integration/audit-logging.test.ts
+++ b/query-connector/src/app/tests/integration/audit-logging.test.ts
@@ -106,6 +106,8 @@ describe("audit log", () => {
     expect(addedVal[0]?.audit_message).toStrictEqual({
       request: JSON.stringify(request),
     });
+
+    expect(addedVal[0]?.audit_checksum).toMatch(/^[a-f0-9]{64}$/);
   });
 
   it("an audited function should  retries successfully", async () => {

--- a/query-connector/src/app/tests/integration/audit-logging.test.ts
+++ b/query-connector/src/app/tests/integration/audit-logging.test.ts
@@ -164,5 +164,6 @@ describe("audit log", () => {
       parsedMessage,
       new Date(latestAudit.created_at).toISOString(),
     );
+    expect(latestAudit.audit_checksum).toBe(recomputedChecksum);
   });
 });

--- a/query-connector/src/app/tests/integration/audit-logging.test.ts
+++ b/query-connector/src/app/tests/integration/audit-logging.test.ts
@@ -138,4 +138,33 @@ describe("audit log", () => {
     await new Promise((r) => setTimeout(r, 6000));
     expect(auditGenerationSpy).toHaveBeenCalledTimes(AUDIT_LOG_MAX_RETRIES);
   }, 10000);
+
+  it("should generate the correct checksum based on stored message and timestamp", async () => {
+    const auditQuery =
+      "SELECT * FROM audit_logs ORDER BY created_at DESC LIMIT 1;";
+    const result = await dbClient.query(auditQuery);
+
+    if (!result || !result.rows || result.rows.length === 0) {
+      throw new Error(
+        "No audit logs found. Ensure an audited action ran before this test.",
+      );
+    }
+
+    const latestAudit = result.rows[0];
+
+    expect(latestAudit.audit_checksum).toMatch(/^[a-f0-9]{64}$/);
+
+    const parsedMessage =
+      typeof latestAudit.audit_message === "string"
+        ? JSON.parse(latestAudit.audit_message)
+        : latestAudit.audit_message;
+
+    const recomputedChecksum = DecoratorUtils.generateAuditChecksum(
+      latestAudit.author,
+      parsedMessage,
+      new Date(latestAudit.created_at).toISOString(),
+    );
+
+    expect(latestAudit.audit_checksum).toBe(recomputedChecksum);
+  });
 });


### PR DESCRIPTION
# PULL REQUEST

## Summary

This adds a hashing function to the audit log table that conducts an update of the audit log role.

The other option to do this would be to INSERT the datetime, as opposed to relying on postgres' NOW() function. We need the datetime for the checksum, and I was concerned that the slight differences in using a datetime computed by the function and one by postgres could lead to small deltas in time. It might be okay if there's a millisecond difference, though...not sure.

## Related Issue

Fixes #476 

## Additional Information

Anything else the review team should know?

## Checklist

- [ ] Descriptive Pull Request title
- [ ] Link to relevant issues
- [ ] Provide necessary context for design reviewers
- [ ] Ensure test coverage is above agreed upon threshold
- [ ] Update documentation
