### PR TITLE
Add docker-compose config for full in-Docker stack

### DIFF
--- a/docker-compose.complete.yaml
+++ b/docker-compose.complete.yaml
@@ -1,0 +1,75 @@
+# Full stack in Docker: Keycloak, Aidbox, and query-connector.
+#
+# Prerequisites:
+#   cp .env.sample .env
+#   Set ERSD_API_KEY, UMLS_API_KEY, AIDBOX_LICENSE, and AUTH_DISABLED=false in .env
+#
+# Start:
+#   docker compose -f docker-compose.complete.yaml up -d --build
+#
+# Equivalent (without include):
+#   docker compose -f docker-compose-dev.yaml -f docker-compose.complete.yaml up -d --build
+#
+# Reset DB so vs_dump.sql runs on first init:
+#   docker compose -f docker-compose.complete.yaml down -v
+#
+# Wait for seeding:
+#   docker compose -f docker-compose.complete.yaml logs -f aidbox-seeder
+#   # until: "Finished configuring Aidbox and database."
+
+include:
+  - docker-compose-dev.yaml
+
+services:
+  db:
+    volumes:
+      - ./vs_dump.sql:/docker-entrypoint-initdb.d/vs_dump.sql
+      - db-data:/var/lib/postgresql
+
+  aidbox:
+    healthcheck:
+      test:
+        [
+          "CMD-SHELL",
+          'wget -qO- http://localhost:8080/health | grep -q ''"status":"pass"'' || exit 1',
+        ]
+      interval: 5s
+      timeout: 5s
+      retries: 60
+      start_period: 30s
+
+  aidbox-seeder:
+    environment:
+      - AIDBOX_BASE_URL=http://aidbox:8080
+      - APP_HOSTNAME=http://query-connector:3000
+    depends_on:
+      db:
+        condition: service_healthy
+      aidbox:
+        condition: service_healthy
+      flyway:
+        condition: service_completed_successfully
+
+  query-connector:
+    extends:
+      file: docker-compose-e2e.yaml
+      service: query-connector
+    env_file: !override
+      - .env
+    environment:
+      - NODE_ENV=production
+      - DATABASE_URL=postgres://postgres:pw@db:5432/tefca_db
+      - AUTH_URL=http://localhost:3000
+      - AUTH_DISABLED=false
+      - LOCAL_KEYCLOAK=http://localhost:8081/realms/master
+      - AUTH_ISSUER=http://localhost:8081/realms/master
+      - NAMED_KEYCLOAK=http://keycloak:8080/realms/master
+    volumes:
+      - ./keys:/app/keys
+    depends_on:
+      db:
+        condition: service_healthy
+      keycloak:
+        condition: service_started
+      aidbox-seeder:
+        condition: service_completed_successfully

--- a/src/docs/development.mdx
+++ b/src/docs/development.mdx
@@ -61,7 +61,25 @@ Username: qc-admin
 Password: QcDev2024!
 ```
 
-#### Running with Docker only
+#### Running the full stack in Docker
+
+The [docker-compose.complete.yaml](../../docker-compose.complete.yaml) file runs Keycloak, Aidbox, PostgreSQL, Flyway, and the Query Connector app entirely in containers. It reuses [docker-compose-dev.yaml](../../docker-compose-dev.yaml) for backends and layers app wiring from the e2e compose file.
+
+1. Complete the [Obtaining API and License Keys](#obtaining-api-and-license-keys) steps and create `.env` from `.env.sample` with `AUTH_DISABLED=false`.
+2. Start the stack: `docker compose -f docker-compose.complete.yaml up -d --build`
+3. Wait for Aidbox seeding: `docker compose -f docker-compose.complete.yaml logs -f aidbox-seeder` until you see `Finished configuring Aidbox and database.`
+4. Open the app at `http://localhost:3000`. Aidbox is at `http://localhost:8080`; Keycloak is at `http://localhost:8081`.
+
+| Service | Host port |
+|---------|-----------|
+| query-connector | 3000 |
+| Aidbox | 8080 |
+| Keycloak | 8081 |
+| PostgreSQL | 5432 |
+
+On first run, the database is pre-seeded from `vs_dump.sql`. To reload that dump on a fresh database, remove volumes first: `docker compose -f docker-compose.complete.yaml down -v`.
+
+#### Running with Docker only (app image + dev backends)
 
 1. Download a copy of the Docker image from the Query Connector repository by running `docker pull ghcr.io/cdcgov/dibbs-query-connector/query-connector:latest`.
    1. If you're using an M1 Mac, you'll need to tell Docker to pull the non-Apple Silicon image using `docker pull --platform linux/amd64 ghcr.io/cdcgov/dibbs-query-connector/query-connector:latest` since we don't have a image for Apple Silicon. If you're using this setup, there might be some issues with architecture incompatability that the team hasn't run into, so please flag if you run into something!


### PR DESCRIPTION
Compose file includes dev backends and extends the e2e app service so Keycloak, Aidbox, and query-connector run together without duplicating service definitions. Document startup steps in development.mdx.
