### PR TITLE
Rename Query Library to Query Repository

### DIFF
--- a/e2e/query_building.spec.ts
+++ b/e2e/query_building.spec.ts
@@ -4,7 +4,7 @@ import { test, expect } from "@playwright/test";
 import { TEST_URL } from "../playwright-setup";
 
 // consts
-const QUERY_LIBRARY = "Query Library";
+const QUERY_REPOSITORY = "Query repository";
 const CUSTOM_QUERY = "Custom Query";
 const SELECT_TEMPLATES = "Start from template(s)";
 const BACKLINK_MY_QUERIES = "Back to My queries";
@@ -35,7 +35,7 @@ test.describe("building a new query", () => {
     await page.goto(`${TEST_URL}/queryBuilding`);
     await expect(
       page.getByRole("heading", {
-        name: QUERY_LIBRARY,
+        name: QUERY_REPOSITORY,
         exact: true,
       }),
     ).toBeVisible();

--- a/e2e/query_editing.spec.ts
+++ b/e2e/query_editing.spec.ts
@@ -23,7 +23,7 @@ test.describe("editing an exisiting query", () => {
     await page.goto(`${TEST_URL}/queryBuilding`);
     await expect(
       page.getByRole("heading", {
-        name: "Query Library",
+        name: "Query repository",
         exact: true,
       }),
     ).toBeVisible();

--- a/src/app/(pages)/query/components/selectQuery/NoQueriesDisplay.tsx
+++ b/src/app/(pages)/query/components/selectQuery/NoQueriesDisplay.tsx
@@ -41,7 +41,7 @@ const NoQueriesDisplay: React.FC<NoQueriesDisplayProps> = ({ userRole }) => {
         <p className="margin-0">
           {userRole === UserRole.STANDARD
             ? `Get started by contacting an admin: ${adminNames.join(", ")}.`
-            : "You can head to the query library to build the query."}
+            : "You can head to the query repository to build the query."}
         </p>
 
         {userRole === UserRole.ADMIN || userRole === UserRole.SUPER_ADMIN ? (
@@ -50,7 +50,7 @@ const NoQueriesDisplay: React.FC<NoQueriesDisplayProps> = ({ userRole }) => {
             className="margin-top-3"
             type={"button"}
           >
-            Go to query library
+            Go to query repository
           </Button>
         ) : (
           <></>

--- a/src/app/(pages)/query/components/selectQuery/QueryRedirectDisplay.tsx
+++ b/src/app/(pages)/query/components/selectQuery/QueryRedirectDisplay.tsx
@@ -38,7 +38,7 @@ const QueryRedirectInfo: React.FC<QueryRedirectInfoProps> = ({ userRole }) => {
             <span>
               Go to the{" "}
               <a target="_blank" href={PAGES.QUERY_BUILDING}>
-                query library{" "}
+                query repository{" "}
               </a>
               to build it.
             </span>

--- a/src/app/(pages)/queryBuilding/__snapshots__/page.test.tsx.snap
+++ b/src/app/(pages)/queryBuilding/__snapshots__/page.test.tsx.snap
@@ -7,7 +7,7 @@ exports[`tests the query building steps renders the empty state 1`] = `
   <h1
     class="queryTitle"
   >
-    Query Library
+    Query repository
   </h1>
   <div
     class="background-dark emptyStateQueryContainer"

--- a/src/app/(pages)/queryBuilding/page.test.tsx
+++ b/src/app/(pages)/queryBuilding/page.test.tsx
@@ -55,7 +55,7 @@ describe("tests the query building steps", () => {
       expect(screen.queryByText("Loading")).not.toBeInTheDocument();
     });
 
-    expect(screen.getByText("Query Library")).toBeInTheDocument();
+    expect(screen.getByText("Query repository")).toBeInTheDocument();
 
     expectedQueryNames.forEach(async (name) => {
       expect(screen.getByText(name)).toBeInTheDocument();

--- a/src/app/(pages)/queryBuilding/querySelection/EmptyQueriesDisplay.tsx
+++ b/src/app/(pages)/queryBuilding/querySelection/EmptyQueriesDisplay.tsx
@@ -44,7 +44,7 @@ export const EmptyQueriesDisplay: React.FC<EmptyQueryProps> = ({
 
   return (
     <div data-testid={"empty-state-container"}>
-      <h1 className={styles.queryTitle}>Query Library</h1>
+      <h1 className={styles.queryTitle}>Query repository</h1>
 
       <div
         className={classNames(

--- a/src/app/(pages)/queryBuilding/querySelection/QueryRepository.tsx
+++ b/src/app/(pages)/queryBuilding/querySelection/QueryRepository.tsx
@@ -105,7 +105,7 @@ export const MyQueriesDisplay: React.FC<UserQueriesDisplayProps> = ({
         setDeletedQuery,
       )}{" "}
       <div className="display-flex flex-justify-between flex-align-center width-full margin-bottom-4">
-        <h1 className="flex-align-center margin-0">Query Library</h1>
+        <h1 className="flex-align-center margin-0">Query repository</h1>
         <div className="margin-left-auto">
           <Button
             onClick={() => {

--- a/src/app/(pages)/queryBuilding/querySelection/QuerySelection.tsx
+++ b/src/app/(pages)/queryBuilding/querySelection/QuerySelection.tsx
@@ -10,7 +10,7 @@ import {
 } from "react";
 import { useSession } from "next-auth/react";
 import EmptyQueriesDisplay from "./EmptyQueriesDisplay";
-import MyQueriesDisplay from "./QueryLibrary";
+import MyQueriesDisplay from "./QueryRepository";
 import { BuildStep } from "@/app/shared/constants";
 import { DataContext } from "@/app/shared/DataProvider";
 import { CustomUserQuery } from "@/app/models/entities/query";

--- a/src/app/shared/constants.ts
+++ b/src/app/shared/constants.ts
@@ -214,5 +214,5 @@ export const MISSING_PATIENT_IDENTIFIERS =
 
 // Constants for the code library
 export const CUSTOM_CONDITION_ID = "custom_condition"; // This should be a unique identifier for the condition, we could just call it '0', but we will need some way to exclude it from certain screens, so that's why I lean toward it being hardcoded.
-export const CUSTOM_CONDITION_NAME = "Additional codes from library"; // This is the name of the condition that will be displayed on the query library home page
+export const CUSTOM_CONDITION_NAME = "Additional codes from library"; // This is the name of the condition that will be displayed on the query repository home page
 export const CUSTOM_VALUESET_ARRAY_ID = "custom"; // This array of valuesets that are user-managed (both user-created and non-user-created), we will need to add this to the query_data table in the query table

--- a/src/app/shared/page-routes.ts
+++ b/src/app/shared/page-routes.ts
@@ -35,7 +35,7 @@ pagesConfig[PAGES.QUERY] = {
 pagesConfig[PAGES.QUERY_BUILDING] = {
   position: 1,
   path: PAGES.QUERY_BUILDING,
-  name: "Query library",
+  name: "Query repository",
   roleAccess: [UserRole.SUPER_ADMIN, UserRole.ADMIN],
 };
 pagesConfig[PAGES.CODE_LIBRARY] = {


### PR DESCRIPTION
# PULL REQUEST

## Summary
Renames the Query library page and all references to `Query repository`, to more clearly distinguish it from `Code library`. 

## Related Issue

Fixes #621 

## Additional Information

Anything else the review team should know?

## Checklist

- [x] Descriptive Pull Request title
- [x] Link to relevant issues
- [x] Provide necessary context for design reviewers
- [x] Ensure test coverage is above agreed upon threshold
- [x] Update documentation
