### PR TITLE
Switch image tag pulled by Terraform to "latest"

### DIFF
--- a/terraform/implementation/ecs/main.tf
+++ b/terraform/implementation/ecs/main.tf
@@ -48,7 +48,7 @@ module "ecs" {
       max_capacity      = 5,
       app_repo          = "ghcr.io/cdcgov/dibbs-query-connector",
       app_image         = "${terraform.workspace}-query-connector",
-      app_version       = "main",
+      app_version       = "latest",
       container_port    = 3000,
       host_port         = 3000,
       public            = true,


### PR DESCRIPTION
#530 changed the way we tagged our docker images - this will fix our deploys to actually pull the latest until we start properly assigning version numbers