### PR TITLE
Upgrade RDS engine version to 16.8 in dev

### DIFF
--- a/terraform/implementation/ecs/_variable.tf
+++ b/terraform/implementation/ecs/_variable.tf
@@ -80,7 +80,7 @@ variable "db_engine_type" {
 variable "db_engine_version" {
   type        = string
   description = "Engine Version of RDS Instance"
-  default     = "16.3"
+  default     = "16.8"
 }
 
 variable "db_instance_class" {


### PR DESCRIPTION
# PULL REQUEST

## Summary

Deploys are currently broken because our dev RDS instance got upgraded (perhaps by @rin-skylight? perhaps automatically? not sure) from 16.3 to 16.8, but Terraform has it pinned to 16.3. This should fix it!
