### PR TITLE
Streamline modal styles

### DIFF
--- a/query-connector/src/app/(pages)/userManagement/components/userModal/userModal.tsx
+++ b/query-connector/src/app/(pages)/userManagement/components/userModal/userModal.tsx
@@ -418,7 +418,7 @@ const UserModal: React.FC<UserModalProps> = ({
         text: ModalStates[modalMode].secondaryBtnText,
         type: "button" as const,
         id: "modal-back-button",
-        className: "usa-button",
+        className: "usa-button usa-button--outline shadow-none",
         onClick: async () =>
           setModalMode(ModalStates[modalMode].prevStep || "closed"),
       },

--- a/query-connector/src/app/ui/components/sessionTimeout/sessionTimeout.tsx
+++ b/query-connector/src/app/ui/components/sessionTimeout/sessionTimeout.tsx
@@ -88,12 +88,9 @@ const SessionTimeout: React.FC<SessionTimeoutProps> = ({
   useEffect(() => {
     // trigger expired token timer
     if (expiresBeforeIdle && expTimerId.current == null) {
-      expTimerId.current = setTimeout(
-        async () => {
-          await handleLogout();
-        },
-        data?.expiresIn,
-      );
+      expTimerId.current = setTimeout(async () => {
+        await handleLogout();
+      }, data?.expiresIn);
     }
 
     if (!started && status === "authenticated") {

--- a/query-connector/src/app/ui/components/sessionTimeout/sessionTimeout.tsx
+++ b/query-connector/src/app/ui/components/sessionTimeout/sessionTimeout.tsx
@@ -88,9 +88,12 @@ const SessionTimeout: React.FC<SessionTimeoutProps> = ({
   useEffect(() => {
     // trigger expired token timer
     if (expiresBeforeIdle && expTimerId.current == null) {
-      expTimerId.current = setTimeout(async () => {
-        await handleLogout();
-      }, data?.expiresIn);
+      expTimerId.current = setTimeout(
+        async () => {
+          await handleLogout();
+        },
+        data?.expiresIn,
+      );
     }
 
     if (!started && status === "authenticated") {

--- a/query-connector/src/app/ui/designSystem/modal/Modal.tsx
+++ b/query-connector/src/app/ui/designSystem/modal/Modal.tsx
@@ -70,7 +70,7 @@ export const Modal: React.FC<ModalProps> = ({
       aria-describedby={`${id}-modal-description`}
       isLarge={isLarge}
       forceAction={forceAction}
-      className={classNames("padding-x-2", className)}
+      className={classNames("qc-modal", className)}
     >
       <ModalHeading id={`${id}-modal-heading`}>{heading}</ModalHeading>
       <div id={`${id}-modal-description`} className="usa-prose">

--- a/query-connector/src/app/ui/designSystem/modal/deleteModal.tsx
+++ b/query-connector/src/app/ui/designSystem/modal/deleteModal.tsx
@@ -37,6 +37,7 @@ export const DeleteModal: React.FC<DeleteModalProps> = ({
       description={description}
       buttons={[
         {
+          id: "modal-delete-button",
           text: "Delete",
           type: "button",
           className: "usa-button--secondary",
@@ -46,9 +47,10 @@ export const DeleteModal: React.FC<DeleteModalProps> = ({
           },
         },
         {
+          id: "modal-cancel-button",
           text: "Cancel",
           type: "button",
-          className: "usa-button--outline",
+          className: "usa-button--outline shadow-none",
           onClick: () => {
             if (onCancel) onCancel();
             modalRef.current?.toggleModal();

--- a/query-connector/src/app/ui/styles/custom-styles.scss
+++ b/query-connector/src/app/ui/styles/custom-styles.scss
@@ -380,33 +380,6 @@ ul.usa-sidenav > li.usa-sidenav__item > ul.usa-sidenav__sublist > li.usa-sidenav
   background-color: white;
 }
 
-.usa-modal--lg {
-  background-color: #edeff0;
-  padding-top: 0;
-}
-
-.usa-modal__content {
-  padding-left: 0.5rem;
-  padding-right: 0.5rem;
-}
-
-.usa-modal__main {
-  margin: 0 auto;
-  padding-top: 0 !important;
-  padding-left: 0 !important;
-  padding-right: 0 !important;
-  padding-bottom: 2rem !important;
-}
-
-.usa-modal__heading {
-  font-family: "Public Sans", sans-serif !important;
-  font-size: 1.219rem !important;
-  font-style: normal;
-  font-weight: 700;
-  line-height: normal;
-  margin-bottom: 1rem;
-}
-
 .usa-pagination .usa-current {
   background-color: white;
   border-color: rgba(27, 27, 27, 0.2);
@@ -550,105 +523,37 @@ ul.usa-sidenav > li.usa-sidenav__item > ul.usa-sidenav__sublist > li.usa-sidenav
   font-size: 0.875rem;
 }
 
-#fhir-server-modal {
-  .usa-modal__close {
-    background-color: transparent !important;
-  }
-
-  .usa-modal__heading {
-    color: #000;
-    font-family: Merriweather !important;
-    font-size: 32px !important;
-    font-style: normal;
-    font-weight: 700;
-    line-height: normal;
-  }
-
-  .usa-modal--lg {
-    max-width: 40rem;
-
-    .usa-modal__main {
-      max-width: 34rem;
-
-      input,
-      select {
-        max-width: 100%;
-      }
-    }
-  }
-
-  .usa-button-group {
-    flex-direction: row-reverse;
-
-    .usa-button-group__item:last-child {
-      margin-right: 0.25rem;
-    }
-
-    .usa-button--secondary {
-      background-color: #d83933 !important;
-    }
-
-    #modal-cancel-button {
-      background-color: transparent;
-
-      &:hover {
-        box-shadow: none;
-      }
-    }
-
-    .usa-button-group__item:has(> #modal-delete-button) {
-      flex: 1 1 0%;
-    }
-  }
-
-  .usa-checkbox {
-    background-color: transparent;
-  }
-}
-
-#user-mgmt-modal {
-  .usa-modal {
-    border-radius: 0;
-    max-width: 31rem;
-    padding: 0 2rem;
-  }
+.qc-modal {
+  padding: 0 2rem !important;
+  max-width: 31rem;
 
   .usa-modal__content {
     padding-top: 0;
-  }
-
-  .usa-modal__close {
-    background-color: transparent !important;
-    margin: 0 !important;
-    padding: 0 !important;
-    width: 1.5rem !important;
-    height: 1.5rem !important;
-    margin: 1rem 0rem 0px 0px !important;
-
-    .usa-icon {
-      height: 1.5rem;
-      margin: 0;
-      width: 1.5rem;
-    }
-  }
-
-  .usa-modal__heading {
-    color: #000;
-    font-family: Merriweather !important;
-    font-size: 32px !important;
-    font-style: normal;
-    font-weight: 700;
-    line-height: 40px;
+    padding-left: 0.5rem;
+    padding-right: 0.5rem;
   }
 
   .usa-modal__main {
     max-width: 26rem;
     margin: 0 !important;
-
+    padding: 0 0 2rem 0 !important;
     input,
     select {
       max-width: 100%;
     }
+  }
+
+  .usa-modal__heading {
+    font-family: "Public Sans", sans-serif !important;
+    font-size: 1.219rem !important;
+    font-style: normal;
+    font-weight: 700;
+    line-height: normal;
+    margin-bottom: 1rem;
+  }
+
+  .usa-checkbox {
+    background-color: transparent;
   }
 
   .usa-button-group {
@@ -661,26 +566,69 @@ ul.usa-sidenav > li.usa-sidenav__item > ul.usa-sidenav__sublist > li.usa-sidenav
 
     .usa-button-group__item:last-child {
       margin-right: 0.25rem;
+
+      #modal-back-button,
+      #modal-cancel-button {
+        padding-left: 0 !important;
+      }
     }
 
-    #modal-back-button {
+    #modal-back-button,
+    #modal-cancel-button {
       background-color: transparent;
       color: #005ea2;
-      padding: 0 !important;
+
       &:hover {
         box-shadow: none;
       }
     }
 
-    .usa-button-group__item:has(> #modal-delete-button) {
+    .usa-button-group__item:last-child:has(> #modal-back-button),
+    .usa-button-group__item:last-child:has(> #modal-cancel-button),
+    .usa-button-group__item:last-child:has(> #modal-delete-button) {
       flex: 1 1 0%;
     }
   }
 
-  .usa-checkbox {
-    background-color: transparent;
-  }
+  .usa-modal__close {
+    background-color: transparent !important;
+    padding: 0 !important;
+    width: 1.5rem !important;
+    height: 1.5rem !important;
+    margin: 1rem 0rem 0rem 0rem !important;
 
+    .usa-icon {
+      margin: 0;
+      height: 1.5rem;
+      width: 1.5rem;
+    }
+  }
+}
+
+.qc-modal.usa-modal--lg {
+  max-width: 40rem !important;
+
+  .usa-modal__main {
+    max-width: 35rem;
+
+    input,
+    select {
+      max-width: 100%;
+    }
+  }
+}
+
+#fhir-server-modal .usa-modal--lg {
+  background-color: #edeff0;
+}
+
+#session-timeout-modal {
+  .usa-modal__main {
+    padding-top: 2rem !important;
+  }
+}
+
+#user-mgmt-modal {
   .role-descriptions {
     background-color: #f3f3f3;
     padding: 0.5rem;


### PR DESCRIPTION
# PULL REQUEST

## Summary
Modals had slightly different styling for each different place they appeared in the app; this PR unifies the font/color/layout of the Modal component . 

## Related Issue

Fixes #470 

## Additional Information
OLD modal styles are on the left, NEW modal styles are on the right:

**FHIR Server modals**
- [Both] Updated font; updated close button placement
- [Add server] Updated Cancel button placement to align with other modals:
<img width="1487" alt="fhir-server-modals" src="https://github.com/user-attachments/assets/77839f8f-b6d5-4a0a-83ed-526f5f7df49a" />
 
**Delete Query & Session Timeout modals**
- [Delete query] Updated Cancel, Delete button styling and placement; updated close button placement
- [Session timeout] Swapped button placement to align with other modals
<img width="1487" alt="delete_query-session_timeout-modals" src="https://github.com/user-attachments/assets/a815327f-e82c-41ae-81ec-b0624977cb98" />

**User Management modals**
- [All] Updated font and rounded corners:
<img width="1487" alt="create_user-modals" src="https://github.com/user-attachments/assets/10a99d08-c6d0-4cd0-8590-0e145f867895" />
<img width="1487" alt="edit_group-edit_user-modals" src="https://github.com/user-attachments/assets/7ece9c5d-9ecf-42ae-a7e8-97e9e40b5a89" />
<img width="1487" alt="create-delete-user_group-modals" src="https://github.com/user-attachments/assets/04447a02-4fdc-4b1c-b206-d3039fb627fa" />


## Checklist

- [x] Descriptive Pull Request title
- [x] Link to relevant issues
- [x] Provide necessary context for design reviewers
- [ ] Ensure test coverage is above agreed upon threshold
- [ ] Update documentation
