### PR TITLE
Add sidebar item and empty state for "Add codes from library" customization

### DIFF
--- a/query-connector/src/app/(pages)/queryBuilding/buildFromTemplates/BuildFromTemplates.test.tsx
+++ b/query-connector/src/app/(pages)/queryBuilding/buildFromTemplates/BuildFromTemplates.test.tsx
@@ -273,9 +273,7 @@ describe("tests the valueset selection page interactions", () => {
       screen.getByText("Save query");
     });
 
-    await user.click(
-      screen.getByTestId("15628003-conditionCard", { exact: false }),
-    );
+    await user.click(screen.getByTestId("15628003-card", { exact: false }));
     await user.click(
       screen.getByTestId("accordionButton_labs", { exact: false }),
     );
@@ -307,14 +305,10 @@ describe("tests the valueset selection page interactions", () => {
       screen.getByTestId(`condition-drawer-added-${CANCER_ID}`),
     ).toBeInTheDocument();
     // click out of the drawer
-    await user.click(screen.getByTestId(`${CANCER_ID}-conditionCard-active`));
+    await user.click(screen.getByTestId(`${CANCER_ID}-card-active`));
 
-    expect(
-      screen.getByTestId(`${CANCER_ID}-conditionCard-active`),
-    ).toBeInTheDocument();
-    expect(
-      screen.getByTestId(`${GONORREHEA_ID}-conditionCard`),
-    ).toBeInTheDocument();
+    expect(screen.getByTestId(`${CANCER_ID}-card-active`)).toBeInTheDocument();
+    expect(screen.getByTestId(`${GONORREHEA_ID}-card`)).toBeInTheDocument();
   });
 
   it("filters search on the valueset selection drawer appropriately", async () => {

--- a/query-connector/src/app/(pages)/queryBuilding/buildFromTemplates/BuildFromTemplates.tsx
+++ b/query-connector/src/app/(pages)/queryBuilding/buildFromTemplates/BuildFromTemplates.tsx
@@ -301,14 +301,11 @@ const BuildFromTemplates: React.FC<BuildFromTemplatesProps> = ({
           <Backlink onClick={goBack} label={"Back to My queries"} />
         )}
 
-        <div className="customQuery__header">
+        <div className={styles.customQuery__header}>
           <h1 className={styles.queryTitle}>Custom query</h1>
           <div className={styles.customQuery__controls}>
             <div className={styles.customQuery__name}>
-              <Label
-                htmlFor="queryNameInput"
-                className="margin-top-0-important"
-              >
+              <Label htmlFor="queryNameInput" className={styles.inputLabel}>
                 Query name <span style={{ color: "#919191" }}>(required)</span>
               </Label>
               <TextInput
@@ -316,7 +313,7 @@ const BuildFromTemplates: React.FC<BuildFromTemplatesProps> = ({
                 id="queryNameInput"
                 name="queryNameInput"
                 type="text"
-                className="width-mobile"
+                className={styles.input}
                 defaultValue={queryName ?? ""}
                 required
                 onChange={(event) => {
@@ -327,7 +324,7 @@ const BuildFromTemplates: React.FC<BuildFromTemplatesProps> = ({
             </div>
             <div className={styles.customQuery__saveButton}>
               <Button
-                className="margin-0"
+                className={classNames(styles.queryBuildingButton, "margin-0")}
                 type={"button"}
                 title={
                   buildStep === "valueset"

--- a/query-connector/src/app/(pages)/queryBuilding/buildFromTemplates/conditionTemplateSelection.module.scss
+++ b/query-connector/src/app/(pages)/queryBuilding/buildFromTemplates/conditionTemplateSelection.module.scss
@@ -7,11 +7,12 @@
   flex-direction: column;
   flex: auto;
   margin-bottom: 0 !important;
+  max-width: 70rem !important;
 }
 
 // Condition styles
 
-.conditionTemplateContainer {
+.templateContainer {
   padding: 3.5rem 5rem;
   border-radius: 4px;
   min-height: 30rem;
@@ -32,7 +33,7 @@
   min-width: 53rem;
 }
 
-#conditionTemplateSearch:first-child {
+#templateSearch:first-child {
   flex: 1;
 }
 
@@ -60,7 +61,7 @@
 }
 
 .bluePill {
-  background-color:#E8F5FF;
+  background-color: #e8f5ff;
   font-size: 0.875rem;
   border-radius: 0.25rem;
 }
@@ -80,6 +81,25 @@
   justify-content: space-between;
 }
 
+.customQuery__name {
+  .inputLabel {
+    line-height: 1.375rem !important;
+    margin-top: 0 !important;
+  }
+
+  .input {
+    width: 20.75rem;
+    height: 2.875rem;
+  }
+}
+
+.queryBuildingButton {
+  line-height: 28px;
+  height: 3.75rem;
+  font-size: 1.25rem;
+  padding: 1rem 1.5rem;
+}
+
 .valueSetSearch {
   width: 25rem !important;
   padding: 0.75rem 0.75rem 0.75rem 2.25rem !important;
@@ -91,16 +111,44 @@
   display: flex;
   flex-direction: row;
   width: 18rem;
+  min-width: 25%;
   justify-content: space-between;
-  padding: 0.5rem !important;
+  padding: 1rem 0 0 0.5rem !important;
 }
 
 .valueSetTemplate__right {
   background-color: #fff;
-  width: 88%;
+  width: 50rem;
+  min-width: 70%;
   border-radius: 8px;
   margin-left: 0.5rem;
   min-height: 50rem;
+
+  .codeLibrary__empty {
+    display: flex;
+    flex-direction: column;
+    padding: 2.5rem;
+    gap: 1.5rem;
+  }
+
+  .icon {
+    height: 10rem;
+    width: 10rem;
+  }
+
+  .codeLibrary__emptyText {
+    font-weight: 700;
+    font-size: 1.25rem;
+    line-height: 1.2;
+    margin: 0;
+  }
+
+  .codeLibrary__button {
+    width: 16.75rem;
+    padding: 1rem 1.5rem;
+    font-size: 1.25rem;
+    line-height: 26px;
+  }
 }
 
 .valueSetTemplate__search {
@@ -177,21 +225,31 @@
   padding: 1rem 1.5rem;
 }
 
-.conditionList {
-  display: flex;
-  flex-direction: column;
-  padding: 0.5rem;
+.sideBarMenu {
   width: 100%;
 
-  .controls {
-    justify-content: space-between;
-    padding: 0.5rem;
+  &__content {
     display: flex;
+    flex-direction: column;
+    justify-content: space-between;
+    padding-top: 0.5rem;
+    gap: 2rem;
 
-    .conditionsTitle {
-      width: 104px;
+    .section_templates,
+    .section_custom {
+      gap: 1rem;
+      display: flex;
+      flex-direction: column;
+    }
+    .sectionTitle {
+      width: 100%;
+      display: flex;
+      flex-direction: row;
+      justify-content: space-between;
+      align-items: center;
       color: #919191;
-      font-size: 19px;
+      font-size: 1rem;
+      line-height: 1.2;
     }
 
     .addCondition {
@@ -215,12 +273,11 @@
     display: none;
   }
 
-  .conditionCard {
+  .card {
     background: transparent;
     border-radius: 4px;
     padding: 1rem;
     line-height: 22px;
-    margin-top: 0.5rem;
     color: #111111;
     cursor: pointer;
     position: relative;
@@ -329,10 +386,14 @@ div.accordionBodyExpanded:last-of-type {
   justify-content: flex-end;
 }
 
+.customQuery__header > h1 {
+  line-height: 2.5rem !important;
+}
+
 .customQuery__controls {
   display: flex;
   flex-direction: row;
-  align-items: flex-end;
+  align-items: center;
   justify-content: space-between;
 }
 

--- a/query-connector/src/app/(pages)/queryBuilding/components/ConditionSelection.tsx
+++ b/query-connector/src/app/(pages)/queryBuilding/components/ConditionSelection.tsx
@@ -9,6 +9,7 @@ import SearchField from "@/app/ui/designSystem/searchField/SearchField";
 import { FormError } from "../buildFromTemplates/BuildFromTemplates";
 import { CONDITION_DRAWER_SEARCH_PLACEHOLDER } from "./utils";
 import { formatDiseaseDisplay } from "../utils";
+import Link from "next/link";
 
 type ConditionSelectionProps = {
   categoryToConditionsMap: CategoryToConditionArrayMap;
@@ -56,15 +57,21 @@ export const ConditionSelection: React.FC<ConditionSelectionProps> = ({
     <div
       className={classNames(
         "bg-gray-5 margin-top-4 ",
-        styles.conditionTemplateContainer,
+        styles.templateContainer,
       )}
     >
-      <div className="display-flex flex-justify flex-align-end margin-bottom-3 width-full">
-        <h2 className="margin-y-0-important">Select condition template(s)</h2>
+      <div className="display-flex flex-column flex-align-center margin-bottom-3 width-full">
+        <h2 className="margin-y-0-important">Start from template(s)</h2>
+        <p>
+          Don't see what you're looking for? You can also{" "}
+          <Link href={""} title={""} className="text-bold text-no-underline">
+            start from scratch.
+          </Link>
+        </p>
       </div>
       <div className={classNames(styles.conditionSelectionForm, "radius-lg")}>
         <SearchField
-          id="conditionTemplateSearch"
+          id="templateSearch"
           placeholder={CONDITION_DRAWER_SEARCH_PLACEHOLDER}
           className={classNames(
             "maxw-mobile margin-x-auto margin-top-0 margin-bottom-2",
@@ -113,7 +120,9 @@ export const ConditionSelection: React.FC<ConditionSelectionProps> = ({
                             onClick={() =>
                               handleConditionUpdate(condition.id, true)
                             }
-                            aria-label={`Remove ${formatDiseaseDisplay(condition.name)}`}
+                            aria-label={`Remove ${formatDiseaseDisplay(
+                              condition.name,
+                            )}`}
                           >
                             ×
                           </button>

--- a/query-connector/src/app/(pages)/queryBuilding/components/ValueSetSelection.tsx
+++ b/query-connector/src/app/(pages)/queryBuilding/components/ValueSetSelection.tsx
@@ -3,7 +3,7 @@
 import styles from "../buildFromTemplates/conditionTemplateSelection.module.scss";
 import { useEffect, useState } from "react";
 import classNames from "classnames";
-import { Icon } from "@trussworks/react-uswds";
+import { Button, Icon } from "@trussworks/react-uswds";
 import {
   CategoryToConditionArrayMap,
   ConditionsMap,
@@ -64,7 +64,7 @@ export const ValueSetSelection: React.FC<ConditionSelectionProps> = ({
 
   useEffect(() => {
     // display the first condition's valuesets on render
-    setActiveCondition(Object.keys(constructedQuery)[0]);
+    setActiveCondition(Object.keys(constructedQuery)[0] || "custom");
   }, [constructedQuery]);
 
   function generateConditionDrawerDisplay(
@@ -154,94 +154,144 @@ export const ValueSetSelection: React.FC<ConditionSelectionProps> = ({
     >
       <div className={styles.valueSetTemplateContainer__inner}>
         <div className={styles.valueSetTemplate__left}>
-          <div className={styles.conditionList}>
-            <div className={styles.controls}>
-              <div className={styles.conditionsTitle}>
-                {"Conditions".toLocaleUpperCase()}
-              </div>
-              <div
-                className={styles.addCondition}
-                role="button"
-                data-testid={"add-condition-icon"}
-                onClick={() => setIsDrawerOpen(true)}
-                tabIndex={0}
-              >
-                <Icon.Add
-                  aria-label="Plus sign icon indicating addition"
-                  className="usa-icon"
-                  size={3}
-                  color="#005EA2"
-                />
-                <span data-testid="add-left-rail">ADD</span>
-              </div>
-            </div>
+          <div className={styles.sideBarMenu}>
+            <div className={styles.sideBarMenu__content}>
+              <div className={styles.section_templates}>
+                <div className={styles.sectionTitle}>
+                  <div>{"Templates".toLocaleUpperCase()}</div>
+                  <div
+                    className={styles.addCondition}
+                    role="button"
+                    data-testid={"add-condition-icon"}
+                    onClick={() => setIsDrawerOpen(true)}
+                    tabIndex={0}
+                  >
+                    <Icon.Add
+                      aria-label="Plus sign icon indicating addition"
+                      className="usa-icon"
+                      size={3}
+                      color="#005EA2"
+                    />
+                    <span data-testid="add-left-rail">ADD</span>
+                  </div>
+                </div>
 
-            {Object.keys(constructedQuery).map((conditionId) => {
-              const condition = conditionsMap[conditionId];
-              return (
+                {Object.keys(constructedQuery).map((conditionId) => {
+                  const condition = conditionsMap[conditionId];
+                  return (
+                    <div
+                      key={conditionId}
+                      data-testid={
+                        activeCondition == conditionId
+                          ? `${conditionId}-card-active`
+                          : `${conditionId}-card`
+                      }
+                      className={classNames(
+                        "align-items-center",
+                        activeCondition == conditionId
+                          ? `${styles.card} ${styles.active}`
+                          : styles.card,
+                      )}
+                    >
+                      <div
+                        key={`tab-${conditionId}`}
+                        id={`tab-${conditionId}`}
+                        onClick={() => handleConditionToggle(conditionId)}
+                        tabIndex={0}
+                      >
+                        {formatDiseaseDisplay(condition.name)}
+                      </div>
+                      <Icon.Delete
+                        className={classNames("usa-icon", styles.deleteIcon)}
+                        size={5}
+                        color="red"
+                        data-testid={`delete-condition-${conditionId}`}
+                        aria-label="Trash icon indicating deletion of disease"
+                        onClick={() => {
+                          handleUpdateCondition(conditionId, true);
+                          handleConditionToggle(
+                            Object.keys(constructedQuery)[0],
+                          );
+                        }}
+                      ></Icon.Delete>
+                    </div>
+                  );
+                })}
+              </div>
+              <div className={styles.section_custom}>
+                <div className={classNames(styles.sectionTitle)}>
+                  {"Custom".toLocaleUpperCase()}
+                </div>
                 <div
-                  key={conditionId}
-                  data-testid={
-                    activeCondition == conditionId
-                      ? `${conditionId}-conditionCard-active`
-                      : `${conditionId}-conditionCard`
-                  }
                   className={classNames(
                     "align-items-center",
-                    activeCondition == conditionId
-                      ? `${styles.conditionCard} ${styles.active}`
-                      : styles.conditionCard,
+                    activeCondition == "custom"
+                      ? `${styles.card} ${styles.active}`
+                      : styles.card,
                   )}
                 >
                   <div
-                    key={`tab-${conditionId}`}
-                    id={`tab-${conditionId}`}
-                    onClick={() => handleConditionToggle(conditionId)}
+                    id={`tab-custom`}
+                    onClick={() => setActiveCondition("custom")}
                     tabIndex={0}
+                    role="button"
                   >
-                    {formatDiseaseDisplay(condition.name)}
+                    Additional codes from library
                   </div>
-                  <Icon.Delete
-                    className={classNames("usa-icon", styles.deleteIcon)}
-                    size={5}
-                    color="red"
-                    data-testid={`delete-condition-${conditionId}`}
-                    aria-label="Trash icon indicating deletion of disease"
-                    onClick={() => {
-                      handleUpdateCondition(conditionId, true);
-                      handleConditionToggle(Object.keys(constructedQuery)[0]);
-                    }}
-                  ></Icon.Delete>
-                </div>
-              );
-            })}
+                </div>{" "}
+              </div>
+            </div>
           </div>
         </div>
         <div className={styles.valueSetTemplate__right}>
-          <div className={styles.valueSetTemplate__search}>
-            <SearchField
-              id="valueSetTemplateSearch"
-              placeholder={VALUESET_SELECTION_SEARCH_PLACEHOLDER}
-              className={styles.valueSetSearch}
-              onChange={(e) => {
-                e.preventDefault();
-                setValueSetSearchFilter(e.target.value);
-              }}
-              value={valueSetSearchFilter}
-            />
-          </div>
-          <div>
-            {activeConditionValueSets && (
-              <ConceptTypeSelectionTable
-                vsTypeLevelOptions={activeConditionValueSets}
-                handleVsTypeLevelUpdate={handleSelectedValueSetUpdate(
-                  activeCondition,
-                )}
-                searchFilter={valueSetSearchFilter}
-                setSearchFilter={setValueSetSearchFilter}
+          {activeCondition !== "custom" && (
+            <div className={styles.valueSetTemplate__search}>
+              <SearchField
+                id="valueSetTemplateSearch"
+                placeholder={VALUESET_SELECTION_SEARCH_PLACEHOLDER}
+                className={styles.valueSetSearch}
+                onChange={(e) => {
+                  e.preventDefault();
+                  setValueSetSearchFilter(e.target.value);
+                }}
+                value={valueSetSearchFilter}
               />
-            )}
-          </div>
+            </div>
+          )}
+
+          {activeConditionValueSets && activeCondition !== "custom" && (
+            <ConceptTypeSelectionTable
+              vsTypeLevelOptions={activeConditionValueSets}
+              handleVsTypeLevelUpdate={handleSelectedValueSetUpdate(
+                activeCondition,
+              )}
+              searchFilter={valueSetSearchFilter}
+              setSearchFilter={setValueSetSearchFilter}
+            />
+          )}
+          {activeCondition == "custom" && (
+            <div className={styles.codeLibrary__empty}>
+              <Icon.GridView
+                aria-label="Stylized icon showing four squares in a grid"
+                className={classNames("usa-icon", styles.icon)}
+                color="#919191"
+              />
+              <p className={styles.codeLibrary__emptyText}>
+                <strong>
+                  This is a space for you to pull in individual value sets
+                </strong>
+              </p>
+              <p className={styles.codeLibrary__emptyText}>
+                <strong>
+                  These can be official value sets from CSTE, or ones that you
+                  have created in the code library.
+                </strong>
+              </p>
+              <Button className={styles.codeLibrary__button} type="button">
+                Add from code library
+              </Button>
+            </div>
+          )}
         </div>
       </div>
 

--- a/query-connector/src/app/(pages)/queryBuilding/querySelection/QueryLibrary.tsx
+++ b/query-connector/src/app/(pages)/queryBuilding/querySelection/QueryLibrary.tsx
@@ -93,7 +93,7 @@ export const MyQueriesDisplay: React.FC<UserQueriesDisplayProps> = ({
           setSelectedQuery,
         )}
       <div className="display-flex flex-justify-between flex-align-center width-full margin-bottom-4">
-        <h1 className="flex-align-center">Query Library</h1>
+        <h1 className="flex-align-center margin-0">Query Library</h1>
         <div className="margin-left-auto">
           <Button
             onClick={() => setBuildStep("condition")}

--- a/query-connector/src/app/(pages)/queryBuilding/querySelection/querySelection.module.scss
+++ b/query-connector/src/app/(pages)/queryBuilding/querySelection/querySelection.module.scss
@@ -52,6 +52,9 @@ $conditionColumnSpacing: 2fr 3fr 3fr;
 .createQueryButton {
   width: fit-content;
   padding: 1rem !important;
+  margin: 0;
+  font-size: 1.25rem;
+  line-height: 1.5rem;
 }
 
 .customQueryTable {

--- a/query-connector/src/app/ui/styles/_variables.scss
+++ b/query-connector/src/app/ui/styles/_variables.scss
@@ -4,6 +4,7 @@
 $query-connector-max-width: 45rem;
 $query-connector-wide-max-width: 90rem;
 $query-connector-content-margins: 13.75rem;
+$query-connector-content-margins-wide: 11rem;
 
 // Design System Fonts
 $serif-font: family("heading");

--- a/query-connector/src/app/ui/styles/custom-styles.scss
+++ b/query-connector/src/app/ui/styles/custom-styles.scss
@@ -510,7 +510,7 @@ ul.usa-sidenav > li.usa-sidenav__item > ul.usa-sidenav__sublist > li.usa-sidenav
   padding: 0rem;
 }
 
-#conditionTemplateSearch > div[data-testid="searchField"] {
+#templateSearch > div[data-testid="searchField"] {
   flex: 1;
 }
 

--- a/query-connector/src/app/ui/styles/layout.scss
+++ b/query-connector/src/app/ui/styles/layout.scss
@@ -11,7 +11,7 @@
 
   &__wide {
     @extend .main-container;
-    max-width: calc($query-connector-wide-max-width - 2 * $query-connector-content-margins);
+    max-width: calc($query-connector-wide-max-width - 2 * $query-connector-content-margins-wide);
   }
 }
 


### PR DESCRIPTION
# PULL REQUEST

## Summary

- Adds a button to the `ConditionsSelection` page for the "start from scratch" flow (does not link anywhere yet)
- Adds a permanent sidebar item in the `ValueSetSelection` page for "Additional codes from library"
- Adds empty state content that renders onClick of the above sidebar item (content not interactive yet)

## Related Issue

Fixes #499 

## Additional Information
This PR is content-only; full UI interaction and navigation will be implemented in #503 

## How to test
-  From `/queryBuilding`, click to create a new query; you should see the following changes:
  - Text is centered and now reads "Start from template(s)"
  - There is an additional line of text with a link to "start from scratch" (non-functional)

<img width="800" alt="Screenshot 2025-04-21 at 15 53 56" src="https://github.com/user-attachments/assets/b9cb2c68-e15d-4535-bddd-5fc89a836f1c" />  
  
- Select at least one condition and name the query, then continue to the next page; you should see the following changes:
  - The selected condition should be highlighted in the left hand side bar, and the associated value sets should display in the table to the right. **The heading should now read "Templates" instead of "Conditions"**
  - A "custom" section should show in the sidebar below the "Templates" section, with a clickable element reading "Additional codes from library

<img width="800" alt="Screenshot 2025-04-21 at 15 56 55" src="https://github.com/user-attachments/assets/a167996e-02f0-41d1-9387-2c5b889bd225" />  

- Clicking the "Additional codes" button should remove the search input and value set table and display the empty view as below ("Add from code library" button is non-functional)  

<img width="800" alt="Screenshot 2025-04-21 at 15 57 07" src="https://github.com/user-attachments/assets/fad6e4c9-6a9a-4e51-b7cd-172165d83e39" />


## Checklist

- [x] Descriptive Pull Request title
- [x] Link to relevant issues
- [x] Provide necessary context for design reviewers
- [ ] Ensure test coverage is above agreed upon threshold
- [ ] Update documentation
