### PR TITLE
modularize e2e env var seeding

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -91,24 +91,24 @@ jobs:
       - name: Create .env
         working-directory: ./query-connector
         run: |
-          echo "AIDBOX_LICENSE=${{ secrets.AIDBOX_LICENSE }}" > .env.e2e
+          echo "AIDBOX_LICENSE=${{ secrets.AIDBOX_LICENSE }}" > .env
       - name: Build Query Connector and Run Playwright Tests
         id: run_tests
         working-directory: ./query-connector
         run: |
           bash ./setup-scripts/e2e_tests.sh
-      # uncomment these next few lines and the corresponding log import
-      # in the setup script you're trying to debug if you're having trouble
-      # in CI. All the best, brave engineer (￣^￣ )ゞ
-      #   continue-on-error: true
+        # uncomment these next few lines and the corresponding log import
+        # in the setup script you're trying to debug if you're having trouble
+        # in CI. All the best, brave engineer (￣^￣ )ゞ
+        continue-on-error: true
 
-      # - name: Upload Docker Logs
-      #   uses: actions/upload-artifact@v4
-      #   with:
-      #     name: docker-logs
-      #     path: |
-      #       ./query-connector/test-results/logs-before-tests.txt
-      #       ./query-connector/test-results/logs-after-tests.txt
+      - name: Upload Docker Logs
+        uses: actions/upload-artifact@v4
+        with:
+          name: docker-logs
+          path: |
+            ./query-connector/test-results/logs-before-tests.txt
+            ./query-connector/test-results/logs-after-tests.txt
 
       - uses: actions/upload-artifact@v4
         if: ${{ !cancelled() }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -92,9 +92,6 @@ jobs:
         working-directory: ./query-connector
         run: |
           echo "AIDBOX_LICENSE=${{ secrets.AIDBOX_LICENSE }}" > .env
-          echo "DATABASE_URL=postgresql://postgres:pw@localhost:5432/tefca_db" >> .env
-          echo "AIDBOX_BASE_URL=http://aidbox:8080" >> .env
-          echo "APP_HOSTNAME=http://query-connector:3000" >> .env
       - name: Build Query Connector and Run Playwright Tests
         id: run_tests
         working-directory: ./query-connector

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -100,15 +100,15 @@ jobs:
         # uncomment these next few lines and the corresponding log import
         # in the setup script you're trying to debug if you're having trouble
         # in CI. All the best, brave engineer (￣^￣ )ゞ
-        continue-on-error: true
+      #   continue-on-error: true
 
-      - name: Upload Docker Logs
-        uses: actions/upload-artifact@v4
-        with:
-          name: docker-logs
-          path: |
-            ./query-connector/test-results/logs-before-tests.txt
-            ./query-connector/test-results/logs-after-tests.txt
+      # - name: Upload Docker Logs
+      #   uses: actions/upload-artifact@v4
+      #   with:
+      #     name: docker-logs
+      #     path: |
+      #       ./query-connector/test-results/logs-before-tests.txt
+      #       ./query-connector/test-results/logs-after-tests.txt
 
       - uses: actions/upload-artifact@v4
         if: ${{ !cancelled() }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -91,7 +91,7 @@ jobs:
       - name: Create .env
         working-directory: ./query-connector
         run: |
-          echo "AIDBOX_LICENSE=${{ secrets.AIDBOX_LICENSE }}" > .env
+          echo "AIDBOX_LICENSE=${{ secrets.AIDBOX_LICENSE }}" > .env.e2e
       - name: Build Query Connector and Run Playwright Tests
         id: run_tests
         working-directory: ./query-connector

--- a/.gitignore
+++ b/.gitignore
@@ -84,6 +84,7 @@ build/
 
 .env
 .local.env 
+.env.e2e
 
 tmp_remote_image_*
 

--- a/query-connector/README.md
+++ b/query-connector/README.md
@@ -152,7 +152,8 @@ Auto generate tests with Codegen.
 
 After running a test set on your local, you can also additionally type `npx playwright show-report` to view an HTML report page of different test statuses and results.
 
-Playwright is managed by an end-to-end job in the `.github/workflows/ci.yaml` file of the project root. Since it requires browser installation to effectively test, and since it operates using an independent framework from jest, it is explicitly _not_ included in the basic `npm test` scripts (specified in `package.json`).
+Playwright is managed by an end-to-end job in the `.github/workflows/ci.yaml` file of the project root. Since it requires browser installation to effectively test, and since it operates using an independent framework from jest, it's run separately from the unit and
+integration tests ran through `npm run test:ci`.
 
 ### Query Connector ERD
 

--- a/query-connector/docker-compose-e2e.yaml
+++ b/query-connector/docker-compose-e2e.yaml
@@ -45,7 +45,7 @@ services:
     ports:
       - 8080:8080
     env_file:
-      - .env
+      - .env.e2e
     environment:
       AIDBOX_TERMINOLOGY_SERVICE_BASE_URL: https://tx.fhir.org/r4
       AIDBOX_FHIR_PACKAGES: hl7.fhir.r4.core#4.0.1
@@ -75,7 +75,7 @@ services:
       - ./src/app/tests/assets/GoldenSickPatient.json:/data/GoldenSickPatient.json
       - ./logs:/var/log
     env_file:
-      - .env
+      - .env.e2e
     depends_on:
       db:
         condition: service_healthy
@@ -90,6 +90,8 @@ services:
       context: .
       dockerfile: Dockerfile
     tty: true
+    env_file:
+      - .env.e2e
     ports:
       - "3000:3000"
     environment:

--- a/query-connector/e2e/smart_on_fhir.spec.ts
+++ b/query-connector/e2e/smart_on_fhir.spec.ts
@@ -8,6 +8,7 @@ import {
 import { decodeJwt, decodeProtectedHeader } from "jose";
 
 test.describe("SMART on FHIR", () => {
+  // NOTE: this E2E doesn't work on local UI mode due to Docker networking issues
   test("successfully validates the e2e flow", async ({ page }) => {
     await page.goto(`${TEST_URL}/fhirServers`);
     expect(

--- a/query-connector/setup-scripts/e2e_tests.sh
+++ b/query-connector/setup-scripts/e2e_tests.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -e  # Exit immediately if a command exits with a non-zero status. Comment this if debugging in CI
+# set -e  # Exit immediately if a command exits with a non-zero status. Comment this if debugging in CI
 
 # setup needed .env values
 > .env.e2e
@@ -22,7 +22,7 @@ fi
 docker compose down --volumes --remove-orphans
 docker compose -f docker-compose-e2e.yaml --env-file .env.e2e up -d --build 
 
-# uncomment these and the corresponding block in ci.yaml to get logs in CI
+# uncomment these and the corresponding block in ci.yaml to get logs in CI. Make sure also to comment the set -e command at the top of this file too!
 mkdir test-results
 docker compose -f docker-compose-e2e.yaml logs > /test-results/logs-before-tests.txt
 

--- a/query-connector/setup-scripts/e2e_tests.sh
+++ b/query-connector/setup-scripts/e2e_tests.sh
@@ -1,8 +1,14 @@
 #!/bin/bash
-
 set -e  # Exit immediately if a command exits with a non-zero status. Comment this if debugging in CI
+
+# setup needed .env values
+> .env.e2e
+echo "DATABASE_URL=postgresql://postgres:pw@localhost:5432/tefca_db" >> .env.e2e
+echo "AIDBOX_BASE_URL=http://aidbox:8080" >> .env.e2e
+echo "APP_HOSTNAME=http://query-connector:3000" >> .env.e2e
+
 docker compose down --volumes --remove-orphans
-docker compose -f docker-compose-e2e.yaml up -d --build 
+docker compose -f docker-compose-e2e.yaml --env-file .env.e2e up -d --build 
 
 # uncomment these and the corresponding block in ci.yaml to get logs in CI
 # mkdir test-results
@@ -21,7 +27,7 @@ done
 echo -e "\nAidbox seeder finished!"
 
 
-npx dotenv -e ./.env -- npx playwright test --reporter=list
+npx dotenv -e ./.env.e2e -- npx playwright test --reporter=list
 E2E_EXIT_CODE=$?
 
 # uncomment these and the corresponding block in the ci.yaml to get the CI logs
@@ -31,3 +37,6 @@ E2E_EXIT_CODE=$?
 docker compose -f docker-compose-e2e.yaml down
 
 exit $E2E_EXIT_CODE
+
+
+

--- a/query-connector/setup-scripts/e2e_tests.sh
+++ b/query-connector/setup-scripts/e2e_tests.sh
@@ -2,7 +2,7 @@
 
 set -e  # Exit immediately if a command exits with a non-zero status. Comment this if debugging in CI
 docker compose down --volumes --remove-orphans
-docker compose -f docker-compose-e2e.yaml --env-file .env up -d --build 
+docker compose -f docker-compose-e2e.yaml up -d --build 
 
 # uncomment these and the corresponding block in ci.yaml to get logs in CI
 # mkdir test-results

--- a/query-connector/setup-scripts/e2e_tests.sh
+++ b/query-connector/setup-scripts/e2e_tests.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# set -e  # Exit immediately if a command exits with a non-zero status. Comment this if debugging in CI
+set -e  # Exit immediately if a command exits with a non-zero status. Comment this if debugging in CI
 
 # setup needed .env values
 > .env.e2e
@@ -23,8 +23,8 @@ docker compose down --volumes --remove-orphans
 docker compose -f docker-compose-e2e.yaml --env-file .env.e2e up -d --build 
 
 # uncomment these and the corresponding block in ci.yaml to get logs in CI. Make sure also to comment the set -e command at the top of this file too!
-mkdir test-results
-docker compose -f docker-compose-e2e.yaml logs > /test-results/logs-before-tests.txt
+# mkdir test-results
+# docker compose -f docker-compose-e2e.yaml logs > /test-results/logs-before-tests.txt
 
 # wait for Aidbox seeder to finish running before...
 docker compose -f docker-compose-e2e.yaml logs -f aidbox-seeder | grep -q "Finished configuring Aidbox and database."
@@ -43,7 +43,7 @@ npx dotenv -e ./.env.e2e -- npx playwright test --reporter=list
 E2E_EXIT_CODE=$?
 
 # uncomment these and the corresponding block in the ci.yaml to get the CI logs
-docker compose -f docker-compose-e2e.yaml logs > /test-results/logs-after-tests.txt
+# docker compose -f docker-compose-e2e.yaml logs > /test-results/logs-after-tests.txt
 
 # Teardown containers
 docker compose -f docker-compose-e2e.yaml down

--- a/query-connector/setup-scripts/e2e_tests.sh
+++ b/query-connector/setup-scripts/e2e_tests.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
 
-set -e
+set -e  # Exit immediately if a command exits with a non-zero status. Comment this if debugging in CI
 docker compose down --volumes --remove-orphans
 docker compose -f docker-compose-e2e.yaml --env-file .env up -d --build 
 
-# uncomment these (and the set -e line at the top!) and the block in ci.yaml to get logs in CI
+# uncomment these and the corresponding block in ci.yaml to get logs in CI
 # mkdir test-results
 # docker compose -f docker-compose-e2e.yaml logs > /test-results/logs-before-tests.txt
 

--- a/query-connector/setup-scripts/e2e_tests_local.sh
+++ b/query-connector/setup-scripts/e2e_tests_local.sh
@@ -4,7 +4,7 @@
 > .env.e2e
 echo "DATABASE_URL=postgresql://postgres:pw@localhost:5432/tefca_db" >> .env.e2e
 echo "AIDBOX_BASE_URL=http://localhost:8080" >> .env.e2e
-echo "APP_HOSTNAME=http://host.internal.docker:3000" >> .env.e2e
+echo "APP_HOSTNAME=http://host.docker.internal:3000" >> .env.e2e
 echo "AUTH_DISABLED=true" >> .env.e2e
 echo "AUTH_SECRET=verysecretsecret" >> .env.e2e
 

--- a/query-connector/setup-scripts/e2e_tests_local.sh
+++ b/query-connector/setup-scripts/e2e_tests_local.sh
@@ -5,7 +5,18 @@
 echo "DATABASE_URL=postgresql://postgres:pw@localhost:5432/tefca_db" >> .env.e2e
 echo "AIDBOX_BASE_URL=http://localhost:8080" >> .env.e2e
 echo "APP_HOSTNAME=http://host.internal.docker:3000" >> .env.e2e
+echo "AUTH_DISABLED=true" >> .env.e2e
+echo "AUTH_SECRET=verysecretsecret" >> .env.e2e
 
+value=$(grep "^AIDBOX_LICENSE=" .env | cut -d '=' -f2)
+
+# Check if the value was found
+if [ -n "$value" ]; then
+     echo "AIDBOX_LICENSE=$value" >> .env.e2e
+  echo "Value copied successfully"
+else
+  echo "Variable not found in source file"
+fi
 # pull down any exisiting docker volumes to make sure we're starting fresh
 docker compose down --volumes --remove-orphans
 
@@ -27,7 +38,7 @@ done
 echo -e "\nAidbox seeder finished!"
 
 # Run Next dev without auth to allow the e2e's to work
-npx dotenv -v AUTH_DISABLED=true -- next dev &
+npx dotenv -e ./.env.e2e -- next dev &
 
 echo "Waiting Next server to be healthy..."
 while ! nc -z localhost 3000; do
@@ -35,6 +46,6 @@ while ! nc -z localhost 3000; do
 done
 echo "Next.js server is up!"
 
-npx dotenv -- npx playwright test --ui
+npx dotenv -e ./.env.e2e -- npx playwright test --ui
 
 docker compose down --volumes --remove-orphans

--- a/query-connector/setup-scripts/e2e_tests_local.sh
+++ b/query-connector/setup-scripts/e2e_tests_local.sh
@@ -1,10 +1,16 @@
 #!/bin/bash
 
+# setup needed .env values
+> .env.e2e
+echo "DATABASE_URL=postgresql://postgres:pw@localhost:5432/tefca_db" >> .env.e2e
+echo "AIDBOX_BASE_URL=http://localhost:8080" >> .env.e2e
+echo "APP_HOSTNAME=http://host.internal.docker:3000" >> .env.e2e
+
 # pull down any exisiting docker volumes to make sure we're starting fresh
 docker compose down --volumes --remove-orphans
 
 # use the dev docker compose setup to allow for hot-reloading locally 
-docker compose -f docker-compose-dev.yaml up -d 
+docker compose -f docker-compose-dev.yaml --env-file .env.e2e up -d 
 
 # Start your command in the background
 docker compose -f docker-compose-dev.yaml logs -f aidbox-seeder | grep -q "Finished configuring Aidbox and database." &

--- a/query-connector/setup-scripts/unit_and_integration_tests.sh
+++ b/query-connector/setup-scripts/unit_and_integration_tests.sh
@@ -7,7 +7,7 @@ docker compose -f docker-compose-integration.yaml up -d
 # wait for Aidbox to finish running before...
 docker compose -f docker-compose-integration.yaml logs -f aidbox-seeder | grep -q "Finished configuring Aidbox and database."
 
-# uncomment these and the corresponding block in ci.yaml to get logs in CI
+# uncomment these and the corresponding block in ci.yaml to get logs in CI. Make sure also to comment the set -e command at the top of this file too!
 # mkdir test-results
 # docker compose -f docker-compose-integration.yaml logs > /test-results/logs-before-tests.txt
 

--- a/query-connector/setup-scripts/unit_and_integration_tests.sh
+++ b/query-connector/setup-scripts/unit_and_integration_tests.sh
@@ -1,13 +1,13 @@
 #!/bin/bash
 
-set -e  # Exit immediately if a command exits with a non-zero status
+set -e  # Exit immediately if a command exits with a non-zero status. Comment this if debugging in CI
 docker compose down --volumes --remove-orphans
 docker compose -f docker-compose-integration.yaml up -d
 
 # wait for Aidbox to finish running before...
 docker compose -f docker-compose-integration.yaml logs -f aidbox-seeder | grep -q "Finished configuring Aidbox and database."
 
-# uncomment these (and the set -e line at the top!) and the block in ci.yaml to get logs in CI
+# uncomment these and the corresponding block in ci.yaml to get logs in CI
 # mkdir test-results
 # docker compose -f docker-compose-integration.yaml logs > /test-results/logs-before-tests.txt
 
@@ -22,11 +22,11 @@ fi
 eval $JEST_CMD
 JEST_EXIT_CODE=$?
 
-# uncomment these and the corresponding block in the ci.yaml to get the CI logs
+# uncomment these and the corresponding block in ci.yaml to get logs in CI
 # docker compose -f docker-compose-integration.yaml logs > /test-results/logs-after-tests.txt
 
 # Teardown containers
-# docker compose -f docker-compose-integration.yaml down
+docker compose -f docker-compose-integration.yaml down
 
 # Exit with the Jest exit code
 exit $JEST_EXIT_CODE

--- a/query-connector/src/app/backend/dbServices/smartOnFhir/lib.ts
+++ b/query-connector/src/app/backend/dbServices/smartOnFhir/lib.ts
@@ -86,7 +86,9 @@ export async function createSmartJwt(clientId: string, tokenEndpoint: string) {
     const exp = now + 300; // 5 minutes
 
     // Determine the JWKS URL - make sure this is an absolute URL that Aidbox can reach
-    const jku = DEFAULT_LOCAL_JWKS_HOSTNAME;
+    const jku = process.env.APP_HOSTNAME
+      ? `${process.env.APP_HOSTNAME}/.well-known/jwks.json`
+      : DEFAULT_LOCAL_JWKS_HOSTNAME;
 
     // Create payload
     const payload = {

--- a/query-connector/src/app/backend/dbServices/smartOnFhir/lib.ts
+++ b/query-connector/src/app/backend/dbServices/smartOnFhir/lib.ts
@@ -86,9 +86,7 @@ export async function createSmartJwt(clientId: string, tokenEndpoint: string) {
     const exp = now + 300; // 5 minutes
 
     // Determine the JWKS URL - make sure this is an absolute URL that Aidbox can reach
-    const jku = process.env.APP_HOSTNAME
-      ? `${process.env.APP_HOSTNAME}/.well-known/jwks.json`
-      : DEFAULT_LOCAL_JWKS_HOSTNAME;
+    const jku = DEFAULT_LOCAL_JWKS_HOSTNAME;
 
     // Create payload
     const payload = {


### PR DESCRIPTION
# PULL REQUEST

## Summary
When looking into fixing the e2e's noticed some areas of improvement for how we're seeding env variables in our e2e scripts. 

- All Dockerized versions of the e2e's (in CI and local run using `npm run test:playwright`) have the e2e's seeded within the `.e2e_tests.sh` script rather than relying on the `ci.yaml` file and the dev's local .env file respectively
    - We do have one secret (the Aidbox license) in the e2e run chain, so added some code to look for that value in the `.env` and then seed that accordingly 
- The Playwright UI command has its e2e var's seeded in the `.e2e_tests_local.sh` script
- All e2e tests now generate / teardown their own `.env.e2e` files so as to separate concerns with any floating .env files
- Added a note about the SMART on FHIR e2e not working for local UI mode because of Docker networking issues

## Checklist

- [x] Descriptive Pull Request title
- [x] Update documentation
