### PR TITLE
Add ability to configure FHIR server headers in frontend

### DIFF
--- a/src/app/backend/fhir-servers.ts
+++ b/src/app/backend/fhir-servers.ts
@@ -156,23 +156,14 @@ class FhirServerConfigService extends FhirServerConfigServiceInternal {
       // Default auth type to none if not provided
       const authType = authData?.authType || "none";
 
-      // Prepare headers
-      let headers = {};
+      // Start with custom headers from authData
+      let headers = { ...(authData?.headers || {}) };
 
-      // Get existing headers if any
-      const existingServer = await dbService.query(
-        "SELECT headers FROM fhir_servers WHERE id = $1",
-        [id],
-      );
-
-      if (existingServer.rows.length > 0 && existingServer.rows[0].headers) {
-        headers = { ...existingServer.rows[0].headers };
-
-        // Remove Authorization header if it exists
-        if ("Authorization" in headers) {
-          const { Authorization, ...restHeaders } = headers;
-          headers = restHeaders;
-        }
+      // Remove Authorization header from custom headers if it exists
+      // (Authorization should only be set via auth methods)
+      if ("Authorization" in headers) {
+        const { Authorization, ...restHeaders } = headers;
+        headers = restHeaders;
       }
 
       // Add Authorization header for basic auth type
@@ -248,12 +239,20 @@ class FhirServerConfigService extends FhirServerConfigServiceInternal {
       // Default auth type to none if not provided
       const authType = authData?.authType || "none";
 
-      // Prepare headers based on auth type
-      let headers = {};
+      // Start with custom headers from authData
+      let headers = { ...(authData?.headers || {}) };
+
+      // Remove Authorization header from custom headers if it exists
+      // (Authorization should only be set via auth methods)
+      if ("Authorization" in headers) {
+        const { Authorization, ...restHeaders } = headers;
+        headers = restHeaders;
+      }
 
       // Add Authorization header for basic auth type
       if (authType === "basic" && authData?.bearerToken) {
         headers = {
+          ...headers,
           Authorization: `Bearer ${authData.bearerToken}`,
         };
       }

--- a/src/app/tests/integration/fhir-servers.test.ts
+++ b/src/app/tests/integration/fhir-servers.test.ts
@@ -6,6 +6,7 @@ import {
   getFhirServerConfigs,
   updateFhirServer,
   deleteFhirServer,
+  insertFhirServer,
 } from "@/app/backend/fhir-servers";
 
 jest.mock("@/app/utils/auth", () => {
@@ -40,6 +41,7 @@ describe("FHIR Servers tests", () => {
     expect(aidbox?.name).toBe("Aidbox");
     expect(aidbox?.hostname).toBe(`${process.env.AIDBOX_BASE_URL}/fhir`);
   });
+
   it("refresh, update, and deletion functions work", async () => {
     await dbService.query(FHIR_SERVER_INSERT_QUERY, [
       TEST_FHIR_SERVER.name,
@@ -88,5 +90,292 @@ describe("FHIR Servers tests", () => {
     newFhirServers = await getFhirServerConfigs(true);
     const shouldBeDeleted = newFhirServers.find((v) => v.id === newServer?.id);
     expect(shouldBeDeleted).toBeUndefined();
+  });
+
+  describe("Custom headers functionality", () => {
+    it("should insert a FHIR server with custom headers", async () => {
+      const customHeaders = {
+        "X-Custom-Header": "test-value",
+        "X-Another-Header": "another-value",
+        "X-Organization-Id": "org-123",
+      };
+
+      const result = await insertFhirServer(
+        "Test Server With Headers",
+        "http://test-server.com/fhir",
+        false,
+        false,
+        true,
+        {
+          authType: "none",
+          headers: customHeaders,
+        },
+      );
+
+      expect(result.success).toBe(true);
+      expect(result.server).toBeDefined();
+
+      const servers = await getFhirServerConfigs(true);
+      const insertedServer = servers.find(
+        (s) => s.name === "Test Server With Headers",
+      );
+
+      expect(insertedServer).toBeDefined();
+      expect(insertedServer?.headers).toEqual(customHeaders);
+
+      // Cleanup
+      if (insertedServer?.id) {
+        await deleteFhirServer(insertedServer.id);
+      }
+    });
+
+    it("should handle custom headers with basic auth", async () => {
+      const customHeaders = {
+        "X-Custom-Header": "test-value",
+        Authorization: "should-be-removed", // This should be removed
+      };
+
+      const result = await insertFhirServer(
+        "Test Server Basic Auth",
+        "http://test-basic-auth.com/fhir",
+        false,
+        false,
+        true,
+        {
+          authType: "basic",
+          bearerToken: "test-token-123",
+          headers: customHeaders,
+        },
+      );
+
+      expect(result.success).toBe(true);
+
+      const servers = await getFhirServerConfigs(true);
+      const insertedServer = servers.find(
+        (s) => s.name === "Test Server Basic Auth",
+      );
+
+      expect(insertedServer).toBeDefined();
+      expect(insertedServer?.headers).toBeDefined();
+      expect(insertedServer?.headers?.["X-Custom-Header"]).toBe("test-value");
+      expect(insertedServer?.headers?.["Authorization"]).toBe(
+        "Bearer test-token-123",
+      );
+      expect(Object.keys(insertedServer?.headers || {}).length).toBe(2);
+
+      // Cleanup
+      if (insertedServer?.id) {
+        await deleteFhirServer(insertedServer.id);
+      }
+    });
+
+    it("should update a FHIR server with new custom headers", async () => {
+      // First insert a server
+      const insertResult = await insertFhirServer(
+        "Test Server For Update",
+        "http://test-update.com/fhir",
+        false,
+        false,
+        true,
+        {
+          authType: "none",
+          headers: {
+            "X-Original-Header": "original-value",
+          },
+        },
+      );
+
+      expect(insertResult.success).toBe(true);
+      const serverId = insertResult.server.id;
+
+      // Update with new headers
+      const newHeaders = {
+        "X-Updated-Header": "updated-value",
+        "X-New-Header": "new-value",
+      };
+
+      const updateResult = await updateFhirServer(
+        serverId,
+        "Test Server For Update",
+        "http://test-update.com/fhir",
+        false,
+        false,
+        true,
+        {
+          authType: "none",
+          headers: newHeaders,
+        },
+      );
+
+      expect(updateResult.success).toBe(true);
+
+      const servers = await getFhirServerConfigs(true);
+      const updatedServer = servers.find((s) => s.id === serverId);
+
+      expect(updatedServer?.headers).toEqual(newHeaders);
+      expect(updatedServer?.headers?.["X-Original-Header"]).toBeUndefined();
+
+      // Cleanup
+      await deleteFhirServer(serverId);
+    });
+
+    it("should handle empty headers object", async () => {
+      const result = await insertFhirServer(
+        "Test Server No Headers",
+        "http://test-no-headers.com/fhir",
+        false,
+        false,
+        true,
+        {
+          authType: "none",
+          headers: {},
+        },
+      );
+
+      expect(result.success).toBe(true);
+
+      const servers = await getFhirServerConfigs(true);
+      const insertedServer = servers.find(
+        (s) => s.name === "Test Server No Headers",
+      );
+
+      expect(insertedServer).toBeDefined();
+      expect(insertedServer?.headers).toEqual({});
+
+      // Cleanup
+      if (insertedServer?.id) {
+        await deleteFhirServer(insertedServer.id);
+      }
+    });
+
+    it("should preserve headers when updating other server properties", async () => {
+      const customHeaders = {
+        "X-Important-Header": "must-preserve",
+        "X-Organization": "org-456",
+      };
+
+      // Insert server with headers
+      const insertResult = await insertFhirServer(
+        "Test Server Preserve Headers",
+        "http://test-preserve.com/fhir",
+        false,
+        false,
+        true,
+        {
+          authType: "none",
+          headers: customHeaders,
+        },
+      );
+
+      const serverId = insertResult.server.id;
+
+      // Update only the URL, headers should be preserved
+      const updateResult = await updateFhirServer(
+        serverId,
+        "Test Server Preserve Headers",
+        "http://test-preserve-updated.com/fhir",
+        false,
+        false,
+        true,
+        {
+          authType: "none",
+          headers: customHeaders,
+        },
+      );
+
+      expect(updateResult.success).toBe(true);
+
+      const servers = await getFhirServerConfigs(true);
+      const updatedServer = servers.find((s) => s.id === serverId);
+
+      expect(updatedServer?.hostname).toBe(
+        "http://test-preserve-updated.com/fhir",
+      );
+      expect(updatedServer?.headers).toEqual(customHeaders);
+
+      // Cleanup
+      await deleteFhirServer(serverId);
+    });
+
+    it("should handle client credentials auth with custom headers", async () => {
+      const customHeaders = {
+        "X-API-Version": "v2",
+        "X-Client-Id": "client-app",
+      };
+
+      const result = await insertFhirServer(
+        "Test Server Client Creds",
+        "http://test-client-creds.com/fhir",
+        false,
+        false,
+        true,
+        {
+          authType: "client_credentials",
+          clientId: "test-client",
+          clientSecret: "test-secret",
+          tokenEndpoint: "http://test-client-creds.com/token",
+          scopes: "system/*.read",
+          headers: customHeaders,
+        },
+      );
+
+      expect(result.success).toBe(true);
+
+      const servers = await getFhirServerConfigs(true);
+      const insertedServer = servers.find(
+        (s) => s.name === "Test Server Client Creds",
+      );
+
+      expect(insertedServer).toBeDefined();
+      expect(insertedServer?.authType).toBe("client_credentials");
+      expect(insertedServer?.clientId).toBe("test-client");
+      expect(insertedServer?.headers).toEqual(customHeaders);
+      // Authorization header should not be present for OAuth flows
+      expect(insertedServer?.headers?.["Authorization"]).toBeUndefined();
+
+      // Cleanup
+      if (insertedServer?.id) {
+        await deleteFhirServer(insertedServer.id);
+      }
+    });
+
+    it("should handle SMART auth with custom headers", async () => {
+      const customHeaders = {
+        "X-SMART-Version": "1.0",
+        "X-Request-Id": "req-123",
+      };
+
+      const result = await insertFhirServer(
+        "Test Server SMART",
+        "http://test-smart.com/fhir",
+        false,
+        false,
+        true,
+        {
+          authType: "SMART",
+          clientId: "smart-client",
+          tokenEndpoint: "http://test-smart.com/auth/token",
+          scopes: "patient/*.read",
+          headers: customHeaders,
+        },
+      );
+
+      expect(result.success).toBe(true);
+
+      const servers = await getFhirServerConfigs(true);
+      const insertedServer = servers.find(
+        (s) => s.name === "Test Server SMART",
+      );
+
+      expect(insertedServer).toBeDefined();
+      expect(insertedServer?.authType).toBe("SMART");
+      expect(insertedServer?.clientId).toBe("smart-client");
+      expect(insertedServer?.headers).toEqual(customHeaders);
+
+      // Cleanup
+      if (insertedServer?.id) {
+        await deleteFhirServer(insertedServer.id);
+      }
+    });
   });
 });


### PR DESCRIPTION
# PULL REQUEST

## Summary

Adds the ability to configure headers for FHIR servers. Can add, edit, remove each key value pair independently. Tried to make it clear too that the Authorization header is handled separately.

<img width="1754" alt="Screenshot 2025-06-16 at 4 06 13 PM" src="https://github.com/user-attachments/assets/444ac994-ef9f-431c-aae5-4574b92b5650" />

<img width="1754" alt="Screenshot 2025-06-16 at 4 06 58 PM" src="https://github.com/user-attachments/assets/cc8103dc-0e51-4150-9284-a21f035f6c62" />


## Related Issue

Fixes #653 (https://linear.app/skylight-cdc/issue/QUE-294/add-support-for-setting-headers-for-fhir-servers)

## Copilot summary

This pull request introduces support for managing custom HTTP headers in the FHIR server configuration, including both frontend and backend changes. The changes enable users to add, update, and remove custom headers through the UI, and ensure these headers are properly handled during server interactions and persisted in the database. Additionally, integration tests have been added to validate the functionality.

### Frontend Changes

* Added a `HeaderPair` interface and a `headers` state to manage custom headers in the `FhirServers` component. This includes methods to add, update, and remove headers, as well as a utility function to convert the header state into an object. (`src/app/(pages)/fhirServers/page.tsx`, [[1]](diffhunk://#diff-da48056c7881d1c27c453825ad7bfdaac4227afc8aa4c4aeac36a4c3150f5535R37-R42) [[2]](diffhunk://#diff-da48056c7881d1c27c453825ad7bfdaac4227afc8aa4c4aeac36a4c3150f5535R68) [[3]](diffhunk://#diff-da48056c7881d1c27c453825ad7bfdaac4227afc8aa4c4aeac36a4c3150f5535R190-R218)
* Updated the modal UI to include a section for managing custom headers, with input fields for header keys and values, and buttons for adding or removing headers. (`src/app/(pages)/fhirServers/page.tsx`, [src/app/(pages)/fhirServers/page.tsxR722-R778](diffhunk://#diff-da48056c7881d1c27c453825ad7bfdaac4227afc8aa4c4aeac36a4c3150f5535R722-R778))
* Modified the "Test connection" and "Save" functionalities to include custom headers in the request payload. (`src/app/(pages)/fhirServers/page.tsx`, [[1]](diffhunk://#diff-da48056c7881d1c27c453825ad7bfdaac4227afc8aa4c4aeac36a4c3150f5535L180-R231) [[2]](diffhunk://#diff-da48056c7881d1c27c453825ad7bfdaac4227afc8aa4c4aeac36a4c3150f5535R304-R311)

### Backend Changes

* Updated the `FhirServerConfigService` to handle custom headers during server creation and updates, ensuring that the `Authorization` header is excluded from user-defined headers and managed separately based on the authentication method. (`src/app/backend/fhir-servers.ts`, [[1]](diffhunk://#diff-bea67cc8a8de50cbf418de733c8ffe88e52ba9893ae2810ee7bcbbb37055f6b3L159-L176) [[2]](diffhunk://#diff-bea67cc8a8de50cbf418de733c8ffe88e52ba9893ae2810ee7bcbbb37055f6b3L251-R255)

### Testing Enhancements

* Added integration tests to verify the functionality of custom headers, including scenarios for inserting, updating, and preserving headers, as well as handling headers with different authentication methods (e.g., basic, client credentials, SMART). (`src/app/tests/integration/fhir-servers.test.ts`, [src/app/tests/integration/fhir-servers.test.tsR94-R380](diffhunk://#diff-dd7b01c0b86dd1a7e0fd5c450390de9074e8c1f213960c40aa30f392b73bf7beR94-R380))