### PR TITLE
Clear error message when closing FHIR server config modal

### DIFF
--- a/src/app/(pages)/fhirServers/page.tsx
+++ b/src/app/(pages)/fhirServers/page.tsx
@@ -3,7 +3,7 @@
 import { Icon, Label, Tag, TextInput } from "@trussworks/react-uswds";
 
 import dynamic from "next/dynamic";
-import { useEffect, useState, useRef, JSX } from "react";
+import { useEffect, useState, useRef, JSX, useCallback } from "react";
 import type { ModalRef } from "../../ui/designSystem/modal/Modal";
 import styles from "./fhirServers.module.scss";
 import classNames from "classnames";
@@ -135,6 +135,33 @@ const FhirServers: React.FC = () => {
     resetModalState();
     modalRef.current?.toggleModal();
   };
+
+  const clearErrorOnModalClose = useCallback(
+    (event: MouseEvent | KeyboardEvent) => {
+      const clickTarget = (event.target as HTMLElement).getAttribute(
+        "data-testid",
+      );
+
+      if (
+        clickTarget == "modalOverlay" ||
+        (event as KeyboardEvent).key == "Escape"
+      ) {
+        setErrorMessage("");
+      }
+    },
+    [],
+  );
+
+  useEffect(() => {
+    window.addEventListener("mousedown", clearErrorOnModalClose);
+    window.addEventListener("keyup", clearErrorOnModalClose);
+
+    // Cleanup
+    return () => {
+      window.removeEventListener("mousedown", clearErrorOnModalClose);
+      window.removeEventListener("keyup", clearErrorOnModalClose);
+    };
+  }, []);
 
   interface ConnectionTestResult {
     success: boolean;

--- a/src/app/(pages)/fhirServers/page.tsx
+++ b/src/app/(pages)/fhirServers/page.tsx
@@ -146,7 +146,7 @@ const FhirServers: React.FC = () => {
         clickTarget == "modalOverlay" ||
         (event as KeyboardEvent).key == "Escape"
       ) {
-        setErrorMessage("");
+        resetModalState();
       }
     },
     [],


### PR DESCRIPTION
# PULL REQUEST

## Summary
When testing a connection to a FHIR server, if there is an error, the error message persists when you close the modal and open a different FHIR server. This is because `resetModalState()` was getting called when the modal was closed via one of its buttons, but not when closing via the `X` in the top right, clicking outside the modal, or hitting the escape key.


## Related Issue

Fixes #651 

## Additional Information

Anything else the review team should know?

## Checklist

- [x] Descriptive Pull Request title
- [x] Link to relevant issues
- [x] Ensure test coverage is above agreed upon threshold

