### PR TITLE
chore(deps): remove unused @types/uuid and defer jose/bundle-analyzer majors

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,11 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    ignore:
+      - dependency-name: "jose"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "@next/bundle-analyzer"
+        update-types: ["version-update:semver-major"]
 
   - package-ecosystem: "docker"
     directory: "/"

--- a/package-lock.json
+++ b/package-lock.json
@@ -59,7 +59,6 @@
         "@types/react": "19.1.6",
         "@types/react-dom": "19.1.9",
         "@types/react-highlight-words": "^0.20.1",
-        "@types/uuid": "^9.0.8",
         "@typescript-eslint/eslint-plugin": "^8.35.0",
         "@typescript-eslint/parser": "^8.35.0",
         "dotenv": "^17.2.1",
@@ -3237,6 +3236,7 @@
       "version": "2.5.1",
       "resolved": "https://registry.npmjs.org/@parcel/watcher/-/watcher-2.5.1.tgz",
       "integrity": "sha512-dfUnCxiN9H4ap84DvD2ubjw+3vUNpstxa0TneY/Paat8a3R4uQZDLSvWjmznAY/DoahqTHl9V46HF/Zs3F29pg==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -3276,6 +3276,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3296,6 +3297,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3316,6 +3318,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3336,6 +3339,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3356,6 +3360,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3376,6 +3381,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3396,6 +3402,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3416,6 +3423,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3436,6 +3444,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3456,6 +3465,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3476,6 +3486,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3496,6 +3507,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3516,6 +3528,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4825,13 +4838,6 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
       "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
-      "license": "MIT"
-    },
-    "node_modules/@types/uuid": {
-      "version": "9.0.8",
-      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-9.0.8.tgz",
-      "integrity": "sha512-jg+97EGIcY9AGHJJRaaPVgetKDsrTgbRjQ5Msgjh/DQKEFl0DtyRr/VCOyD1T2R1MNeWPK/u7JoGhlDZnKBAfA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/yargs": {
@@ -7352,6 +7358,7 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
       "integrity": "sha512-pGjwhsmsp4kL2RTz08wcOlGN83otlqHeD/Z5T8GXZB+/YcpQ/dgo+lbU8ZsGxV0HIvqqxo9l7mqYwyYMD9bKDg==",
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "bin": {
@@ -12944,6 +12951,7 @@
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz",
       "integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==",
+      "dev": true,
       "license": "MIT",
       "optional": true
     },
@@ -13693,6 +13701,7 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,

--- a/package.json
+++ b/package.json
@@ -77,7 +77,6 @@
     "@types/react": "19.1.6",
     "@types/react-dom": "19.1.9",
     "@types/react-highlight-words": "^0.20.1",
-    "@types/uuid": "^9.0.8",
     "@typescript-eslint/eslint-plugin": "^8.35.0",
     "@typescript-eslint/parser": "^8.35.0",
     "dotenv": "^17.2.1",


### PR DESCRIPTION
## Summary

Triage of the remaining open Dependabot PRs. Closes 3 of them in one shot:

- **Closes #942** — Removes `@types/uuid` from devDependencies. The runtime `uuid` package is not in the dependency tree; all UUID generation uses Node's built-in `crypto.randomUUID()` (8 call sites across `src/`, `setup-scripts/`, and tests). The types are orphaned. Same cleanup pattern as #937.
- **Closes #940** — Adds a Dependabot `ignore` rule for `jose` major bumps. `jose` is used in 5 files for NextAuth, SMART-on-FHIR client assertion signing, and FHIR API token verification. The v5→v6 jump is forward-compatible with our symbol usage (no `KeyLike` or `zip`), but it warrants a dedicated PR with focused auth testing, not a Dependabot drive-by.
- **Closes #941** — Adds a Dependabot `ignore` rule for `@next/bundle-analyzer` major bumps. Must stay aligned with `next`, which is pinned at 15.x (Next 16 deferred per #937).

The two safe Dependabot PRs (#939 fhirpath minor, #943 @types/fhir patch) have been triggered to rebase and will be merged separately once CI goes green.

## Test plan

- [x] `grep -rE "@types/uuid|from ['\"]uuid['\"]|require\(['\"]uuid['\"]\)" src/ e2e/ setup-scripts/` — empty
- [x] `npm install` — clean lockfile regen
- [x] `npm run lint` — 0 errors (6 pre-existing warnings)
- [x] `npm run build` — passes
- [x] `npm run test:unit` — 28 suites, 196 tests passing
- [ ] CI: unit-and-integration-tests + end-to-end-tests green