### PR TITLE
Add Azure Database for PostgreSQL SSL support

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -5,10 +5,13 @@ DATABASE_URL=postgresql://postgres@localhost:5432/tefca_db
 # When set, overrides the password in DATABASE_URL dynamically.
 # DB_SECRET_ARN=arn:aws:secretsmanager:us-east-1:123456789:secret:rds!db-xxx
 
-# (Optional) Path to RDS CA certificate bundle for SSL database connections.
+# (Optional) Path to a CA certificate bundle (e.g., AWS RDS or Azure Database
+# for PostgreSQL) for SSL database connections.
 # When set, enables SSL with certificate verification for both Node.js and Flyway.
-# In Docker, the RDS global bundle is at /app/certs/rds-global-bundle.pem
+# In Docker, the AWS RDS global bundle is at /app/certs/rds-global-bundle.pem
 # DB_SSL_CA_PATH=/app/certs/rds-global-bundle.pem
+# In Docker, the Azure Database for PostgreSQL bundle is at /app/certs/azure-postgres-bundle.pem
+# DB_SSL_CA_PATH=/app/certs/azure-postgres-bundle.pem
 
 # Authentication settings
 AUTH_DISABLED=false

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,9 +16,9 @@ RUN curl --fail --show-error -L https://truststore.pki.rds.amazonaws.com/global/
 # DigiCert Global Root G2, Microsoft RSA Root CA 2017) and concatenate to one PEM.
 RUN mkdir -p /tmp/azure-certs \
     && curl --fail --show-error -L -o /tmp/azure-certs/digicert-global-root.pem \
-         https://dl.cacerts.digicert.com/DigiCertGlobalRootCA.crt.pem \
+         https://cacerts.digicert.com/DigiCertGlobalRootCA.crt.pem \
     && curl --fail --show-error -L -o /tmp/azure-certs/digicert-global-root-g2.pem \
-         https://dl.cacerts.digicert.com/DigiCertGlobalRootG2.crt.pem \
+         https://cacerts.digicert.com/DigiCertGlobalRootG2.crt.pem \
     && curl --fail --show-error -L -o /tmp/azure-certs/ms-rsa-root-2017.der \
          "https://www.microsoft.com/pkiops/certs/Microsoft%20RSA%20Root%20Certificate%20Authority%202017.crt" \
     && openssl x509 -inform DER -in /tmp/azure-certs/ms-rsa-root-2017.der \

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM node:24-alpine AS base
 FROM base AS installer
 
 RUN apk update && apk upgrade
-RUN apk add --no-cache libc6-compat bash curl
+RUN apk add --no-cache libc6-compat bash curl openssl
 
 WORKDIR /app
 COPY . .
@@ -11,6 +11,23 @@ COPY . .
 # Download AWS RDS global CA bundle for SSL database connections
 RUN curl --fail --show-error -L https://truststore.pki.rds.amazonaws.com/global/global-bundle.pem \
     -o /rds-global-bundle.pem
+
+# Download Azure Database for PostgreSQL CA bundle (DigiCert Global Root CA,
+# DigiCert Global Root G2, Microsoft RSA Root CA 2017) and concatenate to one PEM.
+RUN mkdir -p /tmp/azure-certs \
+    && curl --fail --show-error -L -o /tmp/azure-certs/digicert-global-root.pem \
+         https://dl.cacerts.digicert.com/DigiCertGlobalRootCA.crt.pem \
+    && curl --fail --show-error -L -o /tmp/azure-certs/digicert-global-root-g2.pem \
+         https://dl.cacerts.digicert.com/DigiCertGlobalRootG2.crt.pem \
+    && curl --fail --show-error -L -o /tmp/azure-certs/ms-rsa-root-2017.der \
+         "https://www.microsoft.com/pkiops/certs/Microsoft%20RSA%20Root%20Certificate%20Authority%202017.crt" \
+    && openssl x509 -inform DER -in /tmp/azure-certs/ms-rsa-root-2017.der \
+         -outform PEM -out /tmp/azure-certs/ms-rsa-root-2017.pem \
+    && cat /tmp/azure-certs/digicert-global-root.pem \
+           /tmp/azure-certs/digicert-global-root-g2.pem \
+           /tmp/azure-certs/ms-rsa-root-2017.pem \
+         > /azure-postgres-bundle.pem \
+    && rm -rf /tmp/azure-certs
 
 # Install Flyway and remove JRE directory to force flyway to use the openjdk11 version in the runner
 ENV FLYWAY_VERSION=10.19.0
@@ -39,6 +56,8 @@ WORKDIR /app
 RUN apk update && apk upgrade && apk add --no-cache bash openjdk17-jre
 # Copy RDS CA bundle for SSL database connections
 COPY --from=installer /rds-global-bundle.pem /app/certs/rds-global-bundle.pem
+# Copy Azure PostgreSQL CA bundle for SSL database connections
+COPY --from=installer /azure-postgres-bundle.pem /app/certs/azure-postgres-bundle.pem
 # Copy Flyway from the installer stage
 COPY --from=installer /flyway /flyway
 RUN chmod +x /flyway/flyway


### PR DESCRIPTION
## Summary

Mirrors the AWS RDS SSL pattern from #896 for deployments backed by Azure Database for PostgreSQL Flexible Server.

- Downloads the three Microsoft-recommended root CAs (DigiCert Global Root CA, DigiCert Global Root G2, Microsoft RSA Root CA 2017) during the Docker build and concatenates them into a single PEM at `/app/certs/azure-postgres-bundle.pem`.
- Adds `openssl` to the installer stage (needed to convert the Microsoft RSA root from DER to PEM).
- Updates `.env.sample` to document both CA bundle paths and clarify that `DB_SSL_CA_PATH` is provider-agnostic.

No application code changes are needed: `buildSslConfig()` (`src/app/backend/db/config.ts`) and `start.sh` already accept any PEM bundle and configure both the pg pool and Flyway migrations accordingly.

## Test plan

- [x] Existing `buildSslConfig` unit tests still pass (`npm run test:unit -- db-config`)
- [x] Local Docker build succeeds and downloads all three Azure root CAs
- [ ] Verify `/app/certs/azure-postgres-bundle.pem` exists in built image (`docker run --rm <image> ls -la /app/certs/`)
- [ ] Verify the bundle parses (`docker run --rm <image> bash -c "openssl x509 -in /app/certs/azure-postgres-bundle.pem -noout -subject"`)
- [ ] End-to-end: connect a container to a test Azure Flexible Server with `require_secure_transport = ON` and `DB_SSL_CA_PATH` set; confirm both Flyway migrations and Next.js queries succeed
- [ ] Regression: AWS RDS path (`/app/certs/rds-global-bundle.pem`) is still present in the image