### PR TITLE
refactor fhirServers service to use camel case decorator

### DIFF
--- a/query-connector/next-env.d.ts
+++ b/query-connector/next-env.d.ts
@@ -1,5 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
+/// <reference types="next/navigation-types/compat/navigation" />
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/building-your-application/configuring/typescript for more information.

--- a/query-connector/src/app/(pages)/fhirServers/page.tsx
+++ b/query-connector/src/app/(pages)/fhirServers/page.tsx
@@ -61,7 +61,7 @@ const FhirServers: React.FC = () => {
   // Fetch FHIR servers
   async function fetchFHIRServers() {
     try {
-      const servers = await getFhirServerConfigs(true, true);
+      const servers = await getFhirServerConfigs(true);
       setFhirServers(servers);
     } catch (e) {
       showToastConfirmation({
@@ -210,7 +210,7 @@ const FhirServers: React.FC = () => {
       );
 
       if (result.success) {
-        getFhirServerConfigs(true, true).then((servers) => {
+        getFhirServerConfigs(true).then((servers) => {
           setFhirServers(servers);
         });
         handleCloseModal();
@@ -229,7 +229,7 @@ const FhirServers: React.FC = () => {
       );
 
       if (result.success) {
-        getFhirServerConfigs(true, true).then((servers) => {
+        getFhirServerConfigs(true).then((servers) => {
           setFhirServers(servers);
         });
         handleCloseModal();
@@ -248,7 +248,7 @@ const FhirServers: React.FC = () => {
     const result = await deleteFhirServer(selectedServer.id);
 
     if (result.success) {
-      getFhirServerConfigs(true, true).then((servers) => {
+      getFhirServerConfigs(true).then((servers) => {
         setFhirServers(servers);
       });
       handleCloseModal();

--- a/query-connector/src/app/(pages)/fhirServers/page.tsx
+++ b/query-connector/src/app/(pages)/fhirServers/page.tsx
@@ -97,20 +97,20 @@ const FhirServers: React.FC = () => {
       setServerName(server.name);
       setServerUrl(server.hostname);
       setConnectionStatus("idle");
-      setDisableCertValidation(server.disable_cert_validation);
+      setDisableCertValidation(server.disableCertValidation);
 
       // Set auth method and corresponding fields based on server data
-      if (server.auth_type) {
-        setAuthMethod(server.auth_type as AuthMethodType);
+      if (server.authType) {
+        setAuthMethod(server.authType as AuthMethodType);
 
         // Set other auth related fields
-        if (server.client_id) setClientId(server.client_id);
-        if (server.client_secret) setClientSecret(server.client_secret);
-        if (server.token_endpoint) setTokenEndpoint(server.token_endpoint);
+        if (server.clientId) setClientId(server.clientId);
+        if (server.clientSecret) setClientSecret(server.clientSecret);
+        if (server.tokenEndpoint) setTokenEndpoint(server.tokenEndpoint);
         if (server.scopes) setScopes(server.scopes);
 
         // For backward compatibility with basic auth
-        if (server.auth_type === "basic" && server.headers?.Authorization) {
+        if (server.authType === "basic" && server.headers?.Authorization) {
           setBearerToken(server.headers.Authorization.replace("Bearer ", ""));
         }
       } else if (server.headers?.Authorization?.startsWith("Bearer ")) {
@@ -469,12 +469,12 @@ const FhirServers: React.FC = () => {
                 <td>{fhirServer.name}</td>
                 <td>{fhirServer.hostname}</td>
                 <td>
-                  {fhirServer.auth_type ||
+                  {fhirServer.authType ||
                     (fhirServer.headers?.Authorization ? "basic" : "none")}
                 </td>
                 <td width={480}>
                   <div className="grid-container grid-row padding-0 display-flex flex-align-center">
-                    {fhirServer.last_connection_successful ? (
+                    {fhirServer.lastConnectionSuccessful ? (
                       <>
                         <Icon.Check
                           size={3}
@@ -497,9 +497,9 @@ const FhirServers: React.FC = () => {
                     )}
                     <span className={styles.lastChecked}>
                       (last checked:{" "}
-                      {fhirServer.last_connection_attempt
+                      {fhirServer.lastConnectionAttempt
                         ? new Date(
-                            fhirServer.last_connection_attempt,
+                            fhirServer.lastConnectionAttempt,
                           ).toLocaleString()
                         : "unknown"}
                       )

--- a/query-connector/src/app/backend/dbServices/audit-logs.ts
+++ b/query-connector/src/app/backend/dbServices/audit-logs.ts
@@ -9,7 +9,7 @@ export type LogEntry = {
   createdAt: Date;
 };
 
-class AuditLogService extends dbService {
+class AuditLogService {
   static async getAuditLogs() {
     const auditQuery = "SELECT * FROM audit_logs ORDER BY created_at DESC;";
     const results = await dbService.query(auditQuery);

--- a/query-connector/src/app/backend/dbServices/db-service.ts
+++ b/query-connector/src/app/backend/dbServices/db-service.ts
@@ -2,13 +2,13 @@ import { Pool } from "pg";
 import { getDbClient } from "../dbClient";
 import { camelCaseDbColumnNames } from "./decorators";
 
-class dbService {
-  private static dbClient: Pool = getDbClient();
+class DbService {
+  private dbClient: Pool = getDbClient();
 
   @camelCaseDbColumnNames
-  static async query(querySql: string, values?: unknown[]) {
-    return await dbService.dbClient.query(querySql, values);
+  async query(querySql: string, values?: unknown[]) {
+    return await this.dbClient.query(querySql, values);
   }
 }
-
+const dbService = new DbService();
 export default dbService;

--- a/query-connector/src/app/backend/dbServices/fhir-servers.ts
+++ b/query-connector/src/app/backend/dbServices/fhir-servers.ts
@@ -1,6 +1,4 @@
 "use server";
-import { Pool } from "pg";
-import { getDbClient } from "../dbClient";
 import { superAdminRequired, transaction } from "./decorators";
 import { FhirServerConfig } from "@/app/models/entities/fhir-servers";
 import { auditable } from "@/app/backend/auditLogs/decorator";
@@ -36,7 +34,6 @@ class FhirServerConfigServiceInternal {
 }
 
 class FhirServerConfigService extends FhirServerConfigServiceInternal {
-  private static dbClient: Pool = getDbClient();
   private static cachedFhirServerConfigs: FhirServerConfig[] | null = null;
 
   /**
@@ -82,10 +79,7 @@ class FhirServerConfigService extends FhirServerConfigServiceInternal {
   `;
 
     try {
-      const result = await FhirServerConfigService.dbClient.query(updateQuery, [
-        name,
-        wasSuccessful,
-      ]);
+      const result = await dbService.query(updateQuery, [name, wasSuccessful]);
 
       // Clear the cache so the next getFhirServerConfigs call will fetch fresh data
       FhirServerConfigService.cachedFhirServerConfigs = null;
@@ -158,7 +152,7 @@ class FhirServerConfigService extends FhirServerConfigServiceInternal {
       let headers = {};
 
       // Get existing headers if any
-      const existingServer = await FhirServerConfigService.dbClient.query(
+      const existingServer = await dbService.query(
         "SELECT headers FROM fhir_servers WHERE id = $1",
         [id],
       );
@@ -181,7 +175,7 @@ class FhirServerConfigService extends FhirServerConfigServiceInternal {
         };
       }
 
-      const result = await FhirServerConfigService.dbClient.query(updateQuery, [
+      const result = await dbService.query(updateQuery, [
         id,
         name,
         hostname,
@@ -273,7 +267,7 @@ class FhirServerConfigService extends FhirServerConfigServiceInternal {
         };
       }
 
-      const result = await FhirServerConfigService.dbClient.query(insertQuery, [
+      const result = await dbService.query(insertQuery, [
         name,
         hostname,
         new Date(),
@@ -320,9 +314,7 @@ class FhirServerConfigService extends FhirServerConfigServiceInternal {
   `;
 
     try {
-      const result = await FhirServerConfigService.dbClient.query(deleteQuery, [
-        id,
-      ]);
+      const result = await dbService.query(deleteQuery, [id]);
 
       // Clear the cache so the next getFhirServerConfigs call will fetch fresh data
       FhirServerConfigService.cachedFhirServerConfigs = null;

--- a/query-connector/src/app/backend/dbServices/fhir-servers.ts
+++ b/query-connector/src/app/backend/dbServices/fhir-servers.ts
@@ -4,6 +4,7 @@ import { FhirServerConfig } from "@/app/models/entities/fhir-servers";
 import { auditable } from "@/app/backend/auditLogs/decorator";
 import dbService from "./db-service";
 import FHIRClient from "@/app/shared/fhirClient";
+import { FHIR_SERVER_INSERT_QUERY } from "@/app/tests/integration/fhir-servers.test";
 
 // Define an interface for authentication data
 export interface AuthData {
@@ -341,23 +342,3 @@ export const updateFhirServer = FhirServerConfigService.updateFhirServer;
 export const insertFhirServer = FhirServerConfigService.insertFhirServer;
 export const deleteFhirServer = FhirServerConfigService.deleteFhirServer;
 export const prepareFhirClient = FhirServerConfigService.prepareFhirClient;
-
-export const FHIR_SERVER_INSERT_QUERY = `
-INSERT INTO fhir_servers (
-  name,
-  hostname, 
-  last_connection_attempt,
-  last_connection_successful,
-  headers,
-  disable_cert_validation,
-  auth_type,
-  client_id,
-  client_secret,
-  token_endpoint,
-  scopes,
-  access_token,
-  token_expiry
-)
-VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13)
-RETURNING *;
-`;

--- a/query-connector/src/app/backend/dbServices/fhir-servers.ts
+++ b/query-connector/src/app/backend/dbServices/fhir-servers.ts
@@ -4,7 +4,7 @@ import { FhirServerConfig } from "@/app/models/entities/fhir-servers";
 import { auditable } from "@/app/backend/auditLogs/decorator";
 import dbService from "./db-service";
 import FHIRClient from "@/app/shared/fhirClient";
-import { FHIR_SERVER_INSERT_QUERY } from "@/app/tests/integration/fhir-servers.test";
+import { FHIR_SERVER_INSERT_QUERY } from "./util";
 
 // Define an interface for authentication data
 export interface AuthData {

--- a/query-connector/src/app/backend/dbServices/fhir-servers.ts
+++ b/query-connector/src/app/backend/dbServices/fhir-servers.ts
@@ -233,26 +233,6 @@ class FhirServerConfigService extends FhirServerConfigServiceInternal {
     lastConnectionSuccessful?: boolean,
     authData?: AuthData,
   ) {
-    const insertQuery = `
-    INSERT INTO fhir_servers (
-      name,
-      hostname, 
-      last_connection_attempt,
-      last_connection_successful,
-      headers,
-      disable_cert_validation,
-      auth_type,
-      client_id,
-      client_secret,
-      token_endpoint,
-      scopes,
-      access_token,
-      token_expiry
-    )
-    VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13)
-    RETURNING *;
-  `;
-
     try {
       // Default auth type to none if not provided
       const authType = authData?.authType || "none";
@@ -267,7 +247,7 @@ class FhirServerConfigService extends FhirServerConfigServiceInternal {
         };
       }
 
-      const result = await dbService.query(insertQuery, [
+      const result = await dbService.query(FHIR_SERVER_INSERT_QUERY, [
         name,
         hostname,
         new Date(),
@@ -361,3 +341,23 @@ export const updateFhirServer = FhirServerConfigService.updateFhirServer;
 export const insertFhirServer = FhirServerConfigService.insertFhirServer;
 export const deleteFhirServer = FhirServerConfigService.deleteFhirServer;
 export const prepareFhirClient = FhirServerConfigService.prepareFhirClient;
+
+export const FHIR_SERVER_INSERT_QUERY = `
+INSERT INTO fhir_servers (
+  name,
+  hostname, 
+  last_connection_attempt,
+  last_connection_successful,
+  headers,
+  disable_cert_validation,
+  auth_type,
+  client_id,
+  client_secret,
+  token_endpoint,
+  scopes,
+  access_token,
+  token_expiry
+)
+VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13)
+RETURNING *;
+`;

--- a/query-connector/src/app/backend/dbServices/util.ts
+++ b/query-connector/src/app/backend/dbServices/util.ts
@@ -1,0 +1,19 @@
+export const FHIR_SERVER_INSERT_QUERY = `
+INSERT INTO fhir_servers (
+  name,
+  hostname, 
+  last_connection_attempt,
+  last_connection_successful,
+  headers,
+  disable_cert_validation,
+  auth_type,
+  client_id,
+  client_secret,
+  token_endpoint,
+  scopes,
+  access_token,
+  token_expiry
+)
+VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13)
+RETURNING *;
+`;

--- a/query-connector/src/app/models/entities/fhir-servers.ts
+++ b/query-connector/src/app/models/entities/fhir-servers.ts
@@ -4,14 +4,14 @@ export interface FhirServerConfig {
   name: string;
   hostname: string;
   headers?: Record<string, string>;
-  last_connection_attempt?: string;
-  last_connection_successful?: boolean;
-  disable_cert_validation: boolean;
-  auth_type?: "none" | "basic" | "client_credentials" | "SMART";
-  client_id?: string;
-  client_secret?: string;
-  token_endpoint?: string;
+  lastConnectionAttempt?: string;
+  lastConnectionSuccessful?: boolean;
+  disableCertValidation: boolean;
+  authType?: "none" | "basic" | "client_credentials" | "SMART";
+  clientId?: string;
+  clientSecret?: string;
+  tokenEndpoint?: string;
   scopes?: string;
-  access_token?: string;
-  token_expiry?: string;
+  accessToken?: string;
+  tokenExpiry?: string;
 }

--- a/query-connector/src/app/shared/DataProvider.tsx
+++ b/query-connector/src/app/shared/DataProvider.tsx
@@ -13,8 +13,8 @@ const REFRESH_INTERVAL_MINS = 15;
 export interface DataContextValue {
   data: unknown; // You can define a specific data type here
   setData: (data: unknown) => void;
-  currentPage: PageType | string | undefined;
-  setCurrentPage: (currentPage: PageType | string | undefined) => void;
+  currentPage: PageType | string | null;
+  setCurrentPage: (currentPage: PageType | string | null) => void;
   toastConfig: ToastConfigOptions | null;
   setToastConfig: (config: ToastConfigOptions) => void;
   runtimeConfig?: Record<string, string>;
@@ -43,9 +43,9 @@ export function DataProvider({
   session: Session | null;
 }) {
   const [data, setData] = useState<unknown | null>(null);
-  const [currentPage, setCurrentPage] = useState<
-    PageType | string | undefined
-  >();
+  const [currentPage, setCurrentPage] = useState<PageType | string | null>(
+    null,
+  );
   const [toastConfig, setToastConfig] = useState<ToastConfigOptions | null>(
     null,
   );

--- a/query-connector/src/app/tests/integration/fhir-servers.test.ts
+++ b/query-connector/src/app/tests/integration/fhir-servers.test.ts
@@ -1,0 +1,81 @@
+import dbService from "@/app/backend/dbServices/db-service";
+import { suppressConsoleLogs } from "./fixtures";
+import {
+  FHIR_SERVER_INSERT_QUERY,
+  getFhirServerConfigs,
+} from "@/app/backend/dbServices/fhir-servers";
+
+jest.mock("@/app/utils/auth", () => {
+  return {
+    superAdminAccessCheck: jest.fn().mockResolvedValue(true),
+    adminAccessCheck: jest.fn().mockResolvedValue(true),
+  };
+});
+
+const TEST_FHIR_SERVER = {
+  name: "Kongo Jungle",
+  hostname: "http://welcome-to-the-jungle.bananarepublic/fhir",
+  headers: null,
+  lastConnectionSuccessful: true,
+  disableCertValidation: false,
+};
+
+const DEFAULT_FHIR_SERVER_LENGTH = 10;
+
+describe("FHIR Servers tests", () => {
+  beforeAll(async () => {
+    suppressConsoleLogs();
+  });
+
+  it("getter function grabs expected information", async () => {
+    const fhirServers = await getFhirServerConfigs();
+
+    // Check for presence of fixture Aidbox
+    const aidbox = fhirServers.find((v) => v.name === "Aidbox");
+    expect(aidbox).toBeDefined();
+    expect(aidbox?.name).toBe("Aidbox");
+    expect(aidbox?.hostname).toBe(`${process.env.AIDBOX_BASE_URL}/fhir`);
+  });
+  it("passing in refresh grabs new values", async () => {
+    const fhirServers = await getFhirServerConfigs();
+    expect(fhirServers.length).toBe(DEFAULT_FHIR_SERVER_LENGTH);
+
+    await dbService.query(FHIR_SERVER_INSERT_QUERY, [
+      TEST_FHIR_SERVER.name,
+      TEST_FHIR_SERVER.hostname,
+      new Date(),
+      TEST_FHIR_SERVER.lastConnectionSuccessful,
+      {},
+      TEST_FHIR_SERVER.disableCertValidation,
+      "none",
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+    ]);
+    // Has seeded Aidbox
+    const newFhirServers = await getFhirServerConfigs(true);
+    expect(newFhirServers.length).toBe(DEFAULT_FHIR_SERVER_LENGTH + 1);
+    const newServer = newFhirServers.find(
+      (v) => v.name === TEST_FHIR_SERVER.name,
+    );
+    expect(newServer?.name).toBe(TEST_FHIR_SERVER.name);
+    expect(newServer?.hostname).toBe(TEST_FHIR_SERVER.hostname);
+    expect(newServer?.authType).toBe("none");
+
+    try {
+      await dbService.query(
+        `
+            DELETE FROM fhir_servers 
+            WHERE name = $1
+            RETURNING *;
+          `,
+        [TEST_FHIR_SERVER.name],
+      );
+    } catch (error) {
+      console.error("Teardown failed:", error);
+    }
+  });
+});

--- a/query-connector/src/app/tests/integration/fhir-servers.test.ts
+++ b/query-connector/src/app/tests/integration/fhir-servers.test.ts
@@ -5,6 +5,7 @@ import {
   getFhirServerConfigs,
   updateFhirServer,
 } from "@/app/backend/dbServices/fhir-servers";
+import { FHIR_SERVER_INSERT_QUERY } from "@/app/backend/dbServices/util";
 
 jest.mock("@/app/utils/auth", () => {
   return {
@@ -13,25 +14,6 @@ jest.mock("@/app/utils/auth", () => {
   };
 });
 
-export const FHIR_SERVER_INSERT_QUERY = `
-INSERT INTO fhir_servers (
-  name,
-  hostname, 
-  last_connection_attempt,
-  last_connection_successful,
-  headers,
-  disable_cert_validation,
-  auth_type,
-  client_id,
-  client_secret,
-  token_endpoint,
-  scopes,
-  access_token,
-  token_expiry
-)
-VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13)
-RETURNING *;
-`;
 const TEST_FHIR_SERVER = {
   name: "Kongo Jungle",
   hostname: "http://welcome-to-the-jungle.bananarepublic/fhir",
@@ -57,9 +39,6 @@ describe("FHIR Servers tests", () => {
     expect(aidbox?.hostname).toBe(`${process.env.AIDBOX_BASE_URL}/fhir`);
   });
   it("refresh, update, and deletion functions work", async () => {
-    const fhirServers = await getFhirServerConfigs(true);
-    expect(fhirServers.length).toBe(DEFAULT_FHIR_SERVER_LENGTH);
-
     await dbService.query(FHIR_SERVER_INSERT_QUERY, [
       TEST_FHIR_SERVER.name,
       TEST_FHIR_SERVER.hostname,

--- a/query-connector/src/app/tests/integration/fhir-servers.test.ts
+++ b/query-connector/src/app/tests/integration/fhir-servers.test.ts
@@ -2,7 +2,6 @@ import dbService from "@/app/backend/dbServices/db-service";
 import { suppressConsoleLogs } from "./fixtures";
 import {
   deleteFhirServer,
-  FHIR_SERVER_INSERT_QUERY,
   getFhirServerConfigs,
   updateFhirServer,
 } from "@/app/backend/dbServices/fhir-servers";
@@ -14,6 +13,25 @@ jest.mock("@/app/utils/auth", () => {
   };
 });
 
+export const FHIR_SERVER_INSERT_QUERY = `
+INSERT INTO fhir_servers (
+  name,
+  hostname, 
+  last_connection_attempt,
+  last_connection_successful,
+  headers,
+  disable_cert_validation,
+  auth_type,
+  client_id,
+  client_secret,
+  token_endpoint,
+  scopes,
+  access_token,
+  token_expiry
+)
+VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13)
+RETURNING *;
+`;
 const TEST_FHIR_SERVER = {
   name: "Kongo Jungle",
   hostname: "http://welcome-to-the-jungle.bananarepublic/fhir",

--- a/query-connector/src/app/tests/integration/user-management.test.ts
+++ b/query-connector/src/app/tests/integration/user-management.test.ts
@@ -40,12 +40,13 @@ const TEST_USER_SUPER = {
   lastName: "Admin",
   qcRole: "Super Admin",
 };
-suppressConsoleLogs();
 
 describe("User Management Integration Tests", () => {
   let createdUserId: string;
 
   beforeAll(async () => {
+    suppressConsoleLogs();
+
     await dbClient.query("BEGIN");
 
     // Insert first user as super admin

--- a/query-connector/src/app/ui/components/withAuth/WithAuth.tsx
+++ b/query-connector/src/app/ui/components/withAuth/WithAuth.tsx
@@ -22,7 +22,7 @@ const WithAuth: React.FC<React.PropsWithChildren> = ({ children }) => {
   const ctx = useContext(DataContext);
   const isAuthDisabled = isAuthDisabledClientCheck(ctx?.runtimeConfig);
   const path = usePathname();
-  const access = pagesConfig[path]?.roleAccess ?? [];
+  const access = (path && pagesConfig[path]?.roleAccess) ?? [];
 
   if (
     isAuthDisabled ||

--- a/query-connector/src/app/ui/designSystem/SiteAlert.tsx
+++ b/query-connector/src/app/ui/designSystem/SiteAlert.tsx
@@ -29,7 +29,7 @@ const piiDisclaimer = (
 );
 
 type SiteAlertProps = {
-  page?: PageType | string;
+  page?: PageType | string | null;
 };
 
 const PageModeToSiteAlertMap: { [page in Mode]?: React.ReactNode } = {


### PR DESCRIPTION
# PULL REQUEST

## Summary
Refactors the `FhirServersService` to return read queries using camel casing. Picked up some other misc organizational improvements as well

## Related Issue
Part of #515 

## Additional Information
- Split out the functionality within the FhirServers class to be protected so that internal service code could call it while external facing code is decorated with permissions checks
- Moved the FHIR client preparation code into the services class to take advantage of the above

## Checklist
- [x] Descriptive Pull Request title
- [x] Link to relevant issues
- [x] Ensure test coverage is above agreed upon threshold
- [ ] Update documentation
