### PR TITLE
Fix auth provider env var

### DIFF
--- a/terraform/implementation/ecs/main.tf
+++ b/terraform/implementation/ecs/main.tf
@@ -100,7 +100,7 @@ module "ecs" {
           value = var.auth_secret
         },
         {
-          name  = "AUTH_PROVIDER"
+          name  = "NEXT_PUBLIC_AUTH_PROVIDER"
           value = var.auth_provider
         },
         {


### PR DESCRIPTION
We need to set the correct env var in our deployed environment for selecting the auth provider