### PR TITLE
Query MedicationStatement and show it in a Medications section

### DIFF
--- a/e2e/query_editing.spec.ts
+++ b/e2e/query_editing.spec.ts
@@ -441,7 +441,7 @@ async function checkForCancerMedication(
 
   if (medicationShouldExist) {
     await expect(
-      page.getByRole("button", { name: "Medication Requests", expanded: true }),
+      page.getByRole("button", { name: "Medications", expanded: true }),
     ).toBeVisible();
 
     await expect(
@@ -452,7 +452,7 @@ async function checkForCancerMedication(
     ).toHaveCount(1);
   } else {
     await expect(
-      page.getByRole("button", { name: "Medication Requests", expanded: true }),
+      page.getByRole("button", { name: "Medications", expanded: true }),
     ).not.toBeVisible();
   }
 }

--- a/e2e/query_execution.spec.ts
+++ b/e2e/query_execution.spec.ts
@@ -122,7 +122,7 @@ test.describe("querying with the Query Connector", () => {
       page.getByRole("button", { name: "Observations", expanded: true }),
     ).toBeVisible();
     await expect(
-      page.getByRole("button", { name: "Medication Requests", expanded: true }),
+      page.getByRole("button", { name: "Medications", expanded: true }),
     ).toBeVisible();
 
     // We can also just directly ask the page to find us the number of rows

--- a/src/app/(pages)/query/components/ResultsView.tsx
+++ b/src/app/(pages)/query/components/ResultsView.tsx
@@ -203,7 +203,11 @@ function mapQueryResponseToAccordionDataStructure(
           <>
             {medicationRequests && (
               <>
-                <h4 className={styles.accordionHeading}>Medication Requests</h4>
+                <h4
+                  className={`${styles.accordionHeading} ${styles.subTableHeading}`}
+                >
+                  Medication Requests
+                </h4>
                 <MedicationRequestTable
                   medicationRequests={medicationRequests}
                 />
@@ -211,7 +215,9 @@ function mapQueryResponseToAccordionDataStructure(
             )}
             {medicationStatements && (
               <>
-                <h4 className={styles.accordionHeading}>
+                <h4
+                  className={`${styles.accordionHeading} ${styles.subTableHeading}`}
+                >
                   Medication Statements
                 </h4>
                 <MedicationStatementTable

--- a/src/app/(pages)/query/components/ResultsView.tsx
+++ b/src/app/(pages)/query/components/ResultsView.tsx
@@ -11,6 +11,7 @@ import Demographics from "./resultsView/tableComponents/Demographics";
 import DiagnosticReportTable from "./resultsView/tableComponents/DiagnosticReportTable";
 import EncounterTable from "./resultsView/tableComponents/EncounterTable";
 import MedicationRequestTable from "./resultsView/tableComponents/MedicationRequestTable";
+import MedicationStatementTable from "./resultsView/tableComponents/MedicationStatementTable";
 import ObservationTable from "./resultsView/tableComponents/ObservationTable";
 import Backlink from "../../../ui/designSystem/backLink/Backlink";
 import { RETURN_LABEL } from "@/app/(pages)/query/components/stepIndicator/StepIndicator";
@@ -156,6 +157,9 @@ function mapQueryResponseToAccordionDataStructure(
   const medicationRequests = resultsQueryResponse.MedicationRequest
     ? resultsQueryResponse.MedicationRequest
     : null;
+  const medicationStatements = resultsQueryResponse.MedicationStatement
+    ? resultsQueryResponse.MedicationStatement
+    : null;
   const immunizations = resultsQueryResponse.Immunization
     ? resultsQueryResponse.Immunization
     : null;
@@ -193,10 +197,30 @@ function mapQueryResponseToAccordionDataStructure(
       ) : null,
     },
     {
-      title: "Medication Requests",
-      content: medicationRequests ? (
-        <MedicationRequestTable medicationRequests={medicationRequests} />
-      ) : null,
+      title: "Medications",
+      content:
+        medicationRequests || medicationStatements ? (
+          <>
+            {medicationRequests && (
+              <>
+                <h4 className={styles.accordionHeading}>Medication Requests</h4>
+                <MedicationRequestTable
+                  medicationRequests={medicationRequests}
+                />
+              </>
+            )}
+            {medicationStatements && (
+              <>
+                <h4 className={styles.accordionHeading}>
+                  Medication Statements
+                </h4>
+                <MedicationStatementTable
+                  medicationStatements={medicationStatements}
+                />
+              </>
+            )}
+          </>
+        ) : null,
     },
     {
       title: "Immunizations",

--- a/src/app/(pages)/query/components/resultsView/resultsView.module.scss
+++ b/src/app/(pages)/query/components/resultsView/resultsView.module.scss
@@ -22,6 +22,13 @@
   h4[id="demographics"] {
     margin: 1.25rem;
   }
+
+  // Sub-table headings (e.g. "Medication Requests" / "Medication Statements")
+  // are nested inside the accordion body, so give them the same breathing room
+  // as the standalone "Demographics" heading above.
+  .subTableHeading {
+    margin: 1.25rem;
+  }
 }
 
 .accordionWrapper {

--- a/src/app/(pages)/query/components/resultsView/tableComponents/MedicationStatementTable.tsx
+++ b/src/app/(pages)/query/components/resultsView/tableComponents/MedicationStatementTable.tsx
@@ -1,0 +1,75 @@
+import React from "react";
+import Table from "@/app/ui/designSystem/table/Table";
+import { MedicationStatement } from "fhir/r4";
+import {
+  formatCodeableConcept,
+  formatDate,
+} from "../../../../../utils/format-service";
+import styles from "./resultsTables.module.scss";
+import { checkIfSomeElementWithPropertyExists } from "./utils";
+import classNames from "classnames";
+
+/**
+ * The props for the MedicationStatementTable component.
+ */
+export interface MedicationStatementTableProps {
+  medicationStatements: MedicationStatement[];
+}
+
+/**
+ * Displays a table of data from array of MedicationStatement resources.
+ * @param props - MedicationStatement table props.
+ * @param props.medicationStatements - The array of MedicationStatement resources.
+ * @returns - The MedicationStatementTable component.
+ */
+const MedicationStatementTable: React.FC<MedicationStatementTableProps> = ({
+  medicationStatements,
+}) => {
+  const availableElements = checkIfSomeElementWithPropertyExists(
+    medicationStatements,
+    ["reasonCode"],
+  );
+
+  return (
+    <Table
+      contained={false}
+      className={classNames(
+        availableElements.reasonCode && styles.medicationsFixedTable,
+      )}
+    >
+      <thead>
+        <tr>
+          <th>Effective Date</th>
+          <th>Medication</th>
+          {availableElements.reasonCode && <th>Reason Code</th>}
+          <th>Status</th>
+        </tr>
+      </thead>
+      <tbody>
+        {medicationStatements.map((medicationStatement) => (
+          <tr key={medicationStatement.id}>
+            <td>
+              {formatDate(
+                medicationStatement.effectiveDateTime ??
+                  medicationStatement.effectivePeriod?.start,
+              )}
+            </td>
+            <td>
+              {formatCodeableConcept(
+                medicationStatement.medicationCodeableConcept,
+              )}
+            </td>
+            {availableElements.reasonCode && (
+              <td>
+                {formatCodeableConcept(medicationStatement?.reasonCode?.[0])}
+              </td>
+            )}
+            <td>{medicationStatement.status}</td>
+          </tr>
+        ))}
+      </tbody>
+    </Table>
+  );
+};
+
+export default MedicationStatementTable;

--- a/src/app/backend/query-execution/custom-query.test.ts
+++ b/src/app/backend/query-execution/custom-query.test.ts
@@ -1,0 +1,93 @@
+import { CustomQuery } from "./custom-query";
+import {
+  EMPTY_MEDICAL_RECORD_SECTIONS,
+  QueryDataColumn,
+  QueryTableResult,
+} from "../../(pages)/queryBuilding/utils";
+import { DibbsValueSet } from "@/app/models/entities/valuesets";
+
+const PATIENT_ID = "patient-123";
+const RXNORM_CODE = "1665005";
+
+function buildMedicationQuery(
+  timeboxWindows?: QueryTableResult["timeboxWindows"],
+): CustomQuery {
+  const medicationValueSet: DibbsValueSet = {
+    valueSetId: "vs-meds",
+    valueSetVersion: "1",
+    valueSetName: "Test Medications",
+    author: "test",
+    system: "http://www.nlm.nih.gov/research/umls/rxnorm",
+    dibbsConceptType: "medications",
+    includeValueSet: true,
+    concepts: [
+      {
+        code: RXNORM_CODE,
+        display: "ceftriaxone 500 MG Injection",
+        include: true,
+      },
+    ],
+    userCreated: false,
+  };
+
+  const queryData: QueryDataColumn = {
+    "condition-1": { "vs-meds": medicationValueSet },
+  };
+
+  const savedQuery: QueryTableResult = {
+    queryName: "Test Medication Query",
+    queryId: "query-1",
+    queryData,
+    conditionsList: [],
+    medicalRecordSections: EMPTY_MEDICAL_RECORD_SECTIONS,
+    timeboxWindows,
+  };
+
+  return new CustomQuery(savedQuery, PATIENT_ID);
+}
+
+describe("CustomQuery medication queries", () => {
+  it("builds a MedicationStatement query alongside MedicationRequest", () => {
+    const customQuery = buildMedicationQuery();
+
+    const statement = customQuery.getQuery("medicationStatement");
+    expect(statement.basePath).toBe("/MedicationStatement/_search");
+    expect(statement.params.get("subject")).toBe(`Patient/${PATIENT_ID}`);
+    expect(statement.params.get("code")).toBe(RXNORM_CODE);
+    expect(statement.params.get("_include")).toBe(
+      "MedicationStatement:medication",
+    );
+
+    // The existing MedicationRequest query should still be present
+    const request = customQuery.getQuery("medicationRequest");
+    expect(request.basePath).toBe("/MedicationRequest/_search");
+  });
+
+  it("applies the medication time filter to MedicationStatement via the effective param", () => {
+    const customQuery = buildMedicationQuery({
+      medications: {
+        timeWindowStart: "2024-01-01T00:00:00Z",
+        timeWindowEnd: "2024-12-31T00:00:00Z",
+      },
+    });
+
+    const statement = customQuery.getQuery("medicationStatement");
+    expect(statement.params.getAll("effective")).toEqual([
+      "ge2024-01-01",
+      "le2024-12-31",
+    ]);
+  });
+
+  it("does not build a MedicationStatement query when no medication codes are present", () => {
+    const savedQuery: QueryTableResult = {
+      queryName: "Empty Query",
+      queryId: "query-empty",
+      queryData: {},
+      conditionsList: [],
+      medicalRecordSections: EMPTY_MEDICAL_RECORD_SECTIONS,
+    };
+
+    const customQuery = new CustomQuery(savedQuery, PATIENT_ID);
+    expect(customQuery.getQuery("medicationStatement").basePath).toBe("");
+  });
+});

--- a/src/app/backend/query-execution/custom-query.ts
+++ b/src/app/backend/query-execution/custom-query.ts
@@ -238,6 +238,24 @@ export class CustomQuery {
         basePath: `/MedicationRequest/_search`,
         params: formattedParams,
       };
+
+      // MedicationStatement is a separate resource recording medications a
+      // patient is (or was) taking. Query it with the same RXNorm codes; its
+      // date search param is "effective" (not "authoredon").
+      const statementParams = new URLSearchParams();
+      statementParams.append("subject", `Patient/${patientId}`);
+      statementParams.append("code", medicationsFilter);
+      statementParams.append("_include", "MedicationStatement:medication");
+
+      if (medicationsTimeFilter) {
+        statementParams.append("effective", medicationsTimeFilter.startDate);
+        statementParams.append("effective", medicationsTimeFilter.endDate);
+      }
+
+      this.fhirResourceQueries["medicationStatement"] = {
+        basePath: `/MedicationStatement/_search`,
+        params: statementParams,
+      };
     }
   }
 

--- a/src/app/tests/assets/GoldenSickPatient.json
+++ b/src/app/tests/assets/GoldenSickPatient.json
@@ -10556,6 +10556,63 @@
         "method": "PUT",
         "url": "Encounter/22b3486d-269e-43b0-bfa9-2aaac9d92050"
       }
+    },
+    {
+      "fullUrl": "MedicationStatement/b7d3c2a1-4e5f-4a6b-8c9d-0e1f2a3b4c5d",
+      "resource": {
+        "resourceType": "MedicationStatement",
+        "id": "b7d3c2a1-4e5f-4a6b-8c9d-0e1f2a3b4c5d",
+        "meta": {
+          "versionId": "1",
+          "lastUpdated": "2024-04-23T11:06:48.000+00:00",
+          "source": "#UsEE2f93mG3wMjbq"
+        },
+        "status": "active",
+        "medicationCodeableConcept": {
+          "coding": [
+            {
+              "system": "http://www.nlm.nih.gov/research/umls/rxnorm",
+              "code": "1665005",
+              "display": "ceftriaxone 500 MG Injection"
+            }
+          ],
+          "text": "ceftriaxone 500 MG Injection"
+        },
+        "subject": {
+          "reference": "Patient/f288c654-6885-4f48-999c-48d776dc06af"
+        },
+        "effectiveDateTime": "2000-04-05",
+        "dateAsserted": "2000-04-06",
+        "reasonCode": [
+          {
+            "coding": [
+              {
+                "system": "http://id.who.int/icd/release/10/2019",
+                "code": "A54.9",
+                "display": "Gonococcal infection, unspecified"
+              },
+              {
+                "system": "http://snomed.info/sct",
+                "code": "15628003",
+                "display": "Gonorrhea (disorder)"
+              }
+            ],
+            "text": "Gonorrhea infection"
+          }
+        ],
+        "dosage": [
+          {
+            "text": "Ceftriaxone 500 mg injection as a single dose"
+          }
+        ]
+      },
+      "search": {
+        "mode": "match"
+      },
+      "request": {
+        "method": "PUT",
+        "url": "MedicationStatement/b7d3c2a1-4e5f-4a6b-8c9d-0e1f2a3b4c5d"
+      }
     }
   ]
 }

--- a/src/app/utils/format-service.test.tsx
+++ b/src/app/utils/format-service.test.tsx
@@ -422,22 +422,24 @@ describe("formatCodeableConcept", () => {
     expect(getByText("Example Text")).toBeInTheDocument();
   });
 
-  it("should return the display, code, and system of the first coding object", () => {
+  it("should render the display and code of the first coding, with a friendly system label and no raw url", () => {
     const concept: CodeableConcept = {
       text: "Example Text",
       coding: [
         {
           display: "Example Display",
-          code: "Example Code",
-          system: "Example System",
+          code: "1665005",
+          system: "http://www.nlm.nih.gov/research/umls/rxnorm",
         },
       ],
     };
 
-    const { getByText } = render(formatCodeableConcept(concept));
+    const { getByText, queryByText } = render(formatCodeableConcept(concept));
     expect(getByText(/Example Display/)).toBeInTheDocument();
-    expect(getByText(/Example Code/)).toBeInTheDocument();
-    expect(getByText(/Example System/)).toBeInTheDocument();
+    // code is shown, prefixed by a friendly system label
+    expect(getByText(/RXNORM 1665005/)).toBeInTheDocument();
+    // the raw system url is not rendered
+    expect(queryByText(/http/)).not.toBeInTheDocument();
   });
 });
 
@@ -513,28 +515,29 @@ describe("formatCoding", () => {
     expect(result).toBe("");
   });
 
-  it("should return the display, code, and system", () => {
+  it("should render the display and code with a friendly system label and no raw url", () => {
     const coding: Coding = {
       display: "Example Display",
-      code: "Example Code",
-      system: "Example System",
+      code: "15628003",
+      system: "http://snomed.info/sct",
     };
 
-    const { getByText } = render(formatCoding(coding));
+    const { getByText, queryByText } = render(formatCoding(coding));
     expect(getByText(/Example Display/)).toBeInTheDocument();
-    expect(getByText(/Example Code/)).toBeInTheDocument();
-    expect(getByText(/Example System/)).toBeInTheDocument();
+    expect(getByText(/SNOMED 15628003/)).toBeInTheDocument();
+    expect(queryByText(/http/)).not.toBeInTheDocument();
   });
 
-  it("should return the parts of the display, code, and system", () => {
+  it("should render only the display name when the coding has no code", () => {
     const coding: Coding = {
       display: "Example Display",
-      system: "Example System",
+      system: "http://snomed.info/sct",
     };
 
     const { queryByText } = render(formatCoding(coding));
     expect(queryByText(/Example Display/)).toBeInTheDocument();
-    expect(queryByText(/Example Code/)).not.toBeInTheDocument();
-    expect(queryByText(/Example System/)).toBeInTheDocument();
+    // without a code there is no secondary line, and the raw url is never shown
+    expect(queryByText(/SNOMED/)).not.toBeInTheDocument();
+    expect(queryByText(/http/)).not.toBeInTheDocument();
   });
 });

--- a/src/app/utils/format-service.test.tsx
+++ b/src/app/utils/format-service.test.tsx
@@ -4,6 +4,7 @@ import {
   formatContact,
   formatCoding,
   formatCodeableConcept,
+  formatCodeSystemPrefix,
   formatDate,
   formatIdentifier,
   formatName,
@@ -539,5 +540,29 @@ describe("formatCoding", () => {
     // without a code there is no secondary line, and the raw url is never shown
     expect(queryByText(/SNOMED/)).not.toBeInTheDocument();
     expect(queryByText(/http/)).not.toBeInTheDocument();
+  });
+});
+
+describe("formatCodeSystemPrefix", () => {
+  it("returns friendly labels for well-known code systems", () => {
+    expect(
+      formatCodeSystemPrefix("http://www.nlm.nih.gov/research/umls/rxnorm"),
+    ).toBe("RXNORM");
+    expect(formatCodeSystemPrefix("http://snomed.info/sct")).toBe("SNOMED");
+    expect(formatCodeSystemPrefix("http://loinc.org")).toBe("LOINC");
+  });
+
+  it("strips the codesystem- prefix and .html suffix from hl7 doc-page systems", () => {
+    expect(
+      formatCodeSystemPrefix(
+        "http://hl7.org/fhir/codesystem-service-type.html",
+      ),
+    ).toBe("SERVICE-TYPE");
+  });
+
+  it("preserves the ICD-10 label", () => {
+    expect(formatCodeSystemPrefix("http://hl7.org/fhir/sid/icd-10-cm")).toBe(
+      "ICD-10",
+    );
   });
 });

--- a/src/app/utils/format-service.tsx
+++ b/src/app/utils/format-service.tsx
@@ -10,6 +10,35 @@ import {
 } from "fhir/r4";
 
 /**
+ * Renders a single FHIR Coding for display: the human-readable name on the
+ * first line, with the code (prefixed by a friendly system label, e.g.
+ * "RXNORM 1665005") shown as muted secondary text. The raw system URL is
+ * omitted to keep result tables readable.
+ * @param coding - The Coding to render.
+ * @param fallbackText - Text to use as the primary name when the coding has
+ * no display value (e.g. the parent CodeableConcept's text).
+ * @returns The Coding formatted for display.
+ */
+function renderCoding(coding: Coding, fallbackText?: string) {
+  const primary = coding.display || fallbackText || coding.code || "";
+  const systemLabel = coding.system
+    ? formatCodeSystemPrefix(coding.system)
+    : undefined;
+  const codeLabel = [systemLabel, coding.code].filter(Boolean).join(" ");
+
+  return (
+    <>
+      {primary}
+      {coding.code && codeLabel !== primary && (
+        <span className="display-block font-body-2xs text-base-dark">
+          {codeLabel}
+        </span>
+      )}
+    </>
+  );
+}
+
+/**
  * Formats a CodeableConcept object for display. If the object has a coding array,
  * the first coding object is used.
  * @param concept - The CodeableConcept object.
@@ -23,13 +52,7 @@ export function formatCodeableConcept(concept: CodeableConcept | undefined) {
   if (!concept.coding || concept.coding.length === 0) {
     return concept.text || "";
   }
-  const coding = concept.coding[0];
-  return (
-    <>
-      {" "}
-      {coding.display} <br /> {coding.code} <br /> {coding.system}{" "}
-    </>
-  );
+  return renderCoding(concept.coding[0], concept.text);
 }
 
 /**
@@ -265,12 +288,7 @@ export function formatCoding(coding: Coding | undefined) {
   if (!coding) {
     return "";
   }
-  return (
-    <>
-      {" "}
-      {coding?.display} <br /> {coding?.code} <br /> {coding?.system}{" "}
-    </>
-  );
+  return renderCoding(coding);
 }
 
 /**

--- a/src/app/utils/format-service.tsx
+++ b/src/app/utils/format-service.tsx
@@ -336,6 +336,11 @@ export const formatCodeSystemPrefix = (system: string) => {
     case "hl7":
       const hl7Arr = system.split("/");
       result = hl7Arr[hl7Arr.length - 1];
+      // Some hl7 systems point at a documentation page (e.g.
+      // ".../codesystem-service-type.html"). Strip the file extension and the
+      // "codesystem-" prefix so it reads as "SERVICE-TYPE" instead of
+      // "CODESYSTEM-SERVICE-TYPE.HTML".
+      result = result.replace(/\.html?$/i, "").replace(/^codesystem-/i, "");
       if (result == "icd-10-cm") {
         result = result.slice(0, result.indexOf("-cm"));
       }


### PR DESCRIPTION
# PULL REQUEST

## Summary

Adds **`MedicationStatement`** to the FHIR resources queried during a patient records query, and displays the results alongside the existing `MedicationRequest` data.

`MedicationStatement` records what a patient is (or was) actually taking, which is often a better picture of current medications than orders alone. It is queried using the **same RXNorm medication codes** already collected for `MedicationRequest`, so no query-builder changes are needed.

**UX/UI changes:** The results accordion section previously titled **"Medication Requests"** is renamed to **"Medications"** and now contains two stacked sub-tables:
- **Medication Requests** (existing table, unchanged)
- **Medication Statements** (new table: Effective Date, Medication, conditional Reason Code, Status)

Each sub-table only renders when its data is present, and the section is hidden when neither resource type returns data. The left side-nav entry now reads "Medications".

### Changes
- `custom-query.ts` — build a `/MedicationStatement/_search` query (`code` + `subject`, `_include=MedicationStatement:medication`, `effective` time filter). Response parsing and the "View FHIR response" drawer are generic, so they pick up the new resource automatically.
- `MedicationStatementTable.tsx` — new table component (modeled on `MedicationRequestTable`).
- `ResultsView.tsx` — extract `MedicationStatement` and render the combined "Medications" section.
- `custom-query.test.ts` — new unit tests covering the new query building (path, params, time filter, and absence when no medication codes).
- `GoldenSickPatient.json` — add a sample `MedicationStatement` (ceftriaxone) for the test patient.
- `e2e/*.spec.ts` — update accordion-label assertions from "Medication Requests" to "Medications".

## Related Issue

Fixes #

## Additional Information

- Verified locally: `npm run lint` (0 errors), `npm run build`, and `npm run test:unit` (29 suites / 199 tests / 34 snapshots) all pass.
- Manually verified end-to-end against Aidbox: created a `MedicationStatement` for the test patient and confirmed it renders in the new "Medication Statements" sub-table when running a gonorrhea query.

## Checklist

- [x] Descriptive Pull Request title
- [ ] Link to relevant issues
- [x] Provide necessary context for design reviewers
- [x] Ensure test coverage is above agreed upon threshold
- [ ] Update documentation