### PR TITLE
Remove extra fhir servers from Flyway migrations

### DIFF
--- a/flyway/sql/V01_01__tcr_custom_query_schema.sql
+++ b/flyway/sql/V01_01__tcr_custom_query_schema.sql
@@ -199,72 +199,73 @@ WHERE default_server = TRUE;
 -- Direct FHIR servers
 INSERT INTO fhir_servers (name, hostname, last_connection_attempt, last_connection_successful)
 VALUES 
-    ('Public HAPI: Direct', 'https://hapi.fhir.org/baseR4', current_timestamp, true),
-    ('HELIOS Meld: Direct', 'https://gw.interop.community/HeliosConnectathonSa/open', current_timestamp, true),
-    ('JMC Meld: Direct', 'https://gw.interop.community/JMCHeliosSTISandbox/open', current_timestamp, true),
-    ('Local e2e HAPI Server: Direct', 'http://hapi-fhir-server:8080/fhir', current_timestamp, true),
-    ('OPHDST Meld: Direct', 'https://gw.interop.community/CDCSepHL7Connectatho/open', current_timestamp, true);
+    ('Public HAPI: Direct', 'https://hapi.fhir.org/baseR4', current_timestamp, true)
+    -- , ('HELIOS Meld: Direct', 'https://gw.interop.community/HeliosConnectathonSa/open', current_timestamp, true)
+    -- , ('JMC Meld: Direct', 'https://gw.interop.community/JMCHeliosSTISandbox/open', current_timestamp, true)
+    -- , ('Local e2e HAPI Server: Direct', 'http://hapi-fhir-server:8080/fhir', current_timestamp, true)
+    -- , ('OPHDST Meld: Direct', 'https://gw.interop.community/CDCSepHL7Connectatho/open', current_timestamp, true)
+    ;
 
