### PR TITLE
Preserve patient search inputs when revising a search

### DIFF
--- a/src/app/(pages)/query/components/searchForm/SearchForm.tsx
+++ b/src/app/(pages)/query/components/searchForm/SearchForm.tsx
@@ -15,6 +15,7 @@ import {
   Mode,
   hyperUnluckyPatient,
   AddressData,
+  PatientSearchFormValues,
   INSUFFICIENT_PATIENT_IDENTIFIERS,
 } from "@/app/constants";
 import {
@@ -42,6 +43,8 @@ interface SearchFormProps {
   selectedFhirServer: string;
   setFhirServer: React.Dispatch<React.SetStateAction<string>>;
   setUncertainMatchError: React.Dispatch<React.SetStateAction<boolean>>;
+  initialValues?: PatientSearchFormValues;
+  setSearchFormValues: (values: PatientSearchFormValues) => void;
 }
 
 const SearchForm: React.FC<SearchFormProps> = function SearchForm({
@@ -52,21 +55,29 @@ const SearchForm: React.FC<SearchFormProps> = function SearchForm({
   selectedFhirServer: fhirServer,
   setFhirServer,
   setUncertainMatchError,
+  initialValues,
+  setSearchFormValues,
 }) {
   //Set the patient options based on the demoOption
-  const [firstName, setFirstName] = useState<string>("");
-  const [lastName, setLastName] = useState<string>("");
-  const [phone, setPhone] = useState<string>("");
-  const [email, setEmail] = useState<string>("");
-  const [dob, setDOB] = useState<string>("");
-  const [mrn, setMRN] = useState<string>("");
-  const [address, setAddress] = useState<AddressData>({
-    street1: "",
-    street2: "",
-    city: "",
-    state: "",
-    zip: "",
-  });
+  const [firstName, setFirstName] = useState<string>(
+    initialValues?.firstName ?? "",
+  );
+  const [lastName, setLastName] = useState<string>(
+    initialValues?.lastName ?? "",
+  );
+  const [phone, setPhone] = useState<string>(initialValues?.phone ?? "");
+  const [email, setEmail] = useState<string>(initialValues?.email ?? "");
+  const [dob, setDOB] = useState<string>(initialValues?.dob ?? "");
+  const [mrn, setMRN] = useState<string>(initialValues?.mrn ?? "");
+  const [address, setAddress] = useState<AddressData>(
+    initialValues?.address ?? {
+      street1: "",
+      street2: "",
+      city: "",
+      state: "",
+      zip: "",
+    },
+  );
 
   const [fhirServerConfig, setFhirServerConfig] =
     useState<FhirServerConfig | null>(null);
@@ -209,6 +220,19 @@ const SearchForm: React.FC<SearchFormProps> = function SearchForm({
     }
     setLoading(true);
 
+    // Persist the raw field values so the form can be repopulated if the user
+    // revises the search. Stored before the async query so they survive any
+    // outcome (no matches, error, etc.).
+    setSearchFormValues({
+      firstName,
+      lastName,
+      dob,
+      mrn,
+      phone,
+      email,
+      address,
+    });
+
     const patientDiscoveryRequest = getPatientDiscoveryRequest();
     try {
       setMode("patient-results");
@@ -247,7 +271,11 @@ const SearchForm: React.FC<SearchFormProps> = function SearchForm({
 
   useEffect(() => {
     window.scrollTo(0, 0);
-    prefillFromQueryParams();
+    // Skip URL prefill when we already have persisted values (e.g. the user is
+    // revising a prior search), so we don't clobber the repopulated fields.
+    if (!initialValues) {
+      prefillFromQueryParams();
+    }
   }, []);
 
   return (

--- a/src/app/(pages)/query/components/searchForm/searchForm.test.tsx
+++ b/src/app/(pages)/query/components/searchForm/searchForm.test.tsx
@@ -56,6 +56,7 @@ describe("SearchForm", () => {
           setFhirServer={jest.fn()}
           fhirServers={[]}
           setUncertainMatchError={jest.fn()}
+          setSearchFormValues={jest.fn()}
         ></SearchForm>
       </RootProviderMock>,
     );
@@ -74,6 +75,7 @@ describe("SearchForm", () => {
           setFhirServer={jest.fn()}
           fhirServers={[]}
           setUncertainMatchError={jest.fn()}
+          setSearchFormValues={jest.fn()}
         ></SearchForm>
       </RootProviderMock>,
     );
@@ -104,6 +106,7 @@ describe("SearchForm", () => {
           setFhirServer={jest.fn()}
           fhirServers={[]}
           setUncertainMatchError={jest.fn()}
+          setSearchFormValues={jest.fn()}
         ></SearchForm>
       </RootProviderMock>,
     );
@@ -130,6 +133,71 @@ describe("SearchForm", () => {
     expect(mrn).toHaveValue("1234");
   });
 
+  it("repopulates fields from initialValues when revising a search", () => {
+    // Even with URL params present, persisted initialValues take precedence so
+    // the revised search keeps what the user previously entered.
+    (useSearchParams as jest.Mock).mockReturnValue(
+      new URLSearchParams("last=fromurl"),
+    );
+
+    const initialValues = {
+      firstName: "Jane",
+      lastName: "Doe",
+      dob: "1990-01-15",
+      mrn: "9876",
+      phone: "555-123-4567",
+      email: "jane@example.com",
+      address: {
+        street1: "123 Main St",
+        street2: "Apt 4",
+        city: "Anytown",
+        state: "MA",
+        zip: "02101",
+      },
+    };
+
+    renderWithUser(
+      <RootProviderMock currentPage="/query">
+        <SearchForm
+          setMode={jest.fn()}
+          setLoading={jest.fn()}
+          setPatientDiscoveryQueryResponse={jest.fn()}
+          selectedFhirServer="Default server"
+          setFhirServer={jest.fn()}
+          fhirServers={[]}
+          setUncertainMatchError={jest.fn()}
+          setSearchFormValues={jest.fn()}
+          initialValues={initialValues}
+        />
+      </RootProviderMock>,
+    );
+
+    expect(screen.getByRole("textbox", { name: "First name" })).toHaveValue(
+      "Jane",
+    );
+    expect(screen.getByRole("textbox", { name: "Last name" })).toHaveValue(
+      "Doe",
+    );
+    expect(screen.getByRole("textbox", { name: "Phone number" })).toHaveValue(
+      "555-123-4567",
+    );
+    expect(screen.getByRole("textbox", { name: "Email address" })).toHaveValue(
+      "jane@example.com",
+    );
+    expect(
+      screen.getByRole("textbox", { name: "Medical Record Number" }),
+    ).toHaveValue("9876");
+    expect(screen.getByRole("textbox", { name: "Street address" })).toHaveValue(
+      "123 Main St",
+    );
+    expect(screen.getByRole("textbox", { name: "City" })).toHaveValue(
+      "Anytown",
+    );
+    expect(screen.getByRole("textbox", { name: "Zip code" })).toHaveValue(
+      "02101",
+    );
+  });
+
   it("does not prefill fhir server with bad data", async () => {
     const badServerName = "Fake FHIR";
     const defaultServerName = "Default FHIR";
@@ -148,6 +216,7 @@ describe("SearchForm", () => {
           setFhirServer={jest.fn()}
           fhirServers={[defaultServerName, "Some other server name"]}
           setUncertainMatchError={jest.fn()}
+          setSearchFormValues={jest.fn()}
         ></SearchForm>
       </RootProviderMock>,
     );
@@ -184,6 +253,7 @@ describe("SearchForm", () => {
           setFhirServer={jest.fn()}
           fhirServers={["Default server"]}
           setUncertainMatchError={jest.fn()}
+          setSearchFormValues={jest.fn()}
         ></SearchForm>
       </RootProviderMock>,
     );
@@ -242,6 +312,7 @@ describe("SearchForm", () => {
           setFhirServer={jest.fn()}
           fhirServers={["Matching Server"]}
           setUncertainMatchError={jest.fn()}
+          setSearchFormValues={jest.fn()}
         />
       </RootProviderMock>,
     );

--- a/src/app/(pages)/query/page.tsx
+++ b/src/app/(pages)/query/page.tsx
@@ -5,7 +5,7 @@ import ResultsView from "./components/ResultsView";
 import PatientSearchResults from "./components/PatientSearchResults";
 import SearchForm from "./components/searchForm/SearchForm";
 import SelectQuery from "./components/SelectQuery";
-import { Mode } from "@/app/constants";
+import { Mode, PatientSearchFormValues } from "@/app/constants";
 import StepIndicator, {
   CUSTOMIZE_QUERY_STEPS,
 } from "./components/stepIndicator/StepIndicator";
@@ -59,6 +59,8 @@ const Query: React.FC = () => {
     ctx?.setCurrentPage(mode);
   }, [mode]);
 
+  const [searchFormValues, setSearchFormValues] =
+    useState<PatientSearchFormValues>();
   const [patientDiscoveryQueryResponse, setPatientDiscoveryQueryResponse] =
     useState<PatientDiscoveryResponse>();
   const [patientForQuery, setPatientForQueryResponse] = useState<Patient>();
@@ -95,6 +97,8 @@ const Query: React.FC = () => {
               selectedFhirServer={fhirServer}
               setFhirServer={setFhirServer}
               setUncertainMatchError={setUncertainMatchError}
+              initialValues={searchFormValues}
+              setSearchFormValues={setSearchFormValues}
             />
           </Suspense>
         )}
@@ -144,6 +148,7 @@ const Query: React.FC = () => {
               setMode("select-query");
             }}
             goToBeginning={() => {
+              setSearchFormValues(undefined);
               setMode("search");
             }}
             loading={loading}

--- a/src/app/constants.ts
+++ b/src/app/constants.ts
@@ -47,6 +47,18 @@ export type AddressData = {
   zip: string;
 };
 
+// Raw patient search form field values, persisted across the search flow so the
+// form can be repopulated when a user revises a search that returned no matches.
+export type PatientSearchFormValues = {
+  firstName: string;
+  lastName: string;
+  dob: string;
+  mrn: string;
+  phone: string;
+  email: string;
+  address: AddressData;
+};
+
 //Create type to specify the demographic data fields for a patient
 export type DemoDataFields = {
   Id: string;

--- a/src/app/tests/unit/search-form-validation.test.tsx
+++ b/src/app/tests/unit/search-form-validation.test.tsx
@@ -28,6 +28,8 @@ const mockSetPatientDiscoveryQueryResponse = jest.fn();
 const mockSetMode = jest.fn();
 const mockSetLoading = jest.fn();
 const mockSetFhirServer = jest.fn();
+const mockSetUncertainMatchError = jest.fn();
+const mockSetSearchFormValues = jest.fn();
 const mockFhirServer = "Test Server";
 const mockFhirServers = ["Test Server", "mTLS Server"];
 
@@ -57,6 +59,8 @@ describe("Search Form Name Validation", () => {
         fhirServers={mockFhirServers}
         selectedFhirServer={mockFhirServer}
         setFhirServer={mockSetFhirServer}
+        setUncertainMatchError={mockSetUncertainMatchError}
+        setSearchFormValues={mockSetSearchFormValues}
       />,
     );
 
@@ -95,6 +99,8 @@ describe("Search Form Name Validation", () => {
         fhirServers={mockFhirServers}
         selectedFhirServer={mockFhirServer}
         setFhirServer={mockSetFhirServer}
+        setUncertainMatchError={mockSetUncertainMatchError}
+        setSearchFormValues={mockSetSearchFormValues}
       />,
     );
 
@@ -133,6 +139,8 @@ describe("Search Form Name Validation", () => {
         fhirServers={mockFhirServers}
         selectedFhirServer={mockFhirServer}
         setFhirServer={mockSetFhirServer}
+        setUncertainMatchError={mockSetUncertainMatchError}
+        setSearchFormValues={mockSetSearchFormValues}
       />,
     );
 
@@ -171,6 +179,8 @@ describe("Search Form Name Validation", () => {
         fhirServers={mockFhirServers}
         selectedFhirServer={mockFhirServer}
         setFhirServer={mockSetFhirServer}
+        setUncertainMatchError={mockSetUncertainMatchError}
+        setSearchFormValues={mockSetSearchFormValues}
       />,
     );
 
@@ -209,6 +219,8 @@ describe("Search Form Name Validation", () => {
         fhirServers={mockFhirServers}
         selectedFhirServer={mockFhirServer}
         setFhirServer={mockSetFhirServer}
+        setUncertainMatchError={mockSetUncertainMatchError}
+        setSearchFormValues={mockSetSearchFormValues}
       />,
     );
 
@@ -244,6 +256,8 @@ describe("Search Form Name Validation", () => {
         fhirServers={mockFhirServers}
         selectedFhirServer={mockFhirServer}
         setFhirServer={mockSetFhirServer}
+        setUncertainMatchError={mockSetUncertainMatchError}
+        setSearchFormValues={mockSetSearchFormValues}
       />,
     );
 
@@ -285,6 +299,8 @@ describe("Search Form mTLS Server Selection", () => {
         fhirServers={mockFhirServers}
         selectedFhirServer={mockFhirServer}
         setFhirServer={mockSetFhirServer}
+        setUncertainMatchError={mockSetUncertainMatchError}
+        setSearchFormValues={mockSetSearchFormValues}
       />,
     );
 


### PR DESCRIPTION
## Problem

When a patient lookup returns no matches, the results screen shows a **"Revise your patient search"** link. Clicking it returned the user to an **empty** form, forcing them to re-type everything.

**Root cause:** `SearchForm` is conditionally rendered (`mode === "search"`), so submitting unmounts it and destroys its local `useState` field values. "Revise your patient search" just flips `mode` back to `"search"`, remounting a fresh, blank form.

## Fix

Lift the demographic field values into the parent `Query` component so they survive the unmount/remount, hydrate `SearchForm` from them on revise, and persist them on submit.

- **`constants.ts`** — new `PatientSearchFormValues` type (reuses `AddressData`).
- **`page.tsx`** — holds `searchFormValues` state, passed down as `initialValues` + `setSearchFormValues`. **"New patient search"** (`goToBeginning`) clears the saved values so a fresh search starts blank; **"Revise your patient search"** (`goBack`) keeps them.
- **`SearchForm.tsx`** — initializes field `useState` hooks from `initialValues`, persists raw values in `HandleSubmit` (before the async query, so they survive any outcome), and guards the on-mount URL prefill so it doesn't clobber a revise.
- **Tests** — updated render sites for the new prop (also added the previously-missing `setUncertainMatchError` in `search-form-validation.test.tsx`, fixing latent type errors) and added a test asserting the form repopulates from `initialValues`.

Values live in React state only — no PII is placed in the URL.

## Testing

- `jest searchForm|search-form-validation` → **14 passed**, 5 snapshots unchanged (form markup untouched).
- `tsc --noEmit` clean for the changed code.
- `eslint`/Prettier clean.

**Manual:** search for a patient that won't match → on the no-results screen click **"Revise your patient search"** → fields stay populated. Run a successful search, then click **"New patient search"** → form is blank.