### PR TITLE
fix(ci): make aidbox-seeder reliable and surface failures

### DIFF
--- a/docker-compose-e2e.yaml
+++ b/docker-compose-e2e.yaml
@@ -66,6 +66,16 @@ services:
       PGPASSWORD: gOxAmiyiz4
       PGPORT: "5432"
       BOX_SEARCH_INCLUDE_CONFORMANT: true
+    healthcheck:
+      test:
+        [
+          "CMD-SHELL",
+          'wget -qO- http://localhost:8080/health | grep -q ''"status":"pass"'' || exit 1',
+        ]
+      interval: 5s
+      timeout: 5s
+      retries: 60
+      start_period: 30s
 
   aidbox-seeder:
     build:
@@ -80,7 +90,7 @@ services:
       db:
         condition: service_healthy
       aidbox:
-        condition: service_started
+        condition: service_healthy
       flyway:
         condition: service_completed_successfully
 

--- a/docker-compose-integration.yaml
+++ b/docker-compose-integration.yaml
@@ -69,6 +69,17 @@ services:
       PGPASSWORD: gOxAmiyiz4
       PGPORT: "5432"
       BOX_SEARCH_INCLUDE_CONFORMANT: true
+    healthcheck:
+      test:
+        [
+          "CMD-SHELL",
+          'wget -qO- http://localhost:8080/health | grep -q ''"status":"pass"'' || exit 1',
+        ]
+      interval: 5s
+      timeout: 5s
+      retries: 60
+      start_period: 30s
+
   aidbox-seeder:
     build:
       context: .
@@ -83,7 +94,7 @@ services:
       db:
         condition: service_healthy
       aidbox:
-        condition: service_started
+        condition: service_healthy
       flyway:
         condition: service_completed_successfully
 

--- a/setup-scripts/e2e_tests.sh
+++ b/setup-scripts/e2e_tests.sh
@@ -1,6 +1,19 @@
 #!/bin/bash
 set -e  # Exit immediately if a command exits with a non-zero status. Comment this if debugging in CI
 
+# Surface compose logs on any startup failure so CI shows the real cause
+# (otherwise we only get `service "X" didn't complete successfully: exit 1`).
+dump_logs_on_failure() {
+  local code=$?
+  if [ $code -ne 0 ]; then
+    echo "=== docker compose logs (failure dump) ==="
+    docker compose -f docker-compose-e2e.yaml logs --no-color || true
+    echo "=== end docker compose logs ==="
+  fi
+  return $code
+}
+trap dump_logs_on_failure ERR
+
 chmod +x ./setup-scripts/setup_e2e.sh
 bash ./setup-scripts/setup_e2e.sh
 
@@ -9,7 +22,7 @@ echo "APP_HOSTNAME=http://query-connector:3000" >> .env.e2e
 echo "NEXT_PUBLIC_AUTH_PROVIDER=keycloak" >> .env.e2e
 
 docker compose down --volumes --remove-orphans
-docker compose -f docker-compose-e2e.yaml --env-file .env.e2e up -d --build 
+docker compose -f docker-compose-e2e.yaml --env-file .env.e2e up -d --build
 
 # uncomment these and the corresponding block in ci.yaml to get logs in CI. Make sure also to comment the set -e command at the top of this file too!
 # mkdir test-results

--- a/setup-scripts/seed_aidbox.sh
+++ b/setup-scripts/seed_aidbox.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -o pipefail
 
 # Environment variables set by docker-compose
 BASE_URL=$1
@@ -11,31 +12,36 @@ DB_USERNAME="postgres"
 DB_PASSWORD="pw"
 DB_NAME="tefca_db"
 
-# Wait for Aidbox to be healthy
-echo "Waiting for Aidbox to become healthy..."
-max_retries=15
+# All curl invocations time-bound: --max-time caps each request so the seeder
+# can never hang silently in CI when aidbox is slow to respond.
+CURL_OPTS=(--silent --show-error --location --max-time 30)
+
+# Compose already gates this service on `aidbox: service_healthy`, so by the
+# time we run, /health should already be passing. The retry loop below is a
+# belt-and-suspenders safety net for cases where the healthcheck and the
+# seeder race (e.g. aidbox flapping immediately after first /health success).
+echo "Verifying Aidbox is healthy..."
+max_retries=30
 attempt=0
-while [ $attempt -le $max_retries ]; do
-  health_status=$(curl -v -L -o /dev/null -w "%{http_code}" ${NETWORK_URL}/health || echo "000")
+while [ $attempt -lt $max_retries ]; do
+  health_status=$(curl "${CURL_OPTS[@]}" -o /dev/null -w "%{http_code}" "${NETWORK_URL}/health" || echo "000")
   if [[ "$health_status" -ge 200 && "$health_status" -lt 300 ]]; then
     echo "Aidbox is healthy!"
     break
-  else
-    echo "Waiting for Aidbox health check to pass (status: $health_status)... Attempt $attempt/$max_retries"
-
-    if [ $attempt -eq $max_retries ]; then
-      echo "Maximum retry attempts reached. Exiting."
-      exit 1
-    fi
-
-    attempt=$((attempt + 1))
-    sleep 10
   fi
+  attempt=$((attempt + 1))
+  echo "Aidbox not ready yet (status: $health_status); attempt $attempt/$max_retries"
+  if [ $attempt -eq $max_retries ]; then
+    echo "Aidbox never became healthy. Dumping last response for debugging:"
+    curl "${CURL_OPTS[@]}" -v "${NETWORK_URL}/health" || true
+    exit 1
+  fi
+  sleep 5
 done
 
 # Get the access token
 echo "Getting access token..."
