### PR TITLE
change a error to a warning

### DIFF
--- a/src/auth.ts
+++ b/src/auth.ts
@@ -24,10 +24,10 @@ switch (process.env.NEXT_PUBLIC_AUTH_PROVIDER) {
     providers.push(microsoftProvider);
     break;
   default:
-    console.error(
+    console.warn(
       "Configured IdP doesn't match existing options. Please check the setup in your environment settings",
     );
-    console.error("Falling back to Keycloak setup");
+    console.warn("Falling back to Keycloak setup");
     authStrategy = new KeycloakAuthStrategy();
     const fallbackProvider = authStrategy.setUpNextAuthProvider();
     providers.push(fallbackProvider);


### PR DESCRIPTION
During pairing realized a console error was causing some log pollution, so opting to use `console.warn` instead