### PR TITLE
Add PingFederate support

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -20,7 +20,7 @@ NAMED_KEYCLOAK=http://localhost:8081/realms/master
 # Keycloak - set NEXT_PUBLIC_AUTH_PROVIDER to "keycloak"
 # Entra ID - set NEXT_PUBLIC_AUTH_PROVIDER to "microsoft-entra-id" and AUTH_ISSUER to "https://login.microsoftonline.com/your-tenant-id/v2.0"
 # Ping Federate - set NEXT_PUBLIC_AUTH_PROVIDER to "ping-id" and AUTH_ISSUER to your PingFederate AS URL (e.g., "https://your-ping-host/as")
-# PING_ROLE_CLAIM=roles  # Optional: custom claim name for roles in access token (default: "roles")
+# PING_ROLE_CLAIM=roles  # Optional: custom claim name for roles in access and service tokens (default: "roles"); service tokens must include "api-user" in this claim for API access
 AUTH_CLIENT_ID=query-connector
 AUTH_CLIENT_SECRET=ZG3f7R1J3qIwBaw8QtttJnJMinpERQKs
 AUTH_ISSUER=http://localhost:8081/realms/master

--- a/.env.sample
+++ b/.env.sample
@@ -18,7 +18,9 @@ LOCAL_KEYCLOAK=http://localhost:8081/realms/master
 NAMED_KEYCLOAK=http://localhost:8081/realms/master
 
 # Keycloak - set NEXT_PUBLIC_AUTH_PROVIDER to "keycloak"
-# Entra ID - set NEXT_PUBLIC_AUTH_PROVIDER to "microsoft-entra-id" and AUTH_ISSUER to "https://login.microsoftonline.com/your-tenant-id/v2.0""
+# Entra ID - set NEXT_PUBLIC_AUTH_PROVIDER to "microsoft-entra-id" and AUTH_ISSUER to "https://login.microsoftonline.com/your-tenant-id/v2.0"
+# Ping Federate - set NEXT_PUBLIC_AUTH_PROVIDER to "ping-id" and AUTH_ISSUER to your PingFederate AS URL (e.g., "https://your-ping-host/as")
+# PING_ROLE_CLAIM=roles  # Optional: custom claim name for roles in access token (default: "roles")
 AUTH_CLIENT_ID=query-connector
 AUTH_CLIENT_SECRET=ZG3f7R1J3qIwBaw8QtttJnJMinpERQKs
 AUTH_ISSUER=http://localhost:8081/realms/master

--- a/src/app/api/api-auth.ts
+++ b/src/app/api/api-auth.ts
@@ -13,6 +13,10 @@ interface KeycloakJWTPayload extends JWTPayload {
   };
 }
 