-TOKEN_RESPONSE=$(curl -L -X POST \
+TOKEN_RESPONSE=$(curl "${CURL_OPTS[@]}" -X POST \
   -H "Content-Type: application/json" \
   -d '{
     "client_id": "root",
@@ -57,7 +63,7 @@ echo "Access token obtained."
 
 # Post the GoldenSickPatient data to Aidbox
 echo "Loading GoldenSickPatient data into Aidbox..."
-curl -L -X POST \
+curl "${CURL_OPTS[@]}" -X POST \
   -H "Content-Type: application/json" \
   -H "Authorization: Bearer ${TOKEN}" \
   -d @"/data/GoldenSickPatient.json" \
@@ -67,7 +73,7 @@ echo "GoldenSickPatient data loaded successfully."
 
 # Client information for the SMART on FHIR test
 echo "Loading client information into Aidbox..."
-curl -L -X PUT \
+curl "${CURL_OPTS[@]}" -X PUT \
   -H "Content-Type: application/json" \
   -H "Authorization: Bearer ${TOKEN}" \
   -d '{
@@ -96,7 +102,7 @@ echo "Client information data loaded successfully."
 
 # Access policy information for the SMART on FHIR test
 echo "Loading access policy information into Aidbox.."
-curl -L -X PUT \
+curl "${CURL_OPTS[@]}" -X PUT \
   -H "Content-Type: application/json" \
   -H "Authorization: Bearer ${TOKEN}" \
   -d '{

--- a/setup-scripts/unit_and_integration_tests.sh
+++ b/setup-scripts/unit_and_integration_tests.sh
@@ -1,6 +1,21 @@
 #!/bin/bash
 
 set -e # Exit immediately if a command exits with a non-zero status. Comment this if debugging in CI
+
+# On any error before tests run (most commonly: aidbox-seeder failing to come up),
+# dump compose logs so the actual failure is visible in CI output instead of just
+# the cryptic `service "aidbox-seeder" didn't complete successfully: exit 1`.
+dump_logs_on_failure() {
+  local code=$?
+  if [ $code -ne 0 ]; then
+    echo "=== docker compose logs (failure dump) ==="
+    docker compose -f docker-compose-integration.yaml logs --no-color || true
+    echo "=== end docker compose logs ==="
+  fi
+  return $code
+}
+trap dump_logs_on_failure ERR
+
 docker compose down --volumes --remove-orphans
 docker compose -f docker-compose-integration.yaml up -d
 


### PR DESCRIPTION
## Summary

CI's been red on every PR (and on \`main\` since 2026-05-13) because the
\`aidbox-seeder\` container exits with code 1 during \`docker compose up\`, blocking the required \`unit-and-integration-tests\` and \`end-to-end-tests\` checks. The only message that reaches the CI log is the unhelpful \`service \"aidbox-seeder\" didn't complete successfully: exit 1\` — the actual error is hidden because the setup scripts dump seeder logs only *after* compose-up succeeds.

### Why it's failing

The most likely root cause is timing-driven flakiness:

1. \`aidbox-seeder.depends_on.aidbox.condition: service_started\` returns the moment the Aidbox container starts, well before the JVM has finished booting and \`/health\` returns \`pass\`.
2. The seeder's own retry budget is 15 × 10s = 150s. Aidbox JVM startup on GitHub-hosted runners routinely takes 30–60s under load, and any flap (e.g. license verification round-trip to \`aidbox.app\`) eats into that budget.
3. \`curl\` calls inside the seeder have no \`--max-time\`, so a single slow response can hang for minutes and silently consume the entire budget without logging a clear timeout.

I couldn't capture the exact CI error because the seeder's logs are never surfaced — addressing that observability gap is part of this PR.

### Changes

**docker-compose-integration.yaml / docker-compose-e2e.yaml**
- Add a real healthcheck on the \`aidbox\` service: \`wget /health | grep '\"status\":\"pass\"'\`, \`start_period: 30s\`, \`interval: 5s\`, \`retries: 60\` — gives aidbox up to ~5 minutes to warm up on slow runners while still going green quickly on fast ones.
- Change \`aidbox-seeder.depends_on.aidbox.condition\` from \`service_started\` to \`service_healthy\` so the seeder only runs when aidbox is actually serving traffic.

**setup-scripts/seed_aidbox.sh**
- Bound every \`curl\` with \`--max-time 30\` via a shared \`CURL_OPTS\` array — no request can hang the script.
- Keep the seeder's own health-retry loop as belt-and-suspenders (now 30 × 5s), and dump a verbose \`curl -v /health\` on final failure so the next regression is debuggable.

**setup-scripts/unit_and_integration_tests.sh / e2e_tests.sh**
- Add \`trap dump_logs_on_failure ERR\` so any startup failure prints the full \`docker compose logs\` to the CI output. This is exactly the comment-bait debug pattern the existing scripts hint at, but always-on for the failure case.

### Test plan
- [x] \`bash -n\` parses cleanly on all three shell scripts
- [x] \`docker compose -f docker-compose-integration.yaml up aidbox-seeder\` succeeds locally; container exits 0; \"Finished configuring Aidbox and database.\" reached; \`INSERT 0 1\` into \`fhir_servers\` committed
- [x] Aidbox container reaches \"Healthy\" status before seeder starts (verified via \`docker ps\`)
- [ ] CI: \`unit-and-integration-tests\` job goes green on this PR
- [ ] CI: \`end-to-end-tests\` job goes green on this PR

### Follow-up (not in this PR)

The Dependabot PRs are *separately* affected because Dependabot doesn't see repo secrets — \`AIDBOX_LICENSE\` lands empty in those runs, so aidbox almost certainly fails the new healthcheck too. The proper fix is to add \`AIDBOX_LICENSE\` to **Dependabot secrets** in repo settings (different secret store from regular Actions secrets). That requires admin access and is out of scope here.