### PR TITLE
Tweak CodeLibrary styles

### DIFF
--- a/src/app/(pages)/codeLibrary/__snapshots__/CodeLibrary.test.tsx.snap
+++ b/src/app/(pages)/codeLibrary/__snapshots__/CodeLibrary.test.tsx.snap
@@ -51,7 +51,9 @@ exports[`Code library interaction renders action buttons for custom value sets o
               role="button"
               tabindex="0"
             >
-              <div>
+              <div
+                class="display-flex flex-align-center"
+              >
                 <svg
                   aria-label="Icon indicating a menu with filter options"
                   class="usa-icon usa-icon--size-3 usa-icon qc-filter"
@@ -595,7 +597,9 @@ exports[`Code library loading view renders a skeleton loading state when loading
               role="button"
               tabindex="0"
             >
-              <div>
+              <div
+                class="display-flex flex-align-center"
+              >
                 <svg
                   aria-label="Icon indicating a menu with filter options"
                   class="usa-icon usa-icon--size-3 usa-icon qc-filter"
@@ -906,7 +910,9 @@ exports[`Code library rendered view renders concept codes for the value set when
               role="button"
               tabindex="0"
             >
-              <div>
+              <div
+                class="display-flex flex-align-center"
+              >
                 <svg
                   aria-label="Icon indicating a menu with filter options"
                   class="usa-icon usa-icon--size-3 usa-icon qc-filter"
@@ -1429,7 +1435,9 @@ exports[`Code library rendered view renders the correct content 1`] = `
               role="button"
               tabindex="0"
             >
-              <div>
+              <div
+                class="display-flex flex-align-center"
+              >
                 <svg
                   aria-label="Icon indicating a menu with filter options"
                   class="usa-icon usa-icon--size-3 usa-icon qc-filter"

--- a/src/app/(pages)/codeLibrary/codeLibrary.module.scss
+++ b/src/app/(pages)/codeLibrary/codeLibrary.module.scss
@@ -1,6 +1,6 @@
 @use "../../ui/styles/variables" as *;
 
-$pageContainerHeight: calc(100vh - $header-content-height - $site-alert-height);
+$pageContainerHeight: 100vh;
 $pageHeaderHeight: 12rem;
 $pageControlsHeight: 3rem;
 
@@ -173,8 +173,8 @@ $pageControlsHeight: 3rem;
 }
 
 .manageCodesLink {
-  font-weight: 700;
-  text-decoration: none;
+    font-weight: 700;
+    text-decoration: none;
 }
 
 .resultsContainer {
@@ -196,7 +196,7 @@ $pageControlsHeight: 3rem;
     padding: 1rem;
     align-items: center;
     width: calc($query-connector-content-width-wide + 4rem);
-    margin-bottom: 1rem;
+    margin-bottom: -7rem;
 
     ul {
         max-width: 50%;
@@ -354,24 +354,23 @@ $pageControlsHeight: 3rem;
         padding-right: 1rem;
         max-width: 7.5rem;
     }
-  }
+}
 
 .valueSetCode {
-  min-width: 7.5rem;
-  max-width: 7.5rem;
-  padding-right: 1rem;
-  display: flex;
-  align-items: center;
+    min-width: 7.5rem;
+    max-width: 7.5rem;
+    padding-right: 1rem;
+    display: flex;
+    align-items: center;
 }
 
 .conceptRowInline {
-  display: flex;
-  flex-direction: row;
-  align-items: center;
-  gap: 0.5rem; 
-  word-break: break-word;
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    gap: 0.5rem;
+    word-break: break-word;
 }
-
 
 .valueSetTable__tableBody {
     &_row {

--- a/src/app/(pages)/codeLibrary/page.tsx
+++ b/src/app/(pages)/codeLibrary/page.tsx
@@ -584,7 +584,7 @@ const CodeLibrary: React.FC = () => {
                 onClick={() => setShowFilters(true)}
               >
                 {
-                  <div>
+                  <div className="display-flex flex-align-center">
                     <Icon.FilterList
                       className="usa-icon qc-filter"
                       size={3}
@@ -599,7 +599,7 @@ const CodeLibrary: React.FC = () => {
                     {showFilters && (
                       <DropdownFilter
                         filterCount={filterCount}
-                        loading={loading}
+                        loading={valueSets.length <= 0}
                         setShowFilters={setShowFilters}
                         filterSearch={filterSearch}
                         setFilterSearch={setFilterSearch}


### PR DESCRIPTION
# PULL REQUEST

## Summary
Noticed while reviewing the Next upgrade PR that the dropdown filter on /codeLibrary was still sometimes getting stuck in the disabled state. Also the bottom margin of the PaginationContainer was too high, and the filter button was misaligned with its icon.

## Additional Information

Before:
<img width="958" alt="Screenshot 2025-05-28 at 13 04 45" src="https://github.com/user-attachments/assets/eced5293-2d91-4bde-a0e0-dce4d696fbbf" />

After:
<img width="965" alt="Screenshot 2025-05-28 at 13 04 30" src="https://github.com/user-attachments/assets/eb6d5294-cc35-4e98-b755-236980bb4b0f" />

## Checklist

- [x] Descriptive Pull Request title
- [x] Provide necessary context for design reviewers