+interface PingJWTPayload extends JWTPayload {
+  [key: string]: unknown;
+}
+
 /**
  * Validates the service token from the Authorization header of the request.
  * @param req - The NextRequest object containing the Authorization header
@@ -33,9 +37,9 @@ export async function validateServiceToken(req: NextRequest) {
   try {
     let keySetUrl: URL;
     let issuer: string | undefined;
-    let isKeycloak = false;
+    const provider = process.env.NEXT_PUBLIC_AUTH_PROVIDER;
 
-    switch (process.env.NEXT_PUBLIC_AUTH_PROVIDER) {
+    switch (provider) {
       case "microsoft-entra-id":
         keySetUrl = new URL(
           "https://login.microsoftonline.com/common/discovery/keys",
@@ -47,7 +51,10 @@ export async function validateServiceToken(req: NextRequest) {
           `${process.env.AUTH_ISSUER}/protocol/openid-connect/certs`,
         );
         issuer = process.env.AUTH_ISSUER;
-        isKeycloak = true;
+        break;
+      case "ping-id":
+        keySetUrl = new URL(`${process.env.AUTH_ISSUER}/jwks`);
+        issuer = process.env.AUTH_ISSUER;
         break;
       default:
         return { valid: false, error: "Unsupported authentication provider" };
@@ -60,7 +67,7 @@ export async function validateServiceToken(req: NextRequest) {
     });
 
     // Check roles based on provider
-    if (isKeycloak) {
+    if (provider === "keycloak") {
       const keycloakPayload = payload as KeycloakJWTPayload;
       if (
         process.env.AUTH_CLIENT_ID &&
@@ -71,13 +78,24 @@ export async function validateServiceToken(req: NextRequest) {
       ) {
         return { valid: true, payload };
       }
-    } else {
+    } else if (provider === "microsoft-entra-id") {
       const entraPayload = payload as EntraJWTPayload;
       if (
         process.env.AUTH_CLIENT_ID &&
         (entraPayload.aud === process.env.AUTH_CLIENT_ID ||
           entraPayload.aud === `api://${process.env.AUTH_CLIENT_ID}`) &&
         entraPayload.roles?.includes("api-user")
+      ) {
+        return { valid: true, payload };
+      }
+    } else if (provider === "ping-id") {
+      const pingPayload = payload as PingJWTPayload;
+      const roleClaim = process.env.PING_ROLE_CLAIM || "roles";
+      const roles = pingPayload[roleClaim] as string[] | undefined;
+      if (
+        process.env.AUTH_CLIENT_ID &&
+        pingPayload.aud?.includes(process.env.AUTH_CLIENT_ID) &&
+        roles?.includes("api-user")
       ) {
         return { valid: true, payload };
       }

--- a/src/app/api/api-auth.ts
+++ b/src/app/api/api-auth.ts
@@ -17,6 +17,14 @@ interface PingJWTPayload extends JWTPayload {
   [key: string]: unknown;
 }
 
+function audienceMatches(
+  aud: string | string[] | undefined,
+  clientId: string,
+): boolean {
+  if (Array.isArray(aud)) return aud.includes(clientId);
+  return aud === clientId;
+}
+
 /**
  * Validates the service token from the Authorization header of the request.
  * @param req - The NextRequest object containing the Authorization header
@@ -71,7 +79,7 @@ export async function validateServiceToken(req: NextRequest) {
       const keycloakPayload = payload as KeycloakJWTPayload;
       if (
         process.env.AUTH_CLIENT_ID &&
-        keycloakPayload.aud?.includes(process.env.AUTH_CLIENT_ID) &&
+        audienceMatches(keycloakPayload.aud, process.env.AUTH_CLIENT_ID) &&
         keycloakPayload.resource_access?.[
           process.env.AUTH_CLIENT_ID
         ]?.roles?.includes("api-user")
@@ -94,7 +102,7 @@ export async function validateServiceToken(req: NextRequest) {
       const roles = pingPayload[roleClaim] as string[] | undefined;
       if (
         process.env.AUTH_CLIENT_ID &&
-        pingPayload.aud?.includes(process.env.AUTH_CLIENT_ID) &&
+        audienceMatches(pingPayload.aud, process.env.AUTH_CLIENT_ID) &&
         roles?.includes("api-user")
       ) {
         return { valid: true, payload };

--- a/src/app/backend/auth/lib.ts
+++ b/src/app/backend/auth/lib.ts
@@ -6,6 +6,7 @@ import { UserRole } from "@/app/models/entities/users";
 import { isAuthDisabledServerCheck } from "@/app/utils/auth";
 import KeycloakProvider from "next-auth/providers/keycloak";
 import MicrosoftEntraID from "next-auth/providers/microsoft-entra-id";
+import PingId from "next-auth/providers/ping-id";
 import { Provider } from "@auth/core/providers";
 
 export interface AuthStrategy {
@@ -180,6 +181,59 @@ export class MicrosoftEntraAuthStrategy implements AuthStrategy {
               roles: { essential: true },
             },
           },
+        },
+      },
+    });
+  }
+}
+
+export class PingFederateAuthStrategy implements AuthStrategy {
+  public parseIdpResponseForUserToken(
+    token: JWT,
+    account: Account,
+    profile: Profile,
+  ) {
+    let role: UserRole = UserRole.STANDARD;
+
+    if (account?.access_token) {
+      const decodedToken = decodeJwt(account.access_token);
+      const roleClaim = process.env.PING_ROLE_CLAIM || "roles";
+      const tokenRoles = decodedToken[roleClaim] as string[] | undefined;
+      const profileRoles = (profile as Profile & { roles?: string[] }).roles;
+      const roles = tokenRoles ?? profileRoles;
+
+      if (roles && roles[0] && ROLE_TO_ENUM_MAP[roles[0]]) {
+        role = ROLE_TO_ENUM_MAP[roles[0]];
+      } else {
+        console.warn(
+          "No recognized role found in Ping Federate token. Falling back to standard access",
+        );
+      }
+    } else {
+      console.warn(
+        "No access token found in Ping Federate response. Falling back to standard access",
+      );
+    }
+
+    const userToken = {
+      id: profile.sub || "",
+      username: profile.preferred_username || "",
+      email: profile.email || "",
+      firstName: profile.given_name || "",
+      lastName: profile.family_name || "",
+      qcRole: role,
+    };
+    return userToken;
+  }
+
+  public setUpNextAuthProvider() {
+    return PingId({
+      clientId: process.env.AUTH_CLIENT_ID,
+      clientSecret: process.env.AUTH_CLIENT_SECRET,
+      issuer: process.env.AUTH_ISSUER,
+      authorization: {
+        params: {
+          scope: "openid email profile",
         },
       },
     });

--- a/src/app/backend/auth/lib.ts
+++ b/src/app/backend/auth/lib.ts
@@ -196,9 +196,17 @@ export class PingFederateAuthStrategy implements AuthStrategy {
     let role: UserRole = UserRole.STANDARD;
 
     if (account?.access_token) {
-      const decodedToken = decodeJwt(account.access_token);
-      const roleClaim = process.env.PING_ROLE_CLAIM || "roles";
-      const tokenRoles = decodedToken[roleClaim] as string[] | undefined;
+      let tokenRoles: string[] | undefined;
+      try {
+        const decodedToken = decodeJwt(account.access_token);
+        const roleClaim = process.env.PING_ROLE_CLAIM || "roles";
+        tokenRoles = decodedToken[roleClaim] as string[] | undefined;
+      } catch (error) {
+        console.warn(
+          "Failed to decode Ping Federate access token. Falling back to profile roles or standard access",
+          error,
+        );
+      }
       const profileRoles = (profile as Profile & { roles?: string[] }).roles;
       const roles = tokenRoles ?? profileRoles;
 

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -6,6 +6,7 @@ import {
   AuthStrategy,
   KeycloakAuthStrategy,
   MicrosoftEntraAuthStrategy,
+  PingFederateAuthStrategy,
 } from "./app/backend/auth/lib";
 import { UserRole } from "./app/models/entities/users";
 import { returnPredefinedSessionObject } from "./app/utils/auth";
@@ -23,6 +24,11 @@ switch (process.env.NEXT_PUBLIC_AUTH_PROVIDER) {
     authStrategy = new MicrosoftEntraAuthStrategy();
     const microsoftProvider = authStrategy.setUpNextAuthProvider();
     providers.push(microsoftProvider);
+    break;
+  case "ping-id":
+    authStrategy = new PingFederateAuthStrategy();
+    const pingProvider = authStrategy.setUpNextAuthProvider();
+    providers.push(pingProvider);
     break;
   default:
     console.warn(

--- a/src/docs/deployment.mdx
+++ b/src/docs/deployment.mdx
@@ -239,7 +239,8 @@ If using PingFederate:
 3. **Configure role claims** (optional):
 
    - If your PingFederate instance provides user roles in the access token, note the claim name (default: `roles`).
-   - Expected role values: `standard`, `admin`, `super-admin`.
+   - Expected role values for interactive users: `standard`, `admin`, `super-admin`.
+   - If using API service tokens, ensure the same claim also includes `api-user` for those tokens, as Query Connector uses `PING_ROLE_CLAIM` when authorizing API requests.
 
 4. **Configure environment variables**:
 

--- a/src/docs/deployment.mdx
+++ b/src/docs/deployment.mdx
@@ -162,7 +162,7 @@ Query Connector currently supports the following identity providers:
 
 - [Keycloak](https://www.keycloak.org/)
 - [Microsoft Entra ID (formerly Active Directory)](https://www.microsoft.com/en-us/security/business/identity-access/microsoft-entra-id)
-- [(Coming soon) PingFederate](https://www.pingidentity.com/en/solutions/pingfederate.html)
+- [PingFederate](https://www.pingidentity.com/en/solutions/pingfederate.html)
 
 ### Keycloak configuration
 
@@ -221,6 +221,36 @@ If using Microsoft Entra ID:
    AUTH_ISSUER=https://login.microsoftonline.com/your-tenant-id/v2.0
    ```
 
+### PingFederate configuration
+
+If using PingFederate:
+
+1. **Create an OIDC Web App** in PingFederate:
+
+   - Navigate to your PingFederate admin console.
+   - Create a new OAuth client / OIDC Web App.
+   - Set the redirect URI to: `https://your-query-connector-url/api/auth/callback/ping-id`.
+   - Grant the following scopes: `openid`, `email`, `profile`.
+
+2. **Get client credentials**:
+
+   - Note the Client ID and Client Secret from your PingFederate client configuration.
+
+3. **Configure role claims** (optional):
+
+   - If your PingFederate instance provides user roles in the access token, note the claim name (default: `roles`).
+   - Expected role values: `standard`, `admin`, `super-admin`.
+
+4. **Configure environment variables**:
+
+   ```
+   NEXT_PUBLIC_AUTH_PROVIDER=ping-id
+   AUTH_CLIENT_ID=your-client-id
+   AUTH_CLIENT_SECRET=your-client-secret
+   AUTH_ISSUER=https://your-ping-host/as
+   PING_ROLE_CLAIM=roles  # Optional: custom claim name for roles (default: "roles")
+   ```
+
 ## FHIR server
 
 The Query Connector needs to connect to a FHIR server to fetch patient data. This server is typically provided by your data provider (like a healthcare organization) or a QHIN if connecting through TEFCA.
@@ -270,7 +300,8 @@ AUTH_SECRET="anysecretyoulike"
 
 # Keycloak - set NEXT_PUBLIC_AUTH_PROVIDER to "keycloak"
 # Entra ID - set NEXT_PUBLIC_AUTH_PROVIDER to "microsoft-entra-id" and AUTH_ISSUER to:
-# "https://login.microsoftonline.com/your-tenant-id/v2.0""
+# "https://login.microsoftonline.com/your-tenant-id/v2.0"
+# Ping Federate - set NEXT_PUBLIC_AUTH_PROVIDER to "ping-id" and AUTH_ISSUER to your PingFederate AS URL
 NEXT_PUBLIC_AUTH_PROVIDER=keycloak
 AUTH_CLIENT_ID=my-client-id
 AUTH_CLIENT_SECRET=my-client-secret


### PR DESCRIPTION
# PULL REQUEST

## Summary

  - Add PingFederateAuthStrategy implementing the existing auth strategy pattern, using next-auth's built-in ping-id OIDC provider                                          
  - Wire up ping-id as a new provider option in the auth config and API token validation
  - Support configurable role claim via PING_ROLE_CLAIM env var with graceful fallback to UserRole.STANDARD when roles aren't available                                     
  - Document PingFederate setup in deployment docs and .env.sample                                                                                                          
                                                                                                                                                                            
## Context                                                                                                                                                                   
                                                                                                                                                                            
  CDPHE uses Ping Federate as their identity provider and currently runs with AUTH_DISABLED=true. This adds first-class support so they can enable authentication against   
  their Ping Federate instance (https://pinguatdesktop.state.co.us/as).
                                                                                                                                                                            
  The implementation follows the same strategy pattern used by Keycloak and Microsoft Entra ID. Since we don't yet know exactly how CDPHE's Ping Federate will pass user    
  roles, the role resolution is flexible:
  1. Decode access token, look for roles in a configurable claim (PING_ROLE_CLAIM, default: "roles")                                                                        
  2. Fall back to profile.roles from the id_token                                                                                                                           
  3. Default to UserRole.STANDARD with a warning log
                                                                                                                                                                            
 ## Changes                                                                                                                                                                   
                                                                                                                                                                            
1. src/app/backend/auth/lib.ts — Added PingFederateAuthStrategy class that:                                                                                               
    - Extracts user info from standard OIDC profile fields (sub, preferred_username, email, given_name, family_name)                                                        
    - Looks for roles in the access token using configurable PING_ROLE_CLAIM env var (default: "roles"), falls back to profile.roles, then to UserRole.STANDARD             
    - Sets up the PingId next-auth provider with OIDC auto-discovery from AUTH_ISSUER
2. src/auth.ts — Added case "ping-id": to the provider switch statement                                                                                                   
3. src/app/api/api-auth.ts — Added ping-id case for API token validation (JWKS at ${AUTH_ISSUER}/jwks) and refactored role checking from isKeycloak boolean to explicit  provider string comparisons                                                                                                                                               
4. .env.sample — Documented the Ping Federate provider option and PING_ROLE_CLAIM env var                                                                                 
5. src/docs/deployment.mdx — Removed "(Coming soon)" label and added full PingFederate configuration section with setup steps, redirect URI, scopes, and env var          
  documentation                                           
                                                      
 ## Test plan                                                                                                                                                                 
                                                      
  - npm run lint — 0 errors (only pre-existing warnings)                                                                                                                    
  - npm run test:unit — 188 tests pass, 28 suites     
  - Set NEXT_PUBLIC_AUTH_PROVIDER=ping-id with AUTH_DISABLED=true and confirm app starts without errors                                                                     
  - Integration test against CDPHE's UAT Ping Federate instance once client credentials are provided   