--- eHealthExchange FHIR servers
-INSERT INTO fhir_servers (name, hostname, headers, last_connection_attempt, last_connection_successful, disable_cert_validation)
-VALUES 
-    ('HELIOS Meld: eHealthExchange', 
-     'https://concept01.ehealthexchange.org:52780/fhirproxy/r4',
-     '{
-        "Accept": "application/json, application/*+json, */*",
-        "Accept-Encoding": "gzip, deflate, br",
-        "Content-Type": "application/fhir+json; charset=UTF-8",
-        "X-DESTINATION": "MeldOpen",
-        "X-POU": "PUBHLTH",
-        "prefer": "return=representation",
-        "Cache-Control": "no-cache"
-     }',
-     current_timestamp,
-     true,
-     true),
-    ('JMC Meld: eHealthExchange',
-     'https://concept01.ehealthexchange.org:52780/fhirproxy/r4',
-     '{
-        "Accept": "application/json, application/*+json, */*",
-        "Accept-Encoding": "gzip, deflate, br",
-        "Content-Type": "application/fhir+json; charset=UTF-8",
-        "X-DESTINATION": "JMCHelios",
-        "X-POU": "PUBHLTH",
-        "prefer": "return=representation",
-        "Cache-Control": "no-cache"
-     }',
-     current_timestamp,
-     true,
-     true),
-    ('OpenEpic: eHealthExchange',
-     'https://concept01.ehealthexchange.org:52780/fhirproxy/r4',
-     '{
-        "Accept": "application/json, application/*+json, */*",
-        "Accept-Encoding": "gzip, deflate, br",
-        "Content-Type": "application/fhir+json; charset=UTF-8",
-        "X-DESTINATION": "OpenEpic",
-        "X-POU": "PUBHLTH",
-        "prefer": "return=representation",
-        "Cache-Control": "no-cache"
-     }',
-     current_timestamp,
-     true,
-     true),
-    ('CernerHelios: eHealthExchange',
-     'https://concept01.ehealthexchange.org:52780/fhirproxy/r4',
-     '{
-        "Accept": "application/json, application/*+json, */*",
-        "Accept-Encoding": "gzip, deflate, br",
-        "Content-Type": "application/fhir+json; charset=UTF-8",
-        "X-DESTINATION": "CernerHelios",
-        "X-POU": "PUBHLTH",
-        "prefer": "return=representation",
-        "Cache-Control": "no-cache",
-        "OAUTHSCOPES": "system/Condition.read system/Encounter.read system/Immunization.read system/MedicationRequest.read system/Observation.read system/Patient.read system/Procedure.read system/MedicationAdministration.read system/DiagnosticReport.read system/RelatedPerson.read"
-     }',
-     current_timestamp,
-     true,
-     true);
+-- eHealthExchange FHIR servers (optional)
+-- INSERT INTO fhir_servers (name, hostname, headers, last_connection_attempt, last_connection_successful, disable_cert_validation)
+-- VALUES 
+--     ('HELIOS Meld: eHealthExchange', 
+--      'https://concept01.ehealthexchange.org:52780/fhirproxy/r4',
+--      '{
+--         "Accept": "application/json, application/*+json, */*",
+--         "Accept-Encoding": "gzip, deflate, br",
+--         "Content-Type": "application/fhir+json; charset=UTF-8",
+--         "X-DESTINATION": "MeldOpen",
+--         "X-POU": "PUBHLTH",
+--         "prefer": "return=representation",
+--         "Cache-Control": "no-cache"
+--      }',
+--      current_timestamp,
+--      true,
+--      true),
+--     ('JMC Meld: eHealthExchange',
+--      'https://concept01.ehealthexchange.org:52780/fhirproxy/r4',
+--      '{
+--         "Accept": "application/json, application/*+json, */*",
+--         "Accept-Encoding": "gzip, deflate, br",
+--         "Content-Type": "application/fhir+json; charset=UTF-8",
+--         "X-DESTINATION": "JMCHelios",
+--         "X-POU": "PUBHLTH",
+--         "prefer": "return=representation",
+--         "Cache-Control": "no-cache"
+--      }',
+--      current_timestamp,
+--      true,
+--      true),
+--     ('OpenEpic: eHealthExchange',
+--      'https://concept01.ehealthexchange.org:52780/fhirproxy/r4',
+--      '{
+--         "Accept": "application/json, application/*+json, */*",
+--         "Accept-Encoding": "gzip, deflate, br",
+--         "Content-Type": "application/fhir+json; charset=UTF-8",
+--         "X-DESTINATION": "OpenEpic",
+--         "X-POU": "PUBHLTH",
+--         "prefer": "return=representation",
+--         "Cache-Control": "no-cache"
+--      }',
+--      current_timestamp,
+--      true,
+--      true),
+--     ('CernerHelios: eHealthExchange',
+--      'https://concept01.ehealthexchange.org:52780/fhirproxy/r4',
+--      '{
+--         "Accept": "application/json, application/*+json, */*",
+--         "Accept-Encoding": "gzip, deflate, br",
+--         "Content-Type": "application/fhir+json; charset=UTF-8",
+--         "X-DESTINATION": "CernerHelios",
+--         "X-POU": "PUBHLTH",
+--         "prefer": "return=representation",
+--         "Cache-Control": "no-cache",
+--         "OAUTHSCOPES": "system/Condition.read system/Encounter.read system/Immunization.read system/MedicationRequest.read system/Observation.read system/Patient.read system/Procedure.read system/MedicationAdministration.read system/DiagnosticReport.read system/RelatedPerson.read"
+--      }',
+--      current_timestamp,
+--      true,
+--      true);
 
 -- Migrate existing servers with Authorization headers to use the basic auth_type
 UPDATE fhir_servers


### PR DESCRIPTION
# PULL REQUEST

## Summary

Removes extra fhir servers from the migration script. Extra servers are still in the `vs_dump.sql`. Very low priority. Not entirely sure why flyway is falling over atm. Good luck everyone!

## Related Issue

Fixes #

## Additional Information

Anything else the review team should know?

## Checklist

- [ ] Descriptive Pull Request title
- [ ] Link to relevant issues
- [ ] Provide necessary context for design reviewers
- [ ] Ensure test coverage is above agreed upon threshold
- [ ] Update documentation
