### PR TITLE
String custom codes pages together

### DIFF
--- a/src/app/(pages)/codeLibrary/CodeLibrary.test.tsx
+++ b/src/app/(pages)/codeLibrary/CodeLibrary.test.tsx
@@ -22,6 +22,17 @@ import { getCustomValueSetById } from "@/app/shared/custom-code-service";
 
 jest.mock("next-auth/react");
 
+jest.mock("next/navigation", () => ({
+  useRouter: () => ({
+    push: jest.fn(),
+    prefetch: jest.fn(),
+    replace: jest.fn(),
+    back: jest.fn(),
+    forward: jest.fn(),
+    refresh: jest.fn(),
+  }),
+}));
+
 jest.mock(
   "@/app/ui/components/withAuth/WithAuth",
   () =>

--- a/src/app/(pages)/codeLibrary/__snapshots__/CodeLibrary.test.tsx.snap
+++ b/src/app/(pages)/codeLibrary/__snapshots__/CodeLibrary.test.tsx.snap
@@ -12,29 +12,6 @@ exports[`Code library interaction renders action buttons for custom value sets o
         <div
           class="header"
         >
-          <a
-            aria-label="Back arrow indicating ability to navigate back a page if clicked"
-            class="back-link text-no-underline"
-            data-testid="backArrowLink"
-            href="#"
-          >
-            <svg
-              aria-label="Arrow point left indicating return to previous step"
-              class="usa-icon"
-              focusable="false"
-              height="1em"
-              role="img"
-              viewBox="0 0 24 24"
-              width="1em"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="M20 11H7.83l5.59-5.59L12 4l-8 8 8 8 1.41-1.41L7.83 13H20v-2z"
-              />
-            </svg>
-             
-            Back to Query library
-          </a>
           <h1
             class="header__title"
           >
@@ -580,29 +557,6 @@ exports[`Code library loading view renders a skeleton loading state when loading
         <div
           class="header"
         >
-          <a
-            aria-label="Back arrow indicating ability to navigate back a page if clicked"
-            class="back-link text-no-underline"
-            data-testid="backArrowLink"
-            href="#"
-          >
-            <svg
-              aria-label="Arrow point left indicating return to previous step"
-              class="usa-icon"
-              focusable="false"
-              height="1em"
-              role="img"
-              viewBox="0 0 24 24"
-              width="1em"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="M20 11H7.83l5.59-5.59L12 4l-8 8 8 8 1.41-1.41L7.83 13H20v-2z"
-              />
-            </svg>
-             
-            Back to Query library
-          </a>
           <h1
             class="header__title"
           >
@@ -913,29 +867,6 @@ exports[`Code library rendered view renders concept codes for the value set when
         <div
           class="header"
         >
-          <a
-            aria-label="Back arrow indicating ability to navigate back a page if clicked"
-            class="back-link text-no-underline"
-            data-testid="backArrowLink"
-            href="#"
-          >
-            <svg
-              aria-label="Arrow point left indicating return to previous step"
-              class="usa-icon"
-              focusable="false"
-              height="1em"
-              role="img"
-              viewBox="0 0 24 24"
-              width="1em"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="M20 11H7.83l5.59-5.59L12 4l-8 8 8 8 1.41-1.41L7.83 13H20v-2z"
-              />
-            </svg>
-             
-            Back to Query library
-          </a>
           <h1
             class="header__title"
           >
@@ -1458,29 +1389,6 @@ exports[`Code library rendered view renders the correct content 1`] = `
         <div
           class="header"
         >
-          <a
-            aria-label="Back arrow indicating ability to navigate back a page if clicked"
-            class="back-link text-no-underline"
-            data-testid="backArrowLink"
-            href="#"
-          >
-            <svg
-              aria-label="Arrow point left indicating return to previous step"
-              class="usa-icon"
-              focusable="false"
-              height="1em"
-              role="img"
-              viewBox="0 0 24 24"
-              width="1em"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="M20 11H7.83l5.59-5.59L12 4l-8 8 8 8 1.41-1.41L7.83 13H20v-2z"
-              />
-            </svg>
-             
-            Back to Query library
-          </a>
           <h1
             class="header__title"
           >

--- a/src/app/(pages)/codeLibrary/page.tsx
+++ b/src/app/(pages)/codeLibrary/page.tsx
@@ -391,7 +391,12 @@ const CodeLibrary: React.FC = () => {
         >
           <div className={styles.header}>
             {mode !== "manage" && (
-              <Backlink onClick={goBack} label={"Back to My queries"} />
+              <Backlink
+                onClick={goBack}
+                label={`Back to ${
+                  prevPage == "condition" ? "Create query" : "templates"
+                }`}
+              />
             )}
             <h1 className={styles.header__title}>Manage codes</h1>
             {/* <div className={styles.header__subtitle}>
@@ -667,9 +672,13 @@ const CodeLibrary: React.FC = () => {
       {mode == "select" && (
         <>
           <p>
-            <Backlink onClick={goBack} label={"Back to My queries"} />
+            <Backlink
+              onClick={goBack}
+              label={`Back to ${
+                prevPage == "valueset" ? "Create query" : "templates"
+              }`}
+            />
           </p>
-          <p>{`Back to previous page: ${prevPage}`}</p>
         </>
       )}
       <Modal

--- a/src/app/(pages)/codeLibrary/page.tsx
+++ b/src/app/(pages)/codeLibrary/page.tsx
@@ -369,9 +369,7 @@ const CodeLibrary: React.FC = () => {
           className={classNames("main-container__wide", styles.mainContainer)}
         >
           <div className={styles.header}>
-            {mode === "manage" ? (
-              <Backlink onClick={() => {}} label={"Back to Query library"} />
-            ) : (
+            {mode !== "manage" && (
               <Backlink onClick={goBack} label={"Back to My queries"} />
             )}
             <h1 className={styles.header__title}>Manage codes</h1>

--- a/src/app/(pages)/codeLibrary/page.tsx
+++ b/src/app/(pages)/codeLibrary/page.tsx
@@ -37,6 +37,7 @@ import { deleteCustomValueSet } from "@/app/shared/custom-code-service";
 import dynamic from "next/dynamic";
 import type { ModalProps, ModalRef } from "../../ui/designSystem/modal/Modal";
 import { showToastConfirmation } from "@/app/ui/designSystem/toast/Toast";
+import { useSaveQueryAndRedirect } from "@/app/backend/query-building/useSaveQueryAndRedirect";
 
 /**
  * Component for Query Building Flow
@@ -45,9 +46,13 @@ import { showToastConfirmation } from "@/app/ui/designSystem/toast/Toast";
 const CodeLibrary: React.FC = () => {
   // -------- component state -------- //
   // --------------------------------- //
-  const [loading, setLoading] = useState<boolean>(true);
-  const [mode, setMode] = useState<CustomCodeMode>("manage");
+  const ctx = useContext(DataContext);
 
+  const [loading, setLoading] = useState<boolean>(true);
+  const [mode, setMode] = useState<CustomCodeMode>(
+    (ctx?.selectedQuery?.pageMode as CustomCodeMode) || "manage",
+  );
+  const [prevPage, setPrevPage] = useState("");
   const { data: session } = useSession();
   const username = session?.user?.username || "";
   const [currentUser, setCurrentUser] = useState<User>();
@@ -82,7 +87,6 @@ const CodeLibrary: React.FC = () => {
     { ssr: false },
   );
 
-  const ctx = useContext(DataContext);
   let totalPages = Math.ceil(filteredValueSets.length / itemsPerPage);
 
   async function fetchValueSetsAndConditions() {
@@ -115,7 +119,8 @@ const CodeLibrary: React.FC = () => {
 
   // update the current page details when switching between build steps
   useEffect(() => {
-    ctx?.setCurrentPage(mode);
+    setPrevPage(ctx?.currentPage || "");
+    setMode(mode);
     applyFilters();
   }, [mode]);
 
@@ -194,13 +199,16 @@ const CodeLibrary: React.FC = () => {
 
   // ---- page interaction/display ---- //
   // --------------------------------- //
+  const saveQueryAndRedirect = useSaveQueryAndRedirect();
+
   function goBack() {
-    // TODO: this will need to be handled differently
-    // depending on how we arrived at this page:
-    // from gear menu: no backnav
-    // from "start from scratch": back to templates
-    // from hybrid/query building: back to query
-    console.log("do a backnav thing");
+    ctx?.selectedQuery &&
+      saveQueryAndRedirect(
+        {},
+        ctx?.selectedQuery?.queryName,
+        "/queryBuilding",
+        prevPage,
+      );
   }
 
   const handleTextSearch = (vs: DibbsValueSet) => {
@@ -642,6 +650,14 @@ const CodeLibrary: React.FC = () => {
             activeValueSet?.userCreated ? activeValueSet : emptyValueSet
           }
         />
+      )}
+      {mode == "select" && (
+        <>
+          <p>
+            <Backlink onClick={goBack} label={"Back to My queries"} />
+          </p>
+          <p>{`Back to previous page: ${prevPage}`}</p>
+        </>
       )}
       <Modal
         id="delete-vs-modal"

--- a/src/app/(pages)/queryBuilding/buildFromTemplates/BuildFromTemplates.tsx
+++ b/src/app/(pages)/queryBuilding/buildFromTemplates/BuildFromTemplates.tsx
@@ -2,7 +2,7 @@
 
 import Backlink from "@/app/ui/designSystem/backLink/Backlink";
 import styles from "./conditionTemplateSelection.module.scss";
-import { Label, TextInput, Button } from "@trussworks/react-uswds";
+import { Label, TextInput, Button, Icon } from "@trussworks/react-uswds";
 import {
   Dispatch,
   SetStateAction,
@@ -81,6 +81,8 @@ const BuildFromTemplates: React.FC<BuildFromTemplatesProps> = ({
   const { data: session } = useSession();
   const focusRef = useRef<HTMLInputElement | null>(null);
   const [loading, setLoading] = useState<boolean>(false);
+  const [errorMessage, setErrorMessage] = useState<boolean>(false);
+
   const [queryName, setQueryName] = useState<string | undefined>(
     structuredClone(selectedQuery.queryName),
   );
@@ -322,12 +324,16 @@ const BuildFromTemplates: React.FC<BuildFromTemplatesProps> = ({
                 id="queryNameInput"
                 name="queryNameInput"
                 type="text"
-                className={styles.input}
+                className={classNames(
+                  styles.input,
+                  errorMessage ? styles.errorMessage : "",
+                )}
                 defaultValue={queryName ?? ""}
                 required
                 onChange={(event) => {
                   const newName = event.target.value;
                   setQueryName(newName);
+                  setErrorMessage(false);
                   setSelectedQuery(
                     structuredClone({
                       ...selectedQuery,
@@ -337,6 +343,15 @@ const BuildFromTemplates: React.FC<BuildFromTemplatesProps> = ({
                 }}
                 data-testid="queryNameInput"
               />
+              {errorMessage && formError.queryName && (
+                <div className={styles.errorMessage}>
+                  <Icon.Error
+                    aria-label="warning icon indicating an error is present"
+                    className={styles.errorMessage}
+                  />
+                  Enter a name for the query.
+                </div>
+              )}
             </div>
             <div className={styles.customQuery__saveButton}>
               <Button
@@ -375,6 +390,7 @@ const BuildFromTemplates: React.FC<BuildFromTemplatesProps> = ({
               setLoading={setLoading}
               constructedQuery={constructedQuery}
               handleConditionUpdate={handleConditionUpdate}
+              renderErrorMessage={setErrorMessage}
             />
           )}
           {/* Step Two: Select ValueSets */}

--- a/src/app/(pages)/queryBuilding/buildFromTemplates/conditionTemplateSelection.module.scss
+++ b/src/app/(pages)/queryBuilding/buildFromTemplates/conditionTemplateSelection.module.scss
@@ -8,7 +8,21 @@
   margin-bottom: 0 !important;
   max-width: 70rem !important;
 }
+input.errorMessage {
+  border: 2px solid $error-dark;
+}
+.errorMessage {
+  display: flex;
+  align-items: center;
+  color: $error-dark;
+  margin-top: 0.25rem;
+  line-height: 1.25rem;
 
+  svg {
+    margin-right: 0.25rem;
+    margin-bottom: 2.5px;
+  }
+}
 // Condition styles
 
 .templateContainer {

--- a/src/app/(pages)/queryBuilding/components/ConditionSelection.tsx
+++ b/src/app/(pages)/queryBuilding/components/ConditionSelection.tsx
@@ -22,6 +22,7 @@ type ConditionSelectionProps = {
   formError: FormError;
   setLoading: Dispatch<SetStateAction<boolean>>;
   loading: boolean;
+  renderErrorMessage: Dispatch<SetStateAction<boolean>>;
 };
 
 /**
@@ -34,7 +35,7 @@ type ConditionSelectionProps = {
  * @param root0.queryName - current checkbox selection status
  * @param root0.formError - indicates missing or incorrect form data
  * @param root0.setFormError - state function that updates the status of the
- * condition selection form input data
+ * @param root0.renderErrorMessage - state function that renders a form validation error
  * @returns A component for display to redner on the query building page
  */
 export const ConditionSelection: React.FC<ConditionSelectionProps> = ({
@@ -44,6 +45,7 @@ export const ConditionSelection: React.FC<ConditionSelectionProps> = ({
   queryName,
   formError,
   setFormError,
+  renderErrorMessage,
 }) => {
   const focusRef = useRef<HTMLInputElement | null>(null);
   const [searchFilter, setSearchFilter] = useState<string>();
@@ -70,11 +72,17 @@ export const ConditionSelection: React.FC<ConditionSelectionProps> = ({
         <h2 className="margin-y-0-important">Start from template(s)</h2>
         <p>
           Don't see what you're looking for? You can also{" "}
-          {/* TODO: link to "Select" mode of Code library page */}
           <a
             href="#"
             onClick={() => {
-              saveQueryAndRedirect(constructedQuery, queryName, "/codeLibrary");
+              !formError.queryName
+                ? saveQueryAndRedirect(
+                    constructedQuery,
+                    queryName,
+                    "/codeLibrary",
+                    "select",
+                  )
+                : renderErrorMessage(true);
             }}
             className={styles.startFromScratchLink}
           >

--- a/src/app/(pages)/queryBuilding/components/ValueSetSelection.tsx
+++ b/src/app/(pages)/queryBuilding/components/ValueSetSelection.tsx
@@ -329,6 +329,7 @@ export const ValueSetSelection: React.FC<ConditionSelectionProps> = ({
                         constructedQuery,
                         queryName,
                         "/codeLibrary",
+                        "select",
                       )
                     }
                   >
@@ -378,6 +379,7 @@ export const ValueSetSelection: React.FC<ConditionSelectionProps> = ({
                     constructedQuery,
                     queryName,
                     "/codeLibrary",
+                    "select",
                   )
                 }
               >

--- a/src/app/(pages)/queryBuilding/page.tsx
+++ b/src/app/(pages)/queryBuilding/page.tsx
@@ -24,6 +24,10 @@ const QueryBuilding: React.FC = () => {
   }, [buildStep]);
 
   useEffect(() => {
+    if (queryContext.selectedQuery?.pageMode) {
+      setBuildStep(queryContext.selectedQuery.pageMode as BuildStep);
+    }
+
     queryContext.setToastConfig({
       position: "bottom-left",
       stacked: true,

--- a/src/app/(pages)/queryBuilding/querySelection/utils.tsx
+++ b/src/app/(pages)/queryBuilding/querySelection/utils.tsx
@@ -144,5 +144,6 @@ export const renderModal = (
 export type SelectedQueryDetails = {
   queryName?: string;
   queryId?: string;
+  pageMode?: string;
 };
 export type SelectedQueryState = SelectedQueryDetails | null;

--- a/src/app/backend/query-building/useSaveQueryAndRedirect.ts
+++ b/src/app/backend/query-building/useSaveQueryAndRedirect.ts
@@ -24,6 +24,7 @@ export function useSaveQueryAndRedirect() {
     constructedQuery: NestedQuery,
     newQueryName: string | undefined,
     redirectPath: string,
+    pageMode?: string,
   ) {
     const username = session?.user?.username;
     const queryName = newQueryName || context?.selectedQuery?.queryName;
@@ -49,6 +50,7 @@ export function useSaveQueryAndRedirect() {
       context?.setSelectedQuery?.({
         queryId: results[0].id,
         queryName,
+        pageMode,
       });
 
       const queries = await getCustomQueries();


### PR DESCRIPTION
# PULL REQUEST

## Summary
Updates the navigation display text for custom codes pages:
- When navigating to `/codeLibrary` from the gear menu: 
  - no back link appears
- When navigating to `/codeLibrary` via the "start from scratch" link:
  - Back link reads "Back to templates"
  - Clicking back link loads the `/queryBuilding` page with `buildStep` set to "condition"
  - Query name is persisted
- When navigating to `/codeLibrary` via the "Add codes from library" button:
  - Back link reads "Back to Create query"
  - Clicking back link loads the `/queryBuilding` page with `buildStep` set to "valuesets"
  - Query name is persisted

 **NOTE**: "select" mode for the `codeLibrary` page is not included in this PR; the page will be blank with just the back link.  _Query data is also currently not persisted on backnav_. This functionality is covered in #617 

## Related Issue

Fixes #503 

## Additional Information

Anything else the review team should know?

## Checklist

- [x] Descriptive Pull Request title
- [x] Link to relevant issues
- [x] Provide necessary context for design reviewers
- [ ] Ensure test coverage is above agreed upon threshold
- [ ] Update documentation
