### PR TITLE
Rob/751 azure function triggered by blob storage

### DIFF
--- a/src/app/api/azure/post-hl7.ts
+++ b/src/app/api/azure/post-hl7.ts
@@ -10,6 +10,13 @@ type HL7QueryParams = {
 
 /**
  * Sends a raw HL7v2 message to the Query Connector API as text/plain.
+ * @param root0 - The parameters for the HL7 query.
+ * @param root0.endpoint - The endpoint URL of the Query Connector API.
+ * @param root0.queryId - The unique identifier for the query.
+ * @param root0.fhirServer - The FHIR server to associate with the query.
+ * @param root0.serviceToken - The service token for authentication.
+ * @param root0.hl7Message - The HL7v2 message to be sent.
+ * @returns A promise that resolves to the fetch response.
  */
 export async function postHL7({
   endpoint,

--- a/src/app/api/azure/post-hl7.ts
+++ b/src/app/api/azure/post-hl7.ts
@@ -1,0 +1,33 @@
+import fetch, { Response as FetchResponse } from "node-fetch";
+
+type HL7QueryParams = {
+  endpoint: string;
+  queryId: string;
+  fhirServer: string;
+  serviceToken: string;
+  hl7Message: string;
+};
+
+/**
+ * Sends a raw HL7v2 message to the Query Connector API as text/plain.
+ */
+export async function postHL7({
+  endpoint,
+  queryId,
+  fhirServer,
+  serviceToken,
+  hl7Message,
+}: HL7QueryParams): Promise<FetchResponse> {
+  const url = `${endpoint}?id=${encodeURIComponent(queryId)}&fhir_server=${encodeURIComponent(
+    fhirServer,
+  )}&message_format=HL7`;
+
+  return fetch(url, {
+    method: "POST",
+    headers: {
+      "Content-Type": "text/plain",
+      Authorization: `Bearer ${serviceToken}`,
+    },
+    body: hl7Message,
+  });
+}

--- a/src/app/api/azure/process-hl7.ts
+++ b/src/app/api/azure/process-hl7.ts
@@ -1,4 +1,4 @@
-import { postHL7 } from "./postHl7";
+import { postHL7 } from "./post-hl7";
 
 const queryId = process.env.QUERY_ID!;
 const fhirServer = process.env.FHIR_SERVER!;

--- a/src/app/api/azure/process-hl7.ts
+++ b/src/app/api/azure/process-hl7.ts
@@ -1,0 +1,50 @@
+import { postHL7 } from "./postHl7";
+
+const queryId = process.env.QUERY_ID!;
+const fhirServer = process.env.FHIR_SERVER!;
+const serviceToken = process.env.SERVICE_TOKEN!;
+const endpoint = process.env.QUERY_CONNECTOR_ENDPOINT;
+
+interface BlobTriggerContext {
+  log: {
+    (message: string, ...args: any[]): void;
+    error: (message: string, ...args: any[]) => void;
+  };
+}
+
+interface PostHL7Params {
+  queryId: string;
+  fhirServer: string;
+  serviceToken: string;
+  hl7Message: string;
+  endpoint?: string;
+}
+
+const blobTrigger = async function (
+  context: BlobTriggerContext,
+  content: Buffer,
+): Promise<void> {
+  const hl7 = content.toString("utf-8");
+
+  try {
+    const res = await postHL7({
+      queryId,
+      fhirServer,
+      serviceToken,
+      hl7Message: hl7,
+      endpoint: endpoint || "https://queryconnector.dev/api/query",
+    });
+
+    const body: string = await res.text();
+
+    if (!res.ok) {
+      context.log.error("HL7 POST failed", { status: res.status, body });
+    } else {
+      context.log("HL7 POST succeeded");
+    }
+  } catch (err) {
+    context.log.error("Exception during HL7 POST:", err);
+  }
+};
+
+export default blobTrigger;

--- a/src/app/api/azure/process-hl7.ts
+++ b/src/app/api/azure/process-hl7.ts
@@ -7,8 +7,8 @@ const endpoint = process.env.QUERY_CONNECTOR_ENDPOINT;
 
 interface BlobTriggerContext {
   log: {
-    (message: string, ...args: any[]): void;
-    error: (message: string, ...args: any[]) => void;
+    (message: string, ...args: unknown[]): void;
+    error: (message: string, ...args: unknown[]) => void;
   };
 }
 
@@ -42,7 +42,7 @@ const blobTrigger = async function (
     } else {
       context.log("HL7 POST succeeded");
     }
-  } catch (err) {
+  } catch (err: unknown) {
     context.log.error("Exception during HL7 POST:", err);
   }
 };


### PR DESCRIPTION
# PULL REQUEST

## Summary

Adds azure functions to do part of this workflow for work in WA:

```
HL7v2 message
        |
        v
Upload HL7v2 File to Azure Blob Storage Container
        |
        v
 Azure Function Triggered by Blob Upload - Shanice creates IaC that will create function and its trigger. Rob will create TypeScript code that Grabs the HL7v2 message and sends it to Query Connector API
        |
        v
 Azure function will grab HL7v2 Message and send it to QC API
        |
        v
     Query Connector API receives HL7v2 message
```
## Related Issue

Fixes #751 

## Additional Information

Anything else the review team should know?

## Checklist

- [ ] Descriptive Pull Request title
- [ ] Link to relevant issues
- [ ] Provide necessary context for design reviewers
- [ ] Ensure test coverage is above agreed upon threshold
- [ ] Update documentation
