### PR TITLE
Add ability to specify default FHIR server

### DIFF
--- a/flyway/sql/V13_01__add_default_fhir_server.sql
+++ b/flyway/sql/V13_01__add_default_fhir_server.sql
@@ -1,0 +1,7 @@
+ALTER TABLE fhir_servers
+ADD COLUMN default_server BOOLEAN NOT NULL DEFAULT FALSE;
+
+-- Add a unique constraint that only applies when default_server is TRUE
+CREATE UNIQUE INDEX idx_fhir_servers_single_default
+ON fhir_servers (default_server)
+WHERE default_server = TRUE;

--- a/setup-scripts/seed_aidbox.sh
+++ b/setup-scripts/seed_aidbox.sh
@@ -133,14 +133,16 @@ INSERT INTO fhir_servers (
   headers,
   last_connection_attempt,
   last_connection_successful,
-  disable_cert_validation
+  disable_cert_validation,
+  default_server
 ) VALUES (
   'Aidbox',
   '${BASE_URL}/fhir',
   '{"Authorization": "Bearer ${TOKEN}"}'::jsonb,
   '${CURRENT_DATETIME}'::timestamp,
   true,
-  false
+  false,
+  true
 )
 ON CONFLICT(name)
 DO UPDATE SET

--- a/src/app/(pages)/fhirServers/page.tsx
+++ b/src/app/(pages)/fhirServers/page.tsx
@@ -209,6 +209,7 @@ const FhirServers: React.FC = () => {
         serverName,
         serverUrl,
         disableCertValidation,
+        defaultServer,
         connectionResult.success,
         authData,
       );
@@ -228,6 +229,7 @@ const FhirServers: React.FC = () => {
         serverName,
         serverUrl,
         disableCertValidation,
+        defaultServer,
         connectionResult.success,
         authData,
       );

