### PR TITLE
refactor fhir server setup interface

### DIFF
--- a/src/app/(pages)/query/components/searchForm/SearchForm.tsx
+++ b/src/app/(pages)/query/components/searchForm/SearchForm.tsx
@@ -61,15 +61,24 @@ const SearchForm: React.FC<SearchFormProps> = function SearchForm({
   const [autofilled, setAutofilled] = useState(false); // boolean indicating if the form was autofilled, changes color if true
 
   // Fills fields with sample data based on the selected
-  const fillFields = useCallback((highlightAutofilled = true) => {
-    setFirstName(hyperUnluckyPatient.FirstName);
-    setLastName(hyperUnluckyPatient.LastName);
-    setDOB(hyperUnluckyPatient.DOB);
-    setMRN(hyperUnluckyPatient.MRN);
-    setPhone(hyperUnluckyPatient.Phone);
-    setFhirServer(hyperUnluckyPatient.FhirServer as string);
-    setAutofilled(highlightAutofilled);
-  }, []);
+  const fillFields = useCallback(
+    (highlightAutofilled = true) => {
+      const defaultFhirServer = fhirServers.includes(
+        hyperUnluckyPatient.FhirServer,
+      )
+        ? hyperUnluckyPatient.FhirServer
+        : fhirServers[0];
+
+      setFirstName(hyperUnluckyPatient.FirstName);
+      setLastName(hyperUnluckyPatient.LastName);
+      setDOB(hyperUnluckyPatient.DOB);
+      setMRN(hyperUnluckyPatient.MRN);
+      setPhone(hyperUnluckyPatient.Phone);
+      setFhirServer(defaultFhirServer);
+      setAutofilled(highlightAutofilled);
+    },
+    [fhirServers],
+  );
 
   const nameRegex = "^[A-Za-z\u00C0-\u024F\u1E00-\u1EFF\\-'. ]+$";
   const nameRuleHint =

--- a/src/app/shared/fhirClient.ts
+++ b/src/app/shared/fhirClient.ts
@@ -4,6 +4,7 @@ import { AuthData } from "../backend/dbServices/fhir-servers";
 import { createSmartJwt } from "../backend/dbServices/smartOnFhir/lib";
 import { updateFhirServer } from "../backend/dbServices/fhir-servers";
 import { fetchWithoutSSL } from "./utils";
+import dbService from "../backend/dbServices/db-service";
 /**
  * A client for querying a FHIR server.
  * @param server The FHIR server to query.
@@ -15,14 +16,7 @@ class FHIRClient {
   private serverConfig: FhirServerConfig;
   private fetch: (url: string, options?: RequestInit) => Promise<Response>;
 
-  constructor(server: string, configurations: FhirServerConfig[]) {
-    // Find the configuration for the given server
-    const config = configurations.find((c) => c.name === server);
-
-    if (!config) {
-      throw new Error(`No configuration found for server: ${server}`);
-    }
-
+  constructor(config: FhirServerConfig) {
     this.serverConfig = config;
     this.hostname = config.hostname;
 
@@ -34,6 +28,10 @@ class FHIRClient {
       method: "GET",
       headers: config.headers ?? {},
     };
+  }
+
+  static async refreshFhirServerConfig() {
+    dbService.query;
   }
 
   /**
@@ -79,7 +77,7 @@ class FHIRClient {
     }
 
     // Create a client with a configurations array containing only the test config
-    const client = new FHIRClient("test", [testConfig]);
+    const client = new FHIRClient(testConfig);
     return client;
   }
 

--- a/terraform/modules/oidc/_data.tf
+++ b/terraform/modules/oidc/_data.tf
@@ -28,6 +28,7 @@ data "aws_iam_policy_document" "github_assume_role" {
 
 # tfstate and storage policy
 # trivy:ignore:AVD-AWS-0057
+# trivy:ignore:AVD-AWS-0345
 data "aws_iam_policy_document" "storage" {
   statement {
     actions = [


### PR DESCRIPTION
# PULL REQUEST

## Summary
PR that adds a fallback FHIR server in the event that the hard coded Aidbox server isn't defined, as well as some retry logic for FHIR client setup if there's a potentially cache miss.

Screen recording below shows the state directly before (where Public HAPI becomes the fallback) and after Aidbox was seeded (where the default updates to use Aidbox)
https://github.com/user-attachments/assets/68400174-80d3-45a4-b53d-358db621fe8b

## Related Issue
A result of the discussion [here](https://skylight-hq.slack.com/archives/C05BEG226RZ/p1746045646886299)

## Checklist

- [x] Descriptive Pull Request title
- [x] Link to relevant issues
- [ ] Provide necessary context for design reviewers
- [x] Ensure test coverage is above agreed upon threshold
- [ ] Update documentation
