### PR TITLE
Bob/que 305 implement time boxing designs

### DIFF
--- a/src/app/(pages)/auditLogs/page.tsx
+++ b/src/app/(pages)/auditLogs/page.tsx
@@ -182,6 +182,7 @@ const AuditLogs: React.FC = () => {
             <label htmlFor="dateRange">Custom date range</label>
             <div>
               <DateRangePicker
+                id={"auditLogDatePicker"}
                 startDate={dateRange.startDate || null}
                 endDate={dateRange.endDate || null}
                 onChange={({ startDate, endDate }) =>

--- a/src/app/(pages)/queryBuilding/buildFromTemplates/conditionTemplateSelection.module.scss
+++ b/src/app/(pages)/queryBuilding/buildFromTemplates/conditionTemplateSelection.module.scss
@@ -564,3 +564,18 @@ $columnGap: 1rem;
   padding: 1rem 3rem 0.5rem 3rem !important;
   max-width: fit-content;
 }
+
+.accordionBulkAction {
+  display: flex;
+  justify-content: space-between;
+  padding-right: 1.5rem;
+
+  input {
+    width: 12.5rem;
+  }
+
+  // narrower width if the placeholder "All Dates" is shown
+  input:placeholder-shown {
+    width: 7.5rem;
+  }
+}

--- a/src/app/(pages)/queryBuilding/components/ConceptTypeAccordionBody.tsx
+++ b/src/app/(pages)/queryBuilding/components/ConceptTypeAccordionBody.tsx
@@ -28,9 +28,11 @@ import { Concept } from "@/app/models/entities/concepts";
 import ValueSetBulkToggle from "./ValueSetBulkToggle";
 import { showToastConfirmation } from "@/app/ui/designSystem/toast/Toast";
 import classNames from "classnames";
+import DateRangePicker from "@/app/ui/designSystem/timeboxing/DateRangePicker";
 
 type ConceptTypeAccordionBodyProps = {
   activeValueSets: { [vsId: string]: FilterableValueSet };
+  accordionConceptType: DibbsConceptType;
   handleVsNameLevelUpdate: (
     activeType: DibbsConceptType,
   ) => (dibbsValueSets: FilterableValueSet) => void;
@@ -47,15 +49,16 @@ export type ConceptDisplay = Concept & {
 /**
  * An accordion body fragment
  * @param param0 - params
+ * @param param0.accordionConceptType - name of the concept type associated with the accordion
  * @param param0.activeValueSets - Valuesets for display in this accordion
  * @param param0.handleVsNameLevelUpdate - curried state update function that
  * @param param0.handleVsIdLevelUpdate - curried state update function that
- * takes a valueset ID and generates a ValueSet level update
  * @param param0.tableSearchFilter - the search string from the selection table
  * @returns An accordion body component
  */
 const ConceptTypeAccordionBody: React.FC<ConceptTypeAccordionBodyProps> = ({
   activeValueSets,
+  accordionConceptType,
   handleVsIdLevelUpdate,
   handleVsNameLevelUpdate,
   tableSearchFilter = "",
@@ -239,6 +242,14 @@ const ConceptTypeAccordionBody: React.FC<ConceptTypeAccordionBodyProps> = ({
     0,
   );
 
+  const handleTimeboxApplication = (dates: {
+    startDate: Date | null;
+    endDate: Date | null;
+  }) => {
+    console.log(dates.startDate);
+    console.log(dates.endDate);
+  };
+
   const buttons = [
     {
       trigger: totalCount > selectedCount,
@@ -255,24 +266,38 @@ const ConceptTypeAccordionBody: React.FC<ConceptTypeAccordionBodyProps> = ({
   ];
   return (
     <>
-      <div className={styles.bulkActionButtons}>
-        {buttons
-          .filter((btn) => !!btn.trigger)
-          .map((button, idx) => {
-            return (
-              <Button
-                key={idx}
-                ref={idx == 0 ? focusRef : null}
-                className={classNames(styles.selectAll, "usa-button--unstyled")}
-                type="button"
-                onClick={(e) =>
-                  handleConceptTypeBulkToggle(e, button.includeAll)
-                }
-              >
-                {button.text}
-              </Button>
-            );
-          })}
+      <div className={styles.accordionBulkAction}>
+        <div className={styles.bulkActionButtons}>
+          {buttons
+            .filter((btn) => !!btn.trigger)
+            .map((button, idx) => {
+              return (
+                <Button
+                  key={idx}
+                  ref={idx == 0 ? focusRef : null}
+                  className={classNames(
+                    styles.selectAll,
+                    "usa-button--unstyled",
+                  )}
+                  type="button"
+                  onClick={(e) =>
+                    handleConceptTypeBulkToggle(e, button.includeAll)
+                  }
+                >
+                  {button.text}
+                </Button>
+              );
+            })}
+        </div>
+
+        <DateRangePicker
+          id={`dateRangePicker-${accordionConceptType}`}
+          startDate={null}
+          endDate={null}
+          onChange={handleTimeboxApplication}
+          popoverSide="left"
+          placeholderText="All dates"
+        />
       </div>
       <div className={styles.accordionContainer}>
         {Object.values(activeValueSets).map((dibbsVs) => {

--- a/src/app/(pages)/queryBuilding/components/ValueSetSelection.test.tsx
+++ b/src/app/(pages)/queryBuilding/components/ValueSetSelection.test.tsx
@@ -109,4 +109,61 @@ describe("tests the value set selection page", () => {
       expect(screen.getByTestId("15628003-card-active")).toBeInTheDocument();
     });
   });
+
+  it.only("highlights the active tab to the side", async () => {
+    const { user } = renderWithUser(
+      <RootProviderMock
+        currentPage={currentPage}
+        initialQuery={{
+          queryName: undefined,
+          queryId: undefined,
+        }}
+      >
+        <BuildFromTemplates buildStep={"valueset"} setBuildStep={jest.fn} />
+      </RootProviderMock>,
+    );
+
+    await waitFor(() => {
+      screen.getByPlaceholderText(VALUESET_SELECTION_SEARCH_PLACEHOLDER);
+    });
+
+    const additionalCodesTabContainer = screen.getByTestId(
+      "tab-custom-container",
+    );
+    await user.click(screen.getByTestId("tab-custom"));
+    screen.logTestingPlaygroundURL();
+    await waitFor(() => {
+      expect(screen.getByText("Add from code library")).toBeInTheDocument();
+    });
+    console.log(additionalCodesTabContainer.className);
+    expect(
+      additionalCodesTabContainer.className.includes("active"),
+    ).toBeTruthy();
+    expect(document.body).toMatchSnapshot();
+
+    const medicalRecordsTabContainer = screen.getByTestId(
+      "tab-medical-records-container",
+    );
+    await user.click(screen.getByText("Medical record sections"));
+
+    expect(screen.getByLabelText("Include immunizations")).toBeInTheDocument();
+    expect(
+      screen.getByLabelText("Include social determinants"),
+    ).toBeInTheDocument();
+    expect(
+      medicalRecordsTabContainer.className.includes("active"),
+    ).toBeTruthy();
+    expect(document.body).toMatchSnapshot();
+
+    await user.click(screen.getByTestId("add-left-rail"));
+    await waitFor(() => {
+      expect(screen.queryByText("Add Condition(s)")).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByTestId("condition-drawer-add-15628003"));
+    await waitFor(() => {
+      expect(screen.getByTestId("15628003-card-active")).toBeInTheDocument();
+    });
+    expect(document.body).toMatchSnapshot();
+  });
 });

--- a/src/app/(pages)/queryBuilding/components/ValueSetSelection.tsx
+++ b/src/app/(pages)/queryBuilding/components/ValueSetSelection.tsx
@@ -31,7 +31,6 @@ import { DataContext } from "@/app/shared/DataProvider";
 import { CustomConditionView } from "./valueSetSelectionViews/CustomConditionView";
 import { MedicalRecordsView } from "./valueSetSelectionViews/MedicalRecordsView";
 import { Sidebar } from "./valueSetSelectionViews/Sidebar";
-import DateRangePicker from "@/app/ui/designSystem/timeboxing/DateRangePicker";
 
 type ConditionSelectionProps = {
   constructedQuery: NestedQuery;
@@ -178,18 +177,6 @@ export const ValueSetSelection: React.FC<ConditionSelectionProps> = ({
                     Add from code library
                   </Button>
                 )}
-
-                <DateRangePicker
-                  startDate={null}
-                  endDate={null}
-                  onChange={function (dates: {
-                    startDate: Date | null;
-                    endDate: Date | null;
-                  }): void {
-                    throw new Error("Function not implemented.");
-                  }}
-                  popoverSide="left"
-                />
               </div>
 
               <ConceptSelectionView

--- a/src/app/(pages)/queryBuilding/components/ValueSetSelection.tsx
+++ b/src/app/(pages)/queryBuilding/components/ValueSetSelection.tsx
@@ -31,6 +31,7 @@ import { DataContext } from "@/app/shared/DataProvider";
 import { CustomConditionView } from "./valueSetSelectionViews/CustomConditionView";
 import { MedicalRecordsView } from "./valueSetSelectionViews/MedicalRecordsView";
 import { Sidebar } from "./valueSetSelectionViews/Sidebar";
+import DateRangePicker from "@/app/ui/designSystem/timeboxing/DateRangePicker";
 
 type ConditionSelectionProps = {
   constructedQuery: NestedQuery;
@@ -148,7 +149,7 @@ export const ValueSetSelection: React.FC<ConditionSelectionProps> = ({
               setMedicalRecordSections={setMedicalRecordSections}
             />
           ) : (
-            <>
+            <div>
               <div className={styles.valueSetTemplate__search}>
                 <SearchField
                   id="valueSetTemplateSearch"
@@ -177,6 +178,18 @@ export const ValueSetSelection: React.FC<ConditionSelectionProps> = ({
                     Add from code library
                   </Button>
                 )}
+
+                <DateRangePicker
+                  startDate={null}
+                  endDate={null}
+                  onChange={function (dates: {
+                    startDate: Date | null;
+                    endDate: Date | null;
+                  }): void {
+                    throw new Error("Function not implemented.");
+                  }}
+                  popoverSide="left"
+                />
               </div>
 
               <ConceptSelectionView
@@ -201,7 +214,7 @@ export const ValueSetSelection: React.FC<ConditionSelectionProps> = ({
                   queryName={queryName}
                 />
               )}
-            </>
+            </div>
           )}
         </div>
       </div>

--- a/src/app/(pages)/queryBuilding/components/__snapshots__/ValueSetSelection.test.tsx.snap
+++ b/src/app/(pages)/queryBuilding/components/__snapshots__/ValueSetSelection.test.tsx.snap
@@ -1,0 +1,1499 @@
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+
+exports[`tests the value set selection page highlights the active tab to the side 1`] = `
+<body>
+  <div>
+    <div
+      class="main-container__wide mainContainer"
+    >
+      <a
+        aria-label="Back arrow, Back to condition selection"
+        class="back-link text-no-underline width-fit-content"
+        data-testid="backArrowLink"
+        href="#"
+      >
+        <svg
+          aria-label="Arrow point left indicating return to previous step"
+          class="usa-icon"
+          focusable="false"
+          height="1em"
+          role="img"
+          viewBox="0 0 24 24"
+          width="1em"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M20 11H7.83l5.59-5.59L12 4l-8 8 8 8 1.41-1.41L7.83 13H20v-2z"
+          />
+        </svg>
+         
+        Back to condition selection
+      </a>
+      <div
+        class="customQuery__header"
+      >
+        <h1
+          class="queryTitle"
+        >
+          Custom query
+        </h1>
+        <div
+          class="customQuery__controls"
+        >
+          <div
+            class="customQuery__name"
+          >
+            <label
+              class="usa-label inputLabel"
+              data-testid="label"
+              for="queryNameInput"
+            >
+              Query name 
+              <span
+                class="text-secondary"
+              >
+                (required)
+              </span>
+            </label>
+            <input
+              class="usa-input input"
+              data-testid="queryNameInput"
+              id="queryNameInput"
+              name="queryNameInput"
+              required=""
+              type="text"
+              value=""
+            />
+          </div>
+          <div
+            class="customQuery__saveButton"
+          >
+            <button
+              class="usa-button queryBuildingButton margin-0"
+              data-testid="createSaveQueryBtn"
+              disabled=""
+              title="Save query"
+              type="button"
+            >
+              Save query
+            </button>
+          </div>
+        </div>
+      </div>
+      <div
+        class="display-flex flex-auto"
+      >
+        <div
+          class="background-dark margin-top-4  valueSetTemplateContainer"
+        >
+          <div
+            class="valueSetTemplateContainer__inner"
+          >
+            <div
+              class="valueSetTemplate__left"
+            >
+              <div
+                class="sideBarMenu"
+              >
+                <div
+                  class="sideBarMenu__content"
+                >
+                  <div
+                    class="section_templates"
+                  >
+                    <div
+                      class="sectionTitle"
+                    >
+                      <div>
+                        TEMPLATES
+                      </div>
+                      <button
+                        class="unstyled-button-container addCondition"
+                        data-testid="add-condition-icon"
+                      >
+                        <svg
+                          aria-label="Plus sign icon indicating addition"
+                          class="usa-icon usa-icon--size-3 usa-icon"
+                          focusable="false"
+                          height="1em"
+                          role="img"
+                          viewBox="0 0 24 24"
+                          width="1em"
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z"
+                          />
+                        </svg>
+                        <span
+                          data-testid="add-left-rail"
+                        >
+                          ADD
+                        </span>
+                      </button>
+                    </div>
+                  </div>
+                  <div
+                    class="section_custom"
+                  >
+                    <div
+                      class="sectionTitle padding-top-2"
+                    >
+                      CUSTOM
+                    </div>
+                    <div
+                      class="align-items-center card active"
+                      data-testid="tab-custom-container"
+                    >
+                      <button
+                        class="unstyled-button-container"
+                        data-testid="tab-custom"
+                        id="tab-custom"
+                      >
+                        Additional codes from library
+                      </button>
+                    </div>
+                  </div>
+                  <div
+                    class="section_custom"
+                  >
+                    <div
+                      class="align-items-center card"
+                      data-testid="tab-medical-records-container"
+                    >
+                      <button
+                        class="unstyled-button-container"
+                        data-testid="tab-medical-records"
+                        id="tab-medical-records"
+                      >
+                        Medical record sections
+                      </button>
+                    </div>
+                  </div>
+                </div>
+              </div>
+              <div>
+                <div
+                  aria-label="drawer-container"
+                  class="drawer closed width35"
+                  data-testid="drawer-open-false"
+                  id="drawer-container"
+                  role="dialog"
+                >
+                  <div
+                    class="display-none"
+                  />
+                </div>
+              </div>
+              ;
+            </div>
+            <div
+              class="valueSetTemplate__right"
+            >
+              <div>
+                <div
+                  class="valueSetTemplate__search"
+                >
+                  <input
+                    class="usa-input searchField valueSetSearch"
+                    data-testid="textInput"
+                    id="valueSetTemplateSearch"
+                    name="valueSetTemplateSearch"
+                    placeholder="Search labs, medications, conditions"
+                    type="search"
+                    value=""
+                  />
+                  <div
+                    class="datePickerContainer"
+                  >
+                    <div
+                      class="textInputContainer"
+                    >
+                      <input
+                        aria-label="Date range input"
+                        class="usa-input"
+                        data-testid="date-range-input"
+                        id="date-range-input"
+                        name="date-range-input"
+                        placeholder="Filter by date"
+                        readonly=""
+                        type="text"
+                        value=""
+                      />
+                      <svg
+                        aria-label="date-range-calendar-icon"
+                        class="usa-icon usa-icon--size-3 calendarIcon"
+                        focusable="false"
+                        height="1em"
+                        role="img"
+                        viewBox="0 0 24 24"
+                        width="1em"
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          d="M20 3h-1V1h-2v2H7V1H5v2H4c-1.1 0-2 .9-2 2v16c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zm0 18H4V8h16v13z"
+                        />
+                      </svg>
+                    </div>
+                  </div>
+                </div>
+                <div
+                  class="codeLibrary__empty"
+                >
+                  <svg
+                    aria-label="Stylized icon showing four squares in a grid"
+                    class="usa-icon usa-icon icon"
+                    focusable="false"
+                    height="1em"
+                    role="img"
+                    viewBox="0 0 24 24"
+                    width="1em"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M3 3v8h8V3H3zm6 6H5V5h4v4zm-6 4v8h8v-8H3zm6 6H5v-4h4v4zm4-16v8h8V3h-8zm6 6h-4V5h4v4zm-6 4v8h8v-8h-8zm6 6h-4v-4h4v4z"
+                      fill-rule="evenodd"
+                    />
+                  </svg>
+                  <p
+                    class="codeLibrary__emptyText"
+                  >
+                    <strong>
+                      This is a space for you to pull in individual value sets
+                    </strong>
+                  </p>
+                  <p
+                    class="codeLibrary__emptyText"
+                  >
+                    <strong>
+                      These can be official value sets from CSTE, or ones that you have created in the code library.
+                    </strong>
+                  </p>
+                  <button
+                    class="usa-button codeLibrary__button"
+                    data-testid="button"
+                    type="button"
+                  >
+                    Add from code library
+                  </button>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div
+    aria-describedby="warning-confirmation-modal-modal-description"
+    aria-labelledby="warning-confirmation-modal-modal-heading"
+    class="usa-modal-wrapper is-hidden"
+    data-force-action="false"
+    id="warning-confirmation-modal-modal"
+    role="dialog"
+  >
+    <div
+      aria-controls="warning-confirmation-modal-modal"
+      class="usa-modal-overlay"
+      data-testid="modalOverlay"
+    >
+      <div
+        class="usa-modal qc-modal"
+        data-force-action="false"
+        data-testid="modalWindow"
+        tabindex="-1"
+      >
+        <div
+          class="usa-modal__content"
+        >
+          <div
+            class="usa-modal__main"
+          >
+            <h2
+              class="usa-modal__heading"
+              id="warning-confirmation-modal-modal-heading"
+            >
+              You have unsaved changes
+            </h2>
+            <div
+              class="usa-prose"
+              id="warning-confirmation-modal-modal-description"
+            >
+              <p>
+                You've made changes to your query. Would you like to save before leaving?
+              </p>
+            </div>
+            <div
+              class="usa-modal__footer"
+              data-testid="modalFooter"
+            >
+              <ul
+                class="usa-button-group"
+              >
+                <li
+                  class="usa-button-group__item"
+                >
+                  <button
+                    class="usa-button usa-button--default"
+                    data-testid="button"
+                    type="button"
+                  >
+                    Save
+                  </button>
+                </li>
+                <li
+                  class="usa-button-group__item"
+                >
+                  <button
+                    class="usa-button usa-button--secondary"
+                    data-testid="button"
+                    type="button"
+                  >
+                    Dismiss
+                  </button>
+                </li>
+              </ul>
+            </div>
+          </div>
+          <button
+            aria-controls="warning-confirmation-modal-modal"
+            aria-label="Close this window"
+            class="usa-button usa-modal__close"
+            data-close-modal="true"
+            data-testid="button"
+            type="button"
+          >
+            <svg
+              aria-hidden="true"
+              class="usa-icon"
+              focusable="false"
+              height="1em"
+              role="img"
+              viewBox="0 0 24 24"
+              width="1em"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M19 6.41 17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"
+              />
+            </svg>
+          </button>
+        </div>
+      </div>
+    </div>
+  </div>
+</body>
+`;
+
+exports[`tests the value set selection page highlights the active tab to the side 2`] = `
+<body>
+  <div>
+    <div
+      class="main-container__wide mainContainer"
+    >
+      <a
+        aria-label="Back arrow, Back to condition selection"
+        class="back-link text-no-underline width-fit-content"
+        data-testid="backArrowLink"
+        href="#"
+      >
+        <svg
+          aria-label="Arrow point left indicating return to previous step"
+          class="usa-icon"
+          focusable="false"
+          height="1em"
+          role="img"
+          viewBox="0 0 24 24"
+          width="1em"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M20 11H7.83l5.59-5.59L12 4l-8 8 8 8 1.41-1.41L7.83 13H20v-2z"
+          />
+        </svg>
+         
+        Back to condition selection
+      </a>
+      <div
+        class="customQuery__header"
+      >
+        <h1
+          class="queryTitle"
+        >
+          Custom query
+        </h1>
+        <div
+          class="customQuery__controls"
+        >
+          <div
+            class="customQuery__name"
+          >
+            <label
+              class="usa-label inputLabel"
+              data-testid="label"
+              for="queryNameInput"
+            >
+              Query name 
+              <span
+                class="text-secondary"
+              >
+                (required)
+              </span>
+            </label>
+            <input
+              class="usa-input input"
+              data-testid="queryNameInput"
+              id="queryNameInput"
+              name="queryNameInput"
+              required=""
+              type="text"
+              value=""
+            />
+          </div>
+          <div
+            class="customQuery__saveButton"
+          >
+            <button
+              class="usa-button queryBuildingButton margin-0"
+              data-testid="createSaveQueryBtn"
+              disabled=""
+              title="Save query"
+              type="button"
+            >
+              Save query
+            </button>
+          </div>
+        </div>
+      </div>
+      <div
+        class="display-flex flex-auto"
+      >
+        <div
+          class="background-dark margin-top-4  valueSetTemplateContainer"
+        >
+          <div
+            class="valueSetTemplateContainer__inner"
+          >
+            <div
+              class="valueSetTemplate__left"
+            >
+              <div
+                class="sideBarMenu"
+              >
+                <div
+                  class="sideBarMenu__content"
+                >
+                  <div
+                    class="section_templates"
+                  >
+                    <div
+                      class="sectionTitle"
+                    >
+                      <div>
+                        TEMPLATES
+                      </div>
+                      <button
+                        class="unstyled-button-container addCondition"
+                        data-testid="add-condition-icon"
+                      >
+                        <svg
+                          aria-label="Plus sign icon indicating addition"
+                          class="usa-icon usa-icon--size-3 usa-icon"
+                          focusable="false"
+                          height="1em"
+                          role="img"
+                          viewBox="0 0 24 24"
+                          width="1em"
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z"
+                          />
+                        </svg>
+                        <span
+                          data-testid="add-left-rail"
+                        >
+                          ADD
+                        </span>
+                      </button>
+                    </div>
+                  </div>
+                  <div
+                    class="section_custom"
+                  >
+                    <div
+                      class="sectionTitle padding-top-2"
+                    >
+                      CUSTOM
+                    </div>
+                    <div
+                      class="align-items-center card"
+                      data-testid="tab-custom-container"
+                    >
+                      <button
+                        class="unstyled-button-container"
+                        data-testid="tab-custom"
+                        id="tab-custom"
+                      >
+                        Additional codes from library
+                      </button>
+                    </div>
+                  </div>
+                  <div
+                    class="section_custom"
+                  >
+                    <div
+                      class="align-items-center card active"
+                      data-testid="tab-medical-records-container"
+                    >
+                      <button
+                        class="unstyled-button-container"
+                        data-testid="tab-medical-records"
+                        id="tab-medical-records"
+                      >
+                        Medical record sections
+                      </button>
+                    </div>
+                  </div>
+                </div>
+              </div>
+              <div>
+                <div
+                  aria-label="drawer-container"
+                  class="drawer closed width35"
+                  data-testid="drawer-open-false"
+                  id="drawer-container"
+                  role="dialog"
+                >
+                  <div
+                    class="display-none"
+                  />
+                </div>
+              </div>
+              ;
+            </div>
+            <div
+              class="valueSetTemplate__right"
+            >
+              <div
+                class="medicalRecordSectionControls"
+              >
+                <div
+                  class="padding-4"
+                >
+                  <div
+                    class="medicalRecordSectionRow"
+                  >
+                    <div
+                      data-testid="container-medical-record-section-checkbox-immunizations"
+                    >
+                      <div
+                        class="usa-checkbox"
+                        data-testid="checkbox"
+                      >
+                        <input
+                          aria-label="Select medical recored section immunizations"
+                          class="usa-checkbox__input"
+                          id="medical-record-section-checkbox-immunizations"
+                          name="medical-record-section-checkbox-immunizations"
+                          type="checkbox"
+                        />
+                        <label
+                          class="usa-checkbox__label"
+                          for="medical-record-section-checkbox-immunizations"
+                        >
+                          Include immunizations
+                        </label>
+                      </div>
+                    </div>
+                  </div>
+                  <div
+                    class="medicalRecordSectionRow"
+                  >
+                    <div
+                      data-testid="container-medical-record-section-checkbox-socialDeterminants"
+                    >
+                      <div
+                        class="usa-checkbox"
+                        data-testid="checkbox"
+                      >
+                        <input
+                          aria-label="Select medical recored section socialDeterminants"
+                          class="usa-checkbox__input"
+                          id="medical-record-section-checkbox-socialDeterminants"
+                          name="medical-record-section-checkbox-socialDeterminants"
+                          type="checkbox"
+                        />
+                        <label
+                          class="usa-checkbox__label"
+                          for="medical-record-section-checkbox-socialDeterminants"
+                        >
+                          Include social determinants
+                        </label>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div
+    aria-describedby="warning-confirmation-modal-modal-description"
+    aria-labelledby="warning-confirmation-modal-modal-heading"
+    class="usa-modal-wrapper is-hidden"
+    data-force-action="false"
+    id="warning-confirmation-modal-modal"
+    role="dialog"
+  >
+    <div
+      aria-controls="warning-confirmation-modal-modal"
+      class="usa-modal-overlay"
+      data-testid="modalOverlay"
+    >
+      <div
+        class="usa-modal qc-modal"
+        data-force-action="false"
+        data-testid="modalWindow"
+        tabindex="-1"
+      >
+        <div
+          class="usa-modal__content"
+        >
+          <div
+            class="usa-modal__main"
+          >
+            <h2
+              class="usa-modal__heading"
+              id="warning-confirmation-modal-modal-heading"
+            >
+              You have unsaved changes
+            </h2>
+            <div
+              class="usa-prose"
+              id="warning-confirmation-modal-modal-description"
+            >
+              <p>
+                You've made changes to your query. Would you like to save before leaving?
+              </p>
+            </div>
+            <div
+              class="usa-modal__footer"
+              data-testid="modalFooter"
+            >
+              <ul
+                class="usa-button-group"
+              >
+                <li
+                  class="usa-button-group__item"
+                >
+                  <button
+                    class="usa-button usa-button--default"
+                    data-testid="button"
+                    type="button"
+                  >
+                    Save
+                  </button>
+                </li>
+                <li
+                  class="usa-button-group__item"
+                >
+                  <button
+                    class="usa-button usa-button--secondary"
+                    data-testid="button"
+                    type="button"
+                  >
+                    Dismiss
+                  </button>
+                </li>
+              </ul>
+            </div>
+          </div>
+          <button
+            aria-controls="warning-confirmation-modal-modal"
+            aria-label="Close this window"
+            class="usa-button usa-modal__close"
+            data-close-modal="true"
+            data-testid="button"
+            type="button"
+          >
+            <svg
+              aria-hidden="true"
+              class="usa-icon"
+              focusable="false"
+              height="1em"
+              role="img"
+              viewBox="0 0 24 24"
+              width="1em"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M19 6.41 17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"
+              />
+            </svg>
+          </button>
+        </div>
+      </div>
+    </div>
+  </div>
+</body>
+`;
+
+exports[`tests the value set selection page highlights the active tab to the side 3`] = `
+<body>
+  <div>
+    <div
+      class="main-container__wide mainContainer"
+    >
+      <a
+        aria-label="Back arrow, Back to condition selection"
+        class="back-link text-no-underline width-fit-content"
+        data-testid="backArrowLink"
+        href="#"
+      >
+        <svg
+          aria-label="Arrow point left indicating return to previous step"
+          class="usa-icon"
+          focusable="false"
+          height="1em"
+          role="img"
+          viewBox="0 0 24 24"
+          width="1em"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M20 11H7.83l5.59-5.59L12 4l-8 8 8 8 1.41-1.41L7.83 13H20v-2z"
+          />
+        </svg>
+         
+        Back to condition selection
+      </a>
+      <div
+        class="customQuery__header"
+      >
+        <h1
+          class="queryTitle"
+        >
+          Custom query
+        </h1>
+        <div
+          class="customQuery__controls"
+        >
+          <div
+            class="customQuery__name"
+          >
+            <label
+              class="usa-label inputLabel"
+              data-testid="label"
+              for="queryNameInput"
+            >
+              Query name 
+              <span
+                class="text-secondary"
+              >
+                (required)
+              </span>
+            </label>
+            <input
+              class="usa-input input"
+              data-testid="queryNameInput"
+              id="queryNameInput"
+              name="queryNameInput"
+              required=""
+              type="text"
+              value=""
+            />
+          </div>
+          <div
+            class="customQuery__saveButton"
+          >
+            <button
+              class="usa-button queryBuildingButton margin-0"
+              data-testid="createSaveQueryBtn"
+              disabled=""
+              title="Save query"
+              type="button"
+            >
+              Save query
+            </button>
+          </div>
+        </div>
+      </div>
+      <div
+        class="display-flex flex-auto"
+      >
+        <div
+          class="background-dark margin-top-4  valueSetTemplateContainer"
+        >
+          <div
+            class="valueSetTemplateContainer__inner"
+          >
+            <div
+              class="valueSetTemplate__left"
+            >
+              <div
+                class="sideBarMenu"
+              >
+                <div
+                  class="sideBarMenu__content"
+                >
+                  <div
+                    class="section_templates"
+                  >
+                    <div
+                      class="sectionTitle"
+                    >
+                      <div>
+                        TEMPLATES
+                      </div>
+                      <button
+                        class="unstyled-button-container addCondition"
+                        data-testid="add-condition-icon"
+                      >
+                        <svg
+                          aria-label="Plus sign icon indicating addition"
+                          class="usa-icon usa-icon--size-3 usa-icon"
+                          focusable="false"
+                          height="1em"
+                          role="img"
+                          viewBox="0 0 24 24"
+                          width="1em"
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z"
+                          />
+                        </svg>
+                        <span
+                          data-testid="add-left-rail"
+                        >
+                          ADD
+                        </span>
+                      </button>
+                    </div>
+                    <div
+                      class="align-items-center card active"
+                      data-testid="15628003-card-active"
+                    >
+                      <button
+                        class="unstyled-button-container"
+                        data-testid="tab-15628003"
+                        id="tab-15628003"
+                        type="button"
+                      >
+                        Gonorrhea
+                      </button>
+                      <button
+                        class="unstyled-button-container deleteIconContainer"
+                        data-testid="delete-condition-15628003"
+                      >
+                        <svg
+                          aria-label="Trash icon indicating deletion of disease"
+                          class="usa-icon usa-icon--size-4 usa-icon deleteIcon destructive-primary"
+                          focusable="false"
+                          height="1em"
+                          role="img"
+                          viewBox="0 0 24 24"
+                          width="1em"
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            d="M6 19c0 1.1.9 2 2 2h8c1.1 0 2-.9 2-2V7H6v12zM19 4h-3.5l-1-1h-5l-1 1H5v2h14V4z"
+                          />
+                        </svg>
+                      </button>
+                    </div>
+                  </div>
+                  <div
+                    class="section_custom"
+                  >
+                    <div
+                      class="sectionTitle padding-top-2"
+                    >
+                      CUSTOM
+                    </div>
+                    <div
+                      class="align-items-center card"
+                      data-testid="tab-custom-container"
+                    >
+                      <button
+                        class="unstyled-button-container"
+                        data-testid="tab-custom"
+                        id="tab-custom"
+                      >
+                        Additional codes from library
+                      </button>
+                    </div>
+                  </div>
+                  <div
+                    class="section_custom"
+                  >
+                    <div
+                      class="align-items-center card"
+                      data-testid="tab-medical-records-container"
+                    >
+                      <button
+                        class="unstyled-button-container"
+                        data-testid="tab-medical-records"
+                        id="tab-medical-records"
+                      >
+                        Medical record sections
+                      </button>
+                    </div>
+                  </div>
+                </div>
+              </div>
+              <div>
+                <div
+                  aria-label="drawer-container"
+                  class="drawer open width35"
+                  data-testid="drawer-open-true"
+                  id="drawer-container"
+                  role="dialog"
+                >
+                  <div
+                    class="drawerContent display-block"
+                  >
+                    <div
+                      class="drawerHeader"
+                    >
+                      <button
+                        aria-label="Close drawer"
+                        class="closeButton"
+                        data-testid="close-drawer"
+                      >
+                        <svg
+                          aria-label="X icon indicating closure"
+                          class="usa-icon usa-icon--size-3"
+                          focusable="false"
+                          height="1em"
+                          role="img"
+                          viewBox="0 0 24 24"
+                          width="1em"
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            d="M19 6.41 17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"
+                          />
+                        </svg>
+                      </button>
+                      <h2
+                        class="margin-0 padding-bottom-2"
+                        data-testid="drawer-title"
+                        id="drawer-title"
+                      >
+                        Add Condition(s)
+                      </h2>
+                      <div>
+                        <input
+                          class="usa-input searchField"
+                          data-testid="textInput"
+                          id="searchFieldTemplate"
+                          name="searchFieldTemplate"
+                          placeholder="Search condition or category"
+                          type="search"
+                          value=""
+                        />
+                      </div>
+                    </div>
+                    <div
+                      class="drawerBody"
+                    >
+                      <div
+                        id="Cancer"
+                      >
+                        <div
+                          class="conditionDrawerHeader"
+                        >
+                          <span>
+                            <span
+                              class=""
+                            >
+                              Cancer
+                            </span>
+                          </span>
+                        </div>
+                        <div>
+                          <div
+                            class="conditionItem"
+                            data-testid="update-363346000"
+                            id="update-363346000"
+                            tabindex="0"
+                          >
+                            <span>
+                              <span>
+                                <span
+                                  class=""
+                                >
+                                  Malignant neoplastic disease
+                                </span>
+                              </span>
+                            </span>
+                            <button
+                              class="addButton unstyled-button-container"
+                              data-testid="condition-drawer-add-363346000"
+                            >
+                              ADD
+                            </button>
+                          </div>
+                          <div
+                            class="conditionItem"
+                            data-testid="update-2"
+                            id="update-2"
+                            tabindex="0"
+                          >
+                            <span>
+                              <span>
+                                <span
+                                  class=""
+                                >
+                                  Cancer (Leukemia)
+                                </span>
+                              </span>
+                            </span>
+                            <button
+                              class="addButton unstyled-button-container"
+                              data-testid="condition-drawer-add-2"
+                            >
+                              ADD
+                            </button>
+                          </div>
+                        </div>
+                      </div>
+                      <div
+                        id="Sexually Transmitted Diseases"
+                      >
+                        <div
+                          class="conditionDrawerHeader"
+                        >
+                          <span>
+                            <span
+                              class=""
+                            >
+                              Sexually Transmitted Diseases (STI)
+                            </span>
+                          </span>
+                        </div>
+                        <div>
+                          <div
+                            class="conditionItem"
+                            data-testid="update-76272004"
+                            id="update-76272004"
+                            tabindex="0"
+                          >
+                            <span>
+                              <span>
+                                <span
+                                  class=""
+                                >
+                                  Syphilis
+                                </span>
+                              </span>
+                            </span>
+                            <button
+                              class="addButton unstyled-button-container"
+                              data-testid="condition-drawer-add-76272004"
+                            >
+                              ADD
+                            </button>
+                          </div>
+                          <div
+                            class="conditionItem"
+                            data-testid="update-240589008"
+                            id="update-240589008"
+                            tabindex="0"
+                          >
+                            <span>
+                              <span>
+                                <span
+                                  class=""
+                                >
+                                  Chlamydia trachomatis infection
+                                </span>
+                              </span>
+                            </span>
+                            <button
+                              class="addButton unstyled-button-container"
+                              data-testid="condition-drawer-add-240589008"
+                            >
+                              ADD
+                            </button>
+                          </div>
+                          <div
+                            class="conditionItem"
+                            data-testid="update-15628003"
+                            id="update-15628003"
+                            tabindex="0"
+                          >
+                            <span>
+                              <span>
+                                <span
+                                  class=""
+                                >
+                                  Gonorrhea
+                                </span>
+                              </span>
+                            </span>
+                            <span
+                              class="addedStatus"
+                              data-testid="condition-drawer-added-15628003"
+                            >
+                              Added
+                            </span>
+                          </div>
+                        </div>
+                      </div>
+                       
+                    </div>
+                  </div>
+                </div>
+                <div
+                  class="overlay"
+                />
+              </div>
+              ;
+            </div>
+            <div
+              class="valueSetTemplate__right"
+            >
+              <div>
+                <div
+                  class="valueSetTemplate__search"
+                >
+                  <input
+                    class="usa-input searchField valueSetSearch"
+                    data-testid="textInput"
+                    id="valueSetTemplateSearch"
+                    name="valueSetTemplateSearch"
+                    placeholder="Search labs, medications, conditions"
+                    type="search"
+                    value=""
+                  />
+                  <div
+                    class="datePickerContainer"
+                  >
+                    <div
+                      class="textInputContainer"
+                    >
+                      <input
+                        aria-label="Date range input"
+                        class="usa-input"
+                        data-testid="date-range-input"
+                        id="date-range-input"
+                        name="date-range-input"
+                        placeholder="Filter by date"
+                        readonly=""
+                        type="text"
+                        value=""
+                      />
+                      <svg
+                        aria-label="date-range-calendar-icon"
+                        class="usa-icon usa-icon--size-3 calendarIcon"
+                        focusable="false"
+                        height="1em"
+                        role="img"
+                        viewBox="0 0 24 24"
+                        width="1em"
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          d="M20 3h-1V1h-2v2H7V1H5v2H4c-1.1 0-2 .9-2 2v16c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zm0 18H4V8h16v13z"
+                        />
+                      </svg>
+                    </div>
+                  </div>
+                </div>
+                <div
+                  class="accordionContainer"
+                  data-testid="accordion-container"
+                >
+                  <div
+                    class="usa-accordion accordionInnerWrapper"
+                    data-testid="accordion"
+                  >
+                    <fieldset>
+                      <legend
+                        class="usa-accordion__heading"
+                      >
+                        <button
+                          aria-controls="medications"
+                          aria-expanded="false"
+                          class="usa-accordion__button foo"
+                          data-testid="accordionButton_medications"
+                          type="button"
+                        >
+                          <div
+                            class="accordionHeaderContent"
+                          >
+                            <div
+                              class="accordionLabel"
+                            >
+                              <svg
+                                aria-label="Arrow indicating collapsed or expanded toggle content"
+                                class="usa-icon usa-icon--size-3"
+                                focusable="false"
+                                height="1em"
+                                role="img"
+                                style="rotate: 90deg;"
+                                viewBox="0 0 24 24"
+                                width="1em"
+                                xmlns="http://www.w3.org/2000/svg"
+                              >
+                                <path
+                                  d="m7 14 5-5 5 5z"
+                                />
+                              </svg>
+                              <div
+                                class="accordionLabel"
+                                data-testid="accordionHeader_medications"
+                              >
+                                medications
+                              </div>
+                            </div>
+                            <div
+                              class="accordionHeaderCount"
+                            >
+                              2 / 2
+                            </div>
+                          </div>
+                        </button>
+                      </legend>
+                      <div
+                        class="usa-prose accordionInnerWrapper"
+                        data-testid="accordionItem_medications"
+                        hidden=""
+                        id="medications"
+                      >
+                        <div
+                          class="bulkActionButtons"
+                        >
+                          <button
+                            class="usa-button selectAll usa-button--unstyled"
+                            data-testid="button"
+                            type="button"
+                          >
+                            Deselect  All
+                          </button>
+                        </div>
+                        <div
+                          class="accordionContainer"
+                        >
+                          <div
+                            class="accordionBodyExpanded"
+                            data-testid="container-7_20240909"
+                          >
+                            <div
+                              class="accordionExpandedInner"
+                            >
+                              <div
+                                class="valueSetTemplate__checkboxWrapper"
+                              >
+                                <div
+                                  class="valueSetTemplate__checkboxWrapper"
+                                >
+                                  <div
+                                    class="display-flex flex-column"
+                                  >
+                                    <div
+                                      class="checkboxInfoContainer"
+                                      tabindex="-1"
+                                    >
+                                      <div
+                                        class="usa-checkbox valueSetTemplate__checkbox checkbox"
+                                        data-testid="checkbox"
+                                      >
+                                        <input
+                                          checked=""
+                                          class="usa-checkbox__input"
+                                          id="7_20240909"
+                                          name="7_20240909"
+                                          type="checkbox"
+                                        />
+                                        <label
+                                          class="usa-checkbox__label"
+                                          for="7_20240909"
+                                        >
+                                          <div
+                                            class="expandedContent"
+                                          >
+                                            <div
+                                              class="vsName"
+                                            >
+                                              <span>
+                                                <span
+                                                  class=""
+                                                >
+                                                  Gonorrhea Medication
+                                                </span>
+                                              </span>
+                                            </div>
+                                          </div>
+                                        </label>
+                                      </div>
+                                    </div>
+                                    <div
+                                      class="vsDetails"
+                                    >
+                                      <div
+                                        class="padding-right-2"
+                                      >
+                                        Author: DIBBs
+                                      </div>
+                                      <div>
+                                        System: http://www.nlm.nih.gov/research/umls/rxnorm
+                                      </div>
+                                    </div>
+                                  </div>
+                                </div>
+                              </div>
+                              <div
+                                class="accordionBodyExpanded__right"
+                              >
+                                <div
+                                  class="displayCount"
+                                  data-testid="displayCount-7_20240909"
+                                >
+                                  2
+                                   / 
+                                  2
+                                </div>
+                                <button
+                                  class="usa-button usa-button--secondary viewCodesBtn"
+                                  data-testid="viewCodes-7_20240909"
+                                  role="button"
+                                  tabindex="0"
+                                  type="button"
+                                >
+                                  View codes
+                                </button>
+                              </div>
+                            </div>
+                          </div>
+                          <div>
+                            <div
+                              aria-label="drawer-container"
+                              class="drawer closed width35"
+                              data-testid="drawer-open-false"
+                              id="drawer-container"
+                              role="dialog"
+                            >
+                              <div
+                                class="display-none"
+                              />
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                    </fieldset>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div
+    aria-describedby="warning-confirmation-modal-modal-description"
+    aria-labelledby="warning-confirmation-modal-modal-heading"
+    class="usa-modal-wrapper is-hidden"
+    data-force-action="false"
+    id="warning-confirmation-modal-modal"
+    role="dialog"
+  >
+    <div
+      aria-controls="warning-confirmation-modal-modal"
+      class="usa-modal-overlay"
+      data-testid="modalOverlay"
+    >
+      <div
+        class="usa-modal qc-modal"
+        data-force-action="false"
+        data-testid="modalWindow"
+        tabindex="-1"
+      >
+        <div
+          class="usa-modal__content"
+        >
+          <div
+            class="usa-modal__main"
+          >
+            <h2
+              class="usa-modal__heading"
+              id="warning-confirmation-modal-modal-heading"
+            >
+              You have unsaved changes
+            </h2>
+            <div
+              class="usa-prose"
+              id="warning-confirmation-modal-modal-description"
+            >
+              <p>
+                You've made changes to your query. Would you like to save before leaving?
+              </p>
+            </div>
+            <div
+              class="usa-modal__footer"
+              data-testid="modalFooter"
+            >
+              <ul
+                class="usa-button-group"
+              >
+                <li
+                  class="usa-button-group__item"
+                >
+                  <button
+                    class="usa-button usa-button--default"
+                    data-testid="button"
+                    type="button"
+                  >
+                    Save
+                  </button>
+                </li>
+                <li
+                  class="usa-button-group__item"
+                >
+                  <button
+                    class="usa-button usa-button--secondary"
+                    data-testid="button"
+                    type="button"
+                  >
+                    Dismiss
+                  </button>
+                </li>
+              </ul>
+            </div>
+          </div>
+          <button
+            aria-controls="warning-confirmation-modal-modal"
+            aria-label="Close this window"
+            class="usa-button usa-modal__close"
+            data-close-modal="true"
+            data-testid="button"
+            type="button"
+          >
+            <svg
+              aria-hidden="true"
+              class="usa-icon"
+              focusable="false"
+              height="1em"
+              role="img"
+              viewBox="0 0 24 24"
+              width="1em"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M19 6.41 17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"
+              />
+            </svg>
+          </button>
+        </div>
+      </div>
+    </div>
+  </div>
+</body>
+`;

--- a/src/app/(pages)/queryBuilding/components/valueSetSelectionViews/ConceptSelectionView.tsx
+++ b/src/app/(pages)/queryBuilding/components/valueSetSelectionViews/ConceptSelectionView.tsx
@@ -86,6 +86,7 @@ export const ConceptSelectionView: React.FC<ConceptSelectionViewProps> = ({
 
         const content = (
           <ConceptTypeAccordionBody
+            accordionConceptType={vsType}
             activeValueSets={valueSetsInType}
             handleVsNameLevelUpdate={handleVsNameLevelUpdate}
             handleVsIdLevelUpdate={handleVsNameLevelUpdate}

--- a/src/app/(pages)/queryBuilding/components/valueSetSelectionViews/Sidebar.tsx
+++ b/src/app/(pages)/queryBuilding/components/valueSetSelectionViews/Sidebar.tsx
@@ -1,7 +1,4 @@
-import {
-  CUSTOM_CONDITION_ID,
-  CUSTOM_VALUESET_ARRAY_ID,
-} from "@/app/shared/constants";
+import { CUSTOM_VALUESET_ARRAY_ID } from "@/app/shared/constants";
 import { Icon } from "@trussworks/react-uswds";
 import classNames from "classnames";
 import styles from "../../buildFromTemplates/conditionTemplateSelection.module.scss";
@@ -219,13 +216,15 @@ export const Sidebar: React.FC<SidebarProps> = ({
             <div
               className={classNames(
                 "align-items-center",
-                activeCondition === CUSTOM_CONDITION_ID
+                activeCondition === CUSTOM_VALUESET_ARRAY_ID
                   ? `${styles.card} ${styles.active}`
                   : styles.card,
               )}
+              data-testid={`tab-custom-container`}
             >
               <button
                 id={`tab-custom`}
+                data-testid={`tab-custom`}
                 className="unstyled-button-container"
                 onClick={() => setActiveCondition(CUSTOM_VALUESET_ARRAY_ID)}
               >
@@ -241,9 +240,11 @@ export const Sidebar: React.FC<SidebarProps> = ({
                   ? `${styles.card} ${styles.active}`
                   : styles.card,
               )}
+              data-testid={`tab-medical-records-container`}
             >
               <button
                 id={`tab-medical-records`}
+                data-testid={`tab-medical-records`}
                 onClick={() => setActiveCondition(MEDICAL_RECORD_SECTIONS_ID)}
                 className="unstyled-button-container"
               >

--- a/src/app/tests/integration/audit-log/user-management.test.ts
+++ b/src/app/tests/integration/audit-log/user-management.test.ts
@@ -74,6 +74,7 @@ describe("user management tests", () => {
       email: TEST_USER.user.id,
       firstName: TEST_USER.user.id,
       lastName: TEST_USER.user.id,
+      qcRole: UserRole.STANDARD,
     };
     const actionTypeToCheck = "addUserIfNotExists";
     const { user } = await addUserIfNotExists(randomUserToken);
@@ -135,6 +136,7 @@ describe("user management tests", () => {
       email: TEST_USER.user.id,
       firstName: TEST_USER.user.id,
       lastName: TEST_USER.user.id,
+      qcRole: UserRole.STANDARD,
     };
 
     const { user } = await addUserIfNotExists(randomUserToken);

--- a/src/app/ui/designSystem/timeboxing/DateRangePicker.module.scss
+++ b/src/app/ui/designSystem/timeboxing/DateRangePicker.module.scss
@@ -21,19 +21,33 @@
   position: relative;
   display: inline-block;
 
+  :hover {
+    cursor: pointer;
+  }
+
   input {
-    width: 12rem;
+    border-radius: 0.25rem;
+    border: 1px solid $border-dark;
   }
 }
 
 .calendarIcon {
   position: absolute;
-  right: 0.625rem;
+  left: 0.625rem;
   top: 55%;
   transform: translateY(-50%);
   pointer-events: none;
   align-items: center;
   justify-content: center;
+  color: $accent-primary;
+}
+
+.dateRangeInput {
+  padding-left: 2.5rem;
+}
+
+.dateRangeInput::placeholder {
+  color: black;
 }
 
 .datePickerContainer {
@@ -59,7 +73,7 @@
   border-radius: 0.25rem;
   box-shadow: 0 4px 6px $drop-shadow;
   padding: 0.5rem;
-  // width: max-content; // without this, the calendar looks somewhat squished
+  width: max-content; // without this, the calendar looks somewhat squished
   margin-top: 0.5rem;
 }
 
@@ -89,7 +103,7 @@
   box-shadow: 0 4px 6px $drop-shadow;
   padding: 0.5rem;
   margin-top: 0.5rem;
-  width: 125%;
+  width: 15rem;
 }
 
 .popoverLeft {

--- a/src/app/ui/designSystem/timeboxing/DateRangePicker.module.scss
+++ b/src/app/ui/designSystem/timeboxing/DateRangePicker.module.scss
@@ -20,6 +20,10 @@
 .textInputContainer {
   position: relative;
   display: inline-block;
+
+  input {
+    width: 12rem;
+  }
 }
 
 .calendarIcon {
@@ -35,7 +39,6 @@
 .datePickerContainer {
   position: relative;
   display: inline-block;
-  width: 100%;
 }
 
 .customDateRangeWrapper :global(.usa-form-group) {
@@ -76,11 +79,9 @@
   padding: 0;
 }
 
-
 .filterPopover {
   position: absolute;
   top: 100%;
-  left: 0;
   z-index: 10;
   background: white;
   border: 1px solid $border;
@@ -88,7 +89,15 @@
   box-shadow: 0 4px 6px $drop-shadow;
   padding: 0.5rem;
   margin-top: 0.5rem;
-  width: 100%;
+  width: 125%;
+}
+
+.popoverLeft {
+  right: 0;
+}
+
+.popoverRight {
+  left: 0;
 }
 
 .applyButton {

--- a/src/app/ui/designSystem/timeboxing/DateRangePicker.tsx
+++ b/src/app/ui/designSystem/timeboxing/DateRangePicker.tsx
@@ -27,7 +27,9 @@ interface DateRangePickerProps {
   startDate: Date | null;
   endDate: Date | null;
   onChange: (dates: { startDate: Date | null; endDate: Date | null }) => void;
+  id: string;
   popoverSide?: "left" | "right";
+  placeholderText?: string;
 }
 
 const normalizeStart = (date: Date | null) =>
@@ -148,15 +150,19 @@ const CUSTOM_VALUE = "custom";
  * @param root0 - The component props.
  * @param root0.startDate - The start date.
  * @param root0.endDate - The end date.
+ * @param root0.id - The id for the form input.
  * @param root0.onChange - The change handler.
  * @param root0.popoverSide - Optional prop to control the side the popover's on.
+ * @param root0.placeholderText - Text to indicate the filter.
  * @returns - The date range picker component.
  */
 const DateRangePicker: React.FC<DateRangePickerProps> = ({
   startDate: initialStart,
   endDate: initialEnd,
   onChange,
+  id,
   popoverSide = "right",
+  placeholderText = "Filter by date",
 }) => {
   const [selectedPreset, setSelectedPreset] = useState<string>("");
   const [customStart, setCustomStart] = useState<Date | null>(initialStart);
@@ -297,22 +303,28 @@ const DateRangePicker: React.FC<DateRangePickerProps> = ({
 
   return (
     <div className={styles.datePickerContainer} ref={containerRef}>
-      <div className={styles.textInputContainer}>
+      <div
+        className={classNames(
+          styles.textInputContainer,
+          displayText ? styles.textInputContainer__wide : "",
+        )}
+      >
+        <Icon.CalendarToday
+          size={3}
+          className={styles.calendarIcon}
+          aria-label="date-range-calendar-icon"
+        />
         <TextInput
+          id={id}
           type="text"
-          id="date-range-input"
+          className={styles.dateRangeInput}
           data-testid="date-range-input"
           name="date-range-input"
           aria-label="Date range input"
           value={displayText}
           readOnly
-          placeholder="Filter by date"
+          placeholder={placeholderText}
           onClick={() => setIsOpen((prev) => !prev)}
-        />
-        <Icon.CalendarToday
-          size={3}
-          className={styles.calendarIcon}
-          aria-label="date-range-calendar-icon"
         />
       </div>
       {isOpen && (

--- a/src/app/ui/designSystem/timeboxing/DateRangePicker.tsx
+++ b/src/app/ui/designSystem/timeboxing/DateRangePicker.tsx
@@ -11,6 +11,7 @@ import {
 } from "@trussworks/react-uswds";
 import styles from "./DateRangePicker.module.scss";
 import { addHours } from "date-fns";
+import classNames from "classnames";
 
 export interface DateRange {
   startDate?: Date | null;
@@ -26,6 +27,7 @@ interface DateRangePickerProps {
   startDate: Date | null;
   endDate: Date | null;
   onChange: (dates: { startDate: Date | null; endDate: Date | null }) => void;
+  popoverSide?: "left" | "right";
 }
 
 const normalizeStart = (date: Date | null) =>
@@ -147,12 +149,14 @@ const CUSTOM_VALUE = "custom";
  * @param root0.startDate - The start date.
  * @param root0.endDate - The end date.
  * @param root0.onChange - The change handler.
+ * @param root0.popoverSide - Optional prop to control the side the popover's on.
  * @returns - The date range picker component.
  */
 const DateRangePicker: React.FC<DateRangePickerProps> = ({
   startDate: initialStart,
   endDate: initialEnd,
   onChange,
+  popoverSide = "right",
 }) => {
   const [selectedPreset, setSelectedPreset] = useState<string>("");
   const [customStart, setCustomStart] = useState<Date | null>(initialStart);
@@ -302,6 +306,7 @@ const DateRangePicker: React.FC<DateRangePickerProps> = ({
           aria-label="Date range input"
           value={displayText}
           readOnly
+          placeholder="Filter by date"
           onClick={() => setIsOpen((prev) => !prev)}
         />
         <Icon.CalendarToday
@@ -311,7 +316,12 @@ const DateRangePicker: React.FC<DateRangePickerProps> = ({
         />
       </div>
       {isOpen && (
-        <div className={styles.filterPopover}>
+        <div
+          className={classNames(
+            styles.filterPopover,
+            popoverSide === "left" ? styles.popoverLeft : styles.popoverRight,
+          )}
+        >
           <FormGroup className="margin-top-1">
             <fieldset className={styles.radioGroup} aria-label="Filter by">
               <legend className={styles.legend}>Filter by</legend>

--- a/src/app/ui/styles/styles.scss
+++ b/src/app/ui/styles/styles.scss
@@ -28,6 +28,7 @@
 @forward "usa-table/src/styles";
 @forward "usa-pagination/src/styles";
 @forward "usa-prose/src/styles";
+@forward "usa-tag/src/styles";
 
 @forward "uswds-core";
 @forward "uswds-fonts";


### PR DESCRIPTION
# PULL REQUEST

https://github.com/user-attachments/assets/b2b98e9c-09d5-4d45-9260-2bc80a899f97

## Summary
Frontend for timeboxing changes that
- Puts datepickers in each "bulk edit" section of the concept type accordions according to designs [here](https://www.figma.com/design/Iuw9me6kYftBF4WTCEsCZz/Query-Connector?node-id=4049-7977&m=dev)
     - Original designs had them within the accordion, but that creates accessibility issues due to nested component interactions :( 
- Right now there isn't anything happening in the backend: the start / end dates simply get logged out. Backend functionality to come as a followup per [this ticket](https://linear.app/skylight-cdc/issue/QUE-317/add-backend-support-for-including-date-in-valueset-querying)

## Related Issue
Fixes [QUE-305](https://linear.app/skylight-cdc/issue/QUE-305/implement-time-boxing-designs)

## Additional Information
Anything else the review team should know?

## Checklist

- [x] Descriptive Pull Request title
- [x] Link to relevant issues
- [x] Provide necessary context for design reviewers
- [x] Ensure test coverage is above agreed upon threshold
- [x] Update documentation