--- a/src/app/(pages)/fhirServers/page.tsx
+++ b/src/app/(pages)/fhirServers/page.tsx
@@ -470,12 +470,17 @@ const FhirServers: React.FC = () => {
             {fhirServers
               .slice()
               .sort((a, b) =>
+                a.name.localeCompare(b.name, undefined, {
+                  sensitivity: "base",
+                }),
+              ) // Sort by name
+              .sort((a, b) =>
                 b.defaultServer === true
                   ? 1
                   : a.defaultServer === true
                     ? -1
                     : 0,
-              )
+              ) // Sort default server to the top
               .map((fhirServer) => (
                 <tr
                   key={fhirServer.id}

--- a/src/app/(pages)/fhirServers/page.tsx
+++ b/src/app/(pages)/fhirServers/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Icon, Label, TextInput } from "@trussworks/react-uswds";
+import { Icon, Label, Tag, TextInput } from "@trussworks/react-uswds";
 import {
   insertFhirServer,
   updateFhirServer,
@@ -48,6 +48,7 @@ const FhirServers: React.FC = () => {
   const [tokenEndpoint, setTokenEndpoint] = useState("");
   const [scopes, setScopes] = useState("");
   const [disableCertValidation, setDisableCertValidation] = useState(false);
+  const [defaultServer, setDefaultServer] = useState(false);
   const [connectionStatus, setConnectionStatus] = useState<
     "idle" | "success" | "error"
   >("idle");
@@ -86,6 +87,8 @@ const FhirServers: React.FC = () => {
     setTokenEndpoint("");
     setScopes("");
     setConnectionStatus("idle");
+    setDisableCertValidation(false);
+    setDefaultServer(false);
     setErrorMessage("");
     setSelectedServer(null);
   };
@@ -98,6 +101,7 @@ const FhirServers: React.FC = () => {
       setServerUrl(server.hostname);
       setConnectionStatus("idle");
       setDisableCertValidation(server.disableCertValidation);
+      setDefaultServer(server.defaultServer);
 
       // Set auth method and corresponding fields based on server data
       if (server.authType) {
@@ -461,64 +465,78 @@ const FhirServers: React.FC = () => {
             </tr>
           </thead>
           <tbody>
-            {fhirServers.map((fhirServer) => (
-              <tr
-                key={fhirServer.id}
-                className={classNames(styles.tableRowHover)}
-              >
-                <td>{fhirServer.name}</td>
-                <td>{fhirServer.hostname}</td>
-                <td>
-                  {fhirServer.authType ||
-                    (fhirServer.headers?.Authorization ? "basic" : "none")}
-                </td>
-                <td width={480}>
-                  <div className="grid-container grid-row padding-0 display-flex flex-align-center">
-                    {fhirServer.lastConnectionSuccessful ? (
-                      <>
-                        <Icon.Check
-                          size={3}
-                          className="usa-icon margin-right-05"
-                          aria-label="Connected"
-                          color="green"
-                        />
-                        Connected
-                      </>
-                    ) : (
-                      <>
-                        <Icon.Close
-                          size={3}
-                          className="usa-icon margin-right-05"
-                          aria-label="Not connected"
-                          color="red"
-                        />
-                        Not connected
-                      </>
-                    )}
-                    <span className={styles.lastChecked}>
-                      (last checked:{" "}
-                      {fhirServer.lastConnectionAttempt
-                        ? new Date(
-                            fhirServer.lastConnectionAttempt,
-                          ).toLocaleString()
-                        : "unknown"}
-                      )
-                    </span>
-                    <button
-                      className={classNames(
-                        styles.editButton,
-                        "usa-button usa-button--unstyled",
+            {fhirServers
+              .slice()
+              .sort((a, b) =>
+                b.defaultServer === true
+                  ? 1
+                  : a.defaultServer === true
+                    ? -1
+                    : 0,
+              )
+              .map((fhirServer) => (
+                <tr
+                  key={fhirServer.id}
+                  className={classNames(styles.tableRowHover)}
+                >
+                  <td>
+                    {fhirServer.name}{" "}
+                    {fhirServer.defaultServer ? (
+                      <Tag className="margin-left-2">DEFAULT</Tag>
+                    ) : null}
+                  </td>
+                  <td>{fhirServer.hostname}</td>
+                  <td>
+                    {fhirServer.authType ||
+                      (fhirServer.headers?.Authorization ? "basic" : "none")}
+                  </td>
+                  <td width={480}>
+                    <div className="grid-container grid-row padding-0 display-flex flex-align-center">
+                      {fhirServer.lastConnectionSuccessful ? (
+                        <>
+                          <Icon.Check
+                            size={3}
+                            className="usa-icon margin-right-05"
+                            aria-label="Connected"
+                            color="green"
+                          />
+                          Connected
+                        </>
+                      ) : (
+                        <>
+                          <Icon.Close
+                            size={3}
+                            className="usa-icon margin-right-05"
+                            aria-label="Not connected"
+                            color="red"
+                          />
+                          Not connected
+                        </>
                       )}
-                      onClick={() => handleOpenModal("edit", fhirServer)}
-                      aria-label={`Edit ${fhirServer.name}`}
-                    >
-                      <Icon.Edit aria-label="edit" size={3} />
-                      Edit
-                    </button>
-                  </div>
-                </td>
-              </tr>
-            ))}
+                      <span className={styles.lastChecked}>
+                        (last checked:{" "}
+                        {fhirServer.lastConnectionAttempt
+                          ? new Date(
+                              fhirServer.lastConnectionAttempt,
+                            ).toLocaleString()
+                          : "unknown"}
+                        )
+                      </span>
+                      <button
+                        className={classNames(
+                          styles.editButton,
+                          "usa-button usa-button--unstyled",
+                        )}
+                        onClick={() => handleOpenModal("edit", fhirServer)}
+                        aria-label={`Edit ${fhirServer.name}`}
+                      >
+                        <Icon.Edit aria-label="edit" size={3} />
+                        Edit
+                      </button>
+                    </div>
+                  </td>
+                </tr>
+              ))}
           </tbody>
         </Table>
         <Modal
@@ -583,6 +601,13 @@ const FhirServers: React.FC = () => {
             label="Disable certificate validation"
             checked={disableCertValidation}
             onChange={(e) => setDisableCertValidation(e.target.checked)}
+          />
+
+          <Checkbox
+            id="default-server"
+            label="Default server?"
+            checked={defaultServer}
+            onChange={(e) => setDefaultServer(e.target.checked)}
           />
         </Modal>
       </div>

--- a/src/app/(pages)/query/components/searchForm/SearchForm.tsx
+++ b/src/app/(pages)/query/components/searchForm/SearchForm.tsx
@@ -63,18 +63,11 @@ const SearchForm: React.FC<SearchFormProps> = function SearchForm({
   // Fills fields with sample data based on the selected
   const fillFields = useCallback(
     (highlightAutofilled = true) => {
-      const defaultFhirServer = fhirServers.includes(
-        hyperUnluckyPatient.FhirServer,
-      )
-        ? hyperUnluckyPatient.FhirServer
-        : fhirServers[0];
-
       setFirstName(hyperUnluckyPatient.FirstName);
       setLastName(hyperUnluckyPatient.LastName);
       setDOB(hyperUnluckyPatient.DOB);
       setMRN(hyperUnluckyPatient.MRN);
       setPhone(hyperUnluckyPatient.Phone);
-      setFhirServer(defaultFhirServer);
       setAutofilled(highlightAutofilled);
     },
     [fhirServers],

--- a/src/app/(pages)/query/page.tsx
+++ b/src/app/(pages)/query/page.tsx
@@ -5,7 +5,7 @@ import ResultsView from "./components/ResultsView";
 import PatientSearchResults from "./components/PatientSearchResults";
 import SearchForm from "./components/searchForm/SearchForm";
 import SelectQuery from "./components/SelectQuery";
-import { DEFAULT_DEMO_FHIR_SERVER, Mode } from "../../shared/constants";
+import { Mode } from "../../shared/constants";
 import StepIndicator, {
   CUSTOMIZE_QUERY_STEPS,
 } from "./components/stepIndicator/StepIndicator";
@@ -36,15 +36,14 @@ const Query: React.FC = () => {
   );
   const [mode, setMode] = useState<Mode>("search");
   const [loading, setLoading] = useState<boolean>(false);
-  const [fhirServer, setFhirServer] = useState<string>(
-    DEFAULT_DEMO_FHIR_SERVER,
-  );
+  const [fhirServer, setFhirServer] = useState<string>("");
   const [fhirServers, setFhirServers] = useState<string[]>([]);
   const ctx = useContext(DataContext);
 
   async function fetchFHIRServerNames() {
     const servers = await getFhirServerNames();
     setFhirServers(servers);
+    setFhirServer(servers[0]);
   }
 
   useEffect(() => {

--- a/src/app/backend/dbServices/fhir-servers.ts
+++ b/src/app/backend/dbServices/fhir-servers.ts
@@ -115,6 +115,7 @@ class FhirServerConfigService extends FhirServerConfigServiceInternal {
    * @param name - The new name of the FHIR server
    * @param hostname - The new URL/hostname of the FHIR server
    * @param disableCertValidation - Whether to disable certificate validation
+   * @param defaultServer - Whether this is the default server
    * @param lastConnectionSuccessful - Optional boolean indicating if the last connection was successful
    * @param authData - Authentication data including auth type and credentials
    * @returns An object indicating success or failure with optional error message
@@ -126,6 +127,7 @@ class FhirServerConfigService extends FhirServerConfigServiceInternal {
     name: string,
     hostname: string,
     disableCertValidation: boolean,
+    defaultServer: boolean,
     lastConnectionSuccessful?: boolean,
     authData?: AuthData,
   ) {
@@ -138,13 +140,14 @@ class FhirServerConfigService extends FhirServerConfigServiceInternal {
       last_connection_successful = $4,
       headers = $5,
       disable_cert_validation = $6,
-      auth_type = $7,
-      client_id = $8,
-      client_secret = $9,
-      token_endpoint = $10,
-      scopes = $11,
-      access_token = $12,
-      token_expiry = $13
+      default_server = $7,
+      auth_type = $8,
+      client_id = $9,
+      client_secret = $10,
+      token_endpoint = $11,
+      scopes = $12,
+      access_token = $13,
+      token_expiry = $14
     WHERE id = $1
     RETURNING *;
   `;
@@ -187,6 +190,7 @@ class FhirServerConfigService extends FhirServerConfigServiceInternal {
         lastConnectionSuccessful,
         headers,
         disableCertValidation,
+        defaultServer,
         authType,
         authData?.clientId || null,
         authData?.clientSecret || null,
@@ -224,6 +228,7 @@ class FhirServerConfigService extends FhirServerConfigServiceInternal {
    * @param name - The name of the FHIR server
    * @param hostname - The URL/hostname of the FHIR server
    * @param disableCertValidation - Whether to disable certificate validation
+   * @param defaultServer - Whether this is the default server
    * @param lastConnectionSuccessful - Optional boolean indicating if the last connection was successful
    * @param authData - Authentication data including auth type and credentials
    * @returns An object indicating success or failure with optional error message
@@ -235,6 +240,7 @@ class FhirServerConfigService extends FhirServerConfigServiceInternal {
     name: string,
     hostname: string,
     disableCertValidation: boolean,
+    defaultServer: boolean,
     lastConnectionSuccessful?: boolean,
     authData?: AuthData,
   ) {
@@ -259,6 +265,7 @@ class FhirServerConfigService extends FhirServerConfigServiceInternal {
         lastConnectionSuccessful,
         headers,
         disableCertValidation,
+        defaultServer,
         authType,
         authData?.clientId || null,
         authData?.clientSecret || null,

--- a/src/app/backend/dbServices/fhir-servers.ts
+++ b/src/app/backend/dbServices/fhir-servers.ts
@@ -56,6 +56,10 @@ class FhirServerConfigService extends FhirServerConfigServiceInternal {
 
   static async getFhirServerNames(): Promise<string[]> {
     const configs = await super.getFhirServerConfigs();
+    // Sort so that the default server is always first
+    configs.sort((a, b) =>
+      b.defaultServer === true ? 1 : a.defaultServer === true ? -1 : 0,
+    );
     return configs.map((config) => config.name);
   }
 

--- a/src/app/backend/dbServices/util.ts
+++ b/src/app/backend/dbServices/util.ts
@@ -6,6 +6,7 @@ INSERT INTO fhir_servers (
   last_connection_successful,
   headers,
   disable_cert_validation,
+  default_server,
   auth_type,
   client_id,
   client_secret,
@@ -14,7 +15,7 @@ INSERT INTO fhir_servers (
   access_token,
   token_expiry
 )
-VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13)
+VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14)
 RETURNING *;
 `;
 

--- a/src/app/models/entities/fhir-servers.ts
+++ b/src/app/models/entities/fhir-servers.ts
@@ -7,6 +7,7 @@ export interface FhirServerConfig {
   lastConnectionAttempt?: string;
   lastConnectionSuccessful?: boolean;
   disableCertValidation: boolean;
+  defaultServer: boolean;
   authType?: "none" | "basic" | "client_credentials" | "SMART";
   clientId?: string;
   clientSecret?: string;

--- a/src/app/shared/constants.ts
+++ b/src/app/shared/constants.ts
@@ -45,10 +45,8 @@ export type DemoDataFields = {
   DOB: string;
   MRN: string;
   Phone: string;
-  FhirServer: string;
 };
 
-export const DEFAULT_DEMO_FHIR_SERVER = "Aidbox";
 export const HYPER_UNLUCKY_DEFAULT_ID = "f288c654-6885-4f48-999c-48d776dc06af";
 /*
  * Common "Hyper Unlucky" patient data used for all non-newborn screening use cases
@@ -60,7 +58,6 @@ export const hyperUnluckyPatient: DemoDataFields = {
   DOB: "1975-12-06",
   MRN: "8692756",
   Phone: "517-425-1398",
-  FhirServer: DEFAULT_DEMO_FHIR_SERVER,
 };
 
 /*Labels and values for the state options dropdown on the query page*/

--- a/src/app/shared/fhirClient.ts
+++ b/src/app/shared/fhirClient.ts
@@ -52,6 +52,7 @@ class FHIRClient {
       name: "test",
       hostname: url,
       disableCertValidation: disableCertValidation,
+      defaultServer: false,
       headers: authData?.headers || {},
     };
 
@@ -288,6 +289,7 @@ class FHIRClient {
           this.serverConfig.name,
           this.serverConfig.hostname,
           this.serverConfig.disableCertValidation,
+          this.serverConfig.defaultServer,
           this.serverConfig.lastConnectionSuccessful,
           {
             authType: this.serverConfig.authType as

--- a/src/app/tests/integration/fhir-servers.test.ts
+++ b/src/app/tests/integration/fhir-servers.test.ts
@@ -20,6 +20,7 @@ const TEST_FHIR_SERVER = {
   headers: null,
   lastConnectionSuccessful: true,
   disableCertValidation: false,
+  defaultServer: false,
 };
 
 const DEFAULT_FHIR_SERVER_LENGTH = 10;
@@ -46,6 +47,8 @@ describe("FHIR Servers tests", () => {
       TEST_FHIR_SERVER.lastConnectionSuccessful,
       {},
       TEST_FHIR_SERVER.disableCertValidation,
+      TEST_FHIR_SERVER.defaultServer,
+
       "none",
       null,
       null,

--- a/src/app/tests/integration/fhir-servers.test.ts
+++ b/src/app/tests/integration/fhir-servers.test.ts
@@ -75,7 +75,7 @@ describe("FHIR Servers tests", () => {
       NEW_NAME,
       NEW_HOSTNAME,
       false,
-      true,
+      false,
     );
     newFhirServers = await getFhirServerConfigs(true);
     const shouldBeUpdated = newFhirServers.find((v) => v.name === NEW_NAME);


### PR DESCRIPTION
# PULL REQUEST

## Summary

Adds the ability to choose one FHIR server as the default. 

## Related Issue

Fixes #535 
https://linear.app/skylight-cdc/issue/QUE-248/make-default-fhir-server-configurable

## Copilot summary

This pull request introduces a "default server" feature for FHIR servers, allowing one server to be designated as the default. Key changes include database schema updates, backend service modifications, and frontend adjustments to support this new functionality.

### Database Updates:
* Added a `default_server` column to the `fhir_servers` table and enforced a unique constraint to ensure only one server can be marked as default at a time. (`flyway/sql/V13_01__add_default_fhir_server.sql`)

### Backend Changes:
* Updated the `FhirServerConfigService` class to handle the `defaultServer` property, including sorting servers to prioritize the default server and modifying SQL queries to include the new column. (`src/app/backend/dbServices/fhir-servers.ts`) [[1]](diffhunk://#diff-fd5c8944a5c9153f5b87349e5b9eba497529d705fca9d7df2b27df2c36bf49e4R59-R62) [[2]](diffhunk://#diff-fd5c8944a5c9153f5b87349e5b9eba497529d705fca9d7df2b27df2c36bf49e4L137-R150) [[3]](diffhunk://#diff-fd5c8944a5c9153f5b87349e5b9eba497529d705fca9d7df2b27df2c36bf49e4R268)
* Adjusted utility functions to handle the `default_server` field when inserting new FHIR server records. (`src/app/backend/dbServices/util.ts`) [[1]](diffhunk://#diff-b8636a1a2e80cb7a71f1aa2ace5c3ffe6f576c1df2103f53e03acf60067c57b8R9) [[2]](diffhunk://#diff-b8636a1a2e80cb7a71f1aa2ace5c3ffe6f576c1df2103f53e03acf60067c57b8L17-R18)

### Frontend Changes:
* Added a checkbox in the FHIR server modal to set a server as default. (`src/app/(pages)/fhirServers/page.tsx`)
* Updated the FHIR servers table to display a "DEFAULT" tag next to the default server and sort the list to show the default server first. (`src/app/(pages)/fhirServers/page.tsx`)
* Modified the query page to automatically select the default server when fetching server names. (`src/app/(pages)/query/page.tsx`)

### Code Cleanup:
* Removed hardcoded default FHIR server references and associated constants. (`src/app/shared/constants.ts`, `src/app/(pages)/query/components/searchForm/SearchForm.tsx`) [[1]](diffhunk://#diff-6430d707d1faa4492f9d2d4a879c053d26909b22d973491852eac32206a7ff94L48-L51) [[2]](diffhunk://#diff-75665f5569712172c5ffadc1396936b85bdea2f9f867d16b195d24394fa83a6bL66-L77)

These changes ensure that the default server feature is consistently applied across the application, enhancing usability and reducing manual configuration.

## Screenshots

<img width="1754" alt="Screenshot 2025-05-01 at 2 04 37 PM" src="https://github.com/user-attachments/assets/fab5252b-a83d-4a20-bb2b-de97e3bcd994" />
<img width="1754" alt="Screenshot 2025-05-01 at 2 04 49 PM" src="https://github.com/user-attachments/assets/18c9321a-7900-434f-b0ab-40168c2c6a96" />
<img width="1754" alt="Screenshot 2025-05-01 at 2 04 59 PM" src="https://github.com/user-attachments/assets/f97c8b28-6adb-4a97-b420-542d557869d8" />

