### PR TITLE
Properly set issuer including realm instead of adding manually

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -5,8 +5,8 @@ DATABASE_URL=postgresql://postgres@localhost:5432/tefca_db
 AUTH_DISABLED=false
 NEXT_PUBLIC_AUTH_PROVIDER=keycloak
 AUTH_SECRET="ido5D/uybeAB3AmMQwn+ubw2zYC4t2h7RJlW2R79598="
-LOCAL_KEYCLOAK=http://localhost:8081
-NAMED_KEYCLOAK=http://localhost:8081
+LOCAL_KEYCLOAK=http://localhost:8081/realms/master
+NAMED_KEYCLOAK=http://localhost:8081/realms/master
 
 # Keycloak - set NEXT_PUBLIC_AUTH_PROVIDER to "keycloak"
 # Entra ID - set NEXT_PUBLIC_AUTH_PROVIDER to "microsoft-entra-id" and AUTH_ISSUER to "https://login.microsoftonline.com/your-tenant-id/v2.0""

--- a/.github/workflows/ecs_terraform.yaml
+++ b/.github/workflows/ecs_terraform.yaml
@@ -128,7 +128,7 @@ jobs:
           TF_VAR_auth_provider: ${{ secrets.AUTH_PROVIDER }}
           TF_VAR_auth_client_id: ${{ secrets.AUTH_CLIENT_ID }}
           TF_VAR_auth_client_secret: ${{ secrets.AUTH_CLIENT_SECRET }}
-          TF_VAR_auth_issuer: ${{ steps.set-url-format.outputs.base_url }}/${{ secrets.AUTH_PROVIDER }}
+          TF_VAR_auth_issuer: ${{ secrets.AUTH_ISSUER }}
           TF_VAR_auth_url: ${{ steps.set-url-format.outputs.base_url }}
           TF_VAR_aidbox_base_url: ${{ steps.set-url-format.outputs.base_url }}/aidboxone
           TF_VAR_aidbox_client_secret: ${{ secrets.AIDBOX_CLIENT_SECRET }}

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -39,8 +39,8 @@ services:
       - AUTH_DISABLED=false
       - AUTH_SECRET="ido5D/uybeAB3AmMQwn+ubw2zYC4t2h7RJlW2R79598="
       - AUTH_URL=http://localhost:3000
-      - LOCAL_KEYCLOAK=http://localhost:8080
-      - NAMED_KEYCLOAK=http://keycloak:8080
+      - LOCAL_KEYCLOAK=http://localhost:8080/realms/master
+      - NAMED_KEYCLOAK=http://keycloak:8080/realms/master
       - AUTH_KEYCLOAK_ID=query-connector
       - AUTH_KEYCLOAK_SECRET=ZG3f7R1J3qIwBaw8QtttJnJMinpERQKs
       - DATABASE_URL=postgres://postgres:pw@db:5432/tefca_db

--- a/src/app/backend/auth/lib.ts
+++ b/src/app/backend/auth/lib.ts
@@ -114,21 +114,15 @@ export class KeycloakAuthStrategy implements AuthStrategy {
     };
     return userToken;
   }
-  public setUpNextAuthProvider() {
-    function addRealm(url: string) {
-      return url.endsWith("/realms/master") ? url : `${url}/realms/master`;
-    }
 
+  public setUpNextAuthProvider() {
     let { NAMED_KEYCLOAK, LOCAL_KEYCLOAK } = process.env;
     if (!NAMED_KEYCLOAK || !LOCAL_KEYCLOAK) {
-      const KEYCLOAK_URL = process.env.AUTH_ISSUER || "http://localhost:8080";
+      const KEYCLOAK_URL =
+        process.env.AUTH_ISSUER || "http://localhost:8080/realms/master";
       NAMED_KEYCLOAK = KEYCLOAK_URL;
       LOCAL_KEYCLOAK = KEYCLOAK_URL;
     }
-
-    // Add /realms/master to the end of the URL if it's missing.
-    NAMED_KEYCLOAK = addRealm(NAMED_KEYCLOAK);
-    LOCAL_KEYCLOAK = addRealm(LOCAL_KEYCLOAK);
 
     return KeycloakProvider({
       jwks_endpoint: `${NAMED_KEYCLOAK}/protocol/openid-connect/certs`,


### PR DESCRIPTION
Right now in our deployed env we are setting the AUTH_ISSUER to be `https://queryconnector.dev/keycloak`, not including `/realms/master` because we have some code that adds it in later. We should avoid this for a number of reasons:

- It breaks API Auth
- It prevents anyone using a realm with a name other than master