### PR TITLE
Fixing Code Library button hover state

### DIFF
--- a/src/app/(pages)/codeLibrary/__snapshots__/CodeLibrary.test.tsx.snap
+++ b/src/app/(pages)/codeLibrary/__snapshots__/CodeLibrary.test.tsx.snap
@@ -274,14 +274,14 @@ exports[`Code library interaction renders action buttons for custom value sets o
                     >
                       <th>
                         <button
-                          class="usa-button editCodesBtn button-secondary"
+                          class="usa-button usa-button--secondary"
                           data-testid="button"
                           type="button"
                         >
                           Edit codes
                         </button>
                         <button
-                          class="usa-button deleteValueSet"
+                          class="usa-button usa-button--secondary"
                           data-testid="button"
                           type="button"
                         >

--- a/src/app/(pages)/codeLibrary/codeLibrary.module.scss
+++ b/src/app/(pages)/codeLibrary/codeLibrary.module.scss
@@ -293,14 +293,6 @@ $pageControlsHeight: 3rem;
         justify-content: space-between;
         display: flex;
         width: 100%;
-
-        button.deleteValueSet {
-          background-color: transparent;
-          color: $accent-primary;
-          padding: 0 !important;
-          margin-right: 0;
-          width: 126px;
-        }
       }
     }
 
@@ -452,11 +444,6 @@ $pageControlsHeight: 3rem;
   }
 }
 
-.editCodesBtn {
-  background-color: #fff !important;
-  border: 2px solid $accent-primary !important;
-  color: $accent-primary !important;
-}
 
 .customValueSetForm {
   .header {

--- a/src/app/(pages)/codeLibrary/page.tsx
+++ b/src/app/(pages)/codeLibrary/page.tsx
@@ -763,11 +763,8 @@ const CodeLibrary: React.FC = () => {
                             >
                               <th>
                                 <Button
-                                  className={classNames(
-                                    styles.editCodesBtn,
-                                    "button-secondary",
-                                  )}
                                   type="button"
+                                  secondary
                                   onClick={() => handleChangeMode("edit")}
                                 >
                                   {activeValueSet.concepts?.length <= 0
@@ -775,8 +772,8 @@ const CodeLibrary: React.FC = () => {
                                     : "Edit codes"}
                                 </Button>
                                 <Button
-                                  className={styles.deleteValueSet}
                                   type="button"
+                                  secondary
                                   onClick={() =>
                                     modalRef.current?.toggleModal()
                                   }


### PR DESCRIPTION
# PULL REQUEST

## Summary

Noticed some funky hover states on the buttons of the editing/deleting custom valuesets. I think it's fixed just by relying on our secondary button styling.


https://github.com/user-attachments/assets/ee5869d9-9cea-4881-ab0a-daf63e915697


https://github.com/user-attachments/assets/75593100-f440-47c7-9c91-e369cbcd1c96



## Related Issue

Fixes #

## Additional Information

Anything else the review team should know?

## Checklist

- [ ] Descriptive Pull Request title
- [ ] Link to relevant issues
- [ ] Provide necessary context for design reviewers
- [ ] Ensure test coverage is above agreed upon threshold
- [ ] Update documentation
