### PR TITLE
chore: add Dependabot configuration for npm, docker and terraform wee…

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,16 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+
+  - package-ecosystem: "terraform"
+    directory: "/terraform"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
## Changes Proposed

- Added a dependabot configuration file to automate dependency updates.
- Configured weekly update checks for Docker and npm dependencies in the repository root and Terraform in the "/terraform" directory.

## Additional Information

- This PR is meant to start the conversation and is not completely prescriptive. If you have opinions on frequency, a PR limit, or if I got the tooling wrong, LMK!

## Testing

- Review the .github/dependabot.yml file to ensure each package-ecosystem is set correctly with the proper directory along with a schedule.
- Verify that dependabot runs correctly by triggering it after the merge.