### PR TITLE
Add category skips for eRSD drift

### DIFF
--- a/docker-compose-dev.yaml
+++ b/docker-compose-dev.yaml
@@ -13,8 +13,8 @@ services:
       # Note: you must have a local .env file with the ERSD_API_KEY set to a key
       # obtained from the ERSD API at https://ersd.aimsplatform.org/#/api-keys
     volumes:
-      - ./vs_dump.sql:/docker-entrypoint-initdb.d/vs_dump.sql
-      - db-data:/var/lib/postgresql/data
+      # - ./vs_dump.sql:/docker-entrypoint-initdb.d/vs_dump.sql
+      - db-data:/var/lib/postgresql
 
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U postgres"]

--- a/src/app/backend/db-creation/lib.ts
+++ b/src/app/backend/db-creation/lib.ts
@@ -261,6 +261,10 @@ export async function insertDBStructArray(
   // Cache valueset existence checks to avoid redundant queries
   const valuesetIdCache = new Map<string, string | null>();
 
+  // Lazily-loaded set of condition IDs already present in the DB; used to
+  // skip category rows whose condition wasn't inserted (e.g. eRSD drift).
+  let conditionIdSet: Set<string> | null = null;
+
   for (const struct of structs) {
     let values: string[] = [];
 
@@ -348,14 +352,26 @@ export async function insertDBStructArray(
           (struct as ConditionToValueSetStruct).source,
         ];
         break;
-      case "category":
+      case "category": {
+        if (conditionIdSet === null) {
+          const result = await dbClient.query(`SELECT id FROM conditions`);
+          conditionIdSet = new Set(result.rows.map((r) => r.id));
+        }
+        const catStruct = struct as CategoryStruct;
+        if (!conditionIdSet.has(catStruct.conditionCode)) {
+          console.warn(
+            `Skipping category entry ${catStruct.conditionCode} (${catStruct.conditionName}): condition not present in database`,
+          );
+          continue;
+        }
         insertSql = insertCategorySql;
         values = [
-          (struct as CategoryStruct).conditionName,
-          (struct as CategoryStruct).conditionCode,
-          (struct as CategoryStruct).category,
+          catStruct.conditionName,
+          catStruct.conditionCode,
+          catStruct.category,
         ];
         break;
+      }
       case "query":
         insertSql = insertDemoQueryLogicSql;
         values = [


### PR DESCRIPTION
# PULL REQUEST

## Summary

Fixes eRSD drift for now, should investigate the categories that are skipped:

```
Batching IDs 1400 to 1500
Batching IDs 1500 to 1600
Inserting eRSD condition data
Inserting condition-to-valueset mappings
Valuesets and relationships seeded successfully. Proceeding to seed static custom data.
Seeding valuesets
Seeding concepts
Seeding valueset_to_concept
Skipping valueset_to_concept entry 11336: valueset OID 2.16.840.1.113762.1.4.1146.1407 not found in database
Skipping valueset_to_concept entry 37519: valueset OID 2.16.840.1.113762.1.4.1146.239 not found in database
Skipping valueset_to_concept entry 36821: valueset OID 2.16.840.1.113762.1.4.1146.244 not found in database
Skipping valueset_to_concept entry 37519: valueset OID 2.16.840.1.113762.1.4.1146.239 not found in database
Skipping valueset_to_concept entry 4589: valueset OID 2.16.840.1.113762.1.4.1146.395 not found in database
Seeding conditions
Seeding condition_to_valueset
Seeding query
Seeding category
Skipping category entry 363346000 (Cancer): condition not present in database
Skipping category entry 266113007 (Genital Warts): condition not present in database
Skipping category entry 82271004 (Head Injury): condition not present in database
Skipping category entry 38959009 (Methemoglobinemia): condition not present in database
Skipping category entry 407153006 (Motor Vehicle Injury): condition not present in database
Seeding static files completed successfully.
Executing category data updates on inserted conditions
All inserted queries cross-referenced with category data
DB successfully seeded
```