### PR TITLE
fix(terraform): pin RDS engine_version to major version only

### DIFF
--- a/terraform/implementation/ecs/_variable.tf
+++ b/terraform/implementation/ecs/_variable.tf
@@ -80,7 +80,12 @@ variable "db_engine_type" {
 variable "db_engine_version" {
   type        = string
   description = "Engine Version of RDS Instance"
-  default     = "16.8"
+  # Pin the major version only. RDS auto-applies minor version upgrades during
+  # maintenance windows (auto_minor_version_upgrade defaults to true), so pinning
+  # a full minor version (e.g. 16.8) causes apply to fail once AWS bumps the minor
+  # version, since RDS cannot downgrade. The AWS provider treats this as a prefix
+  # and matches whatever 16.x is actually running.
+  default = "16"
 }
 
 variable "db_instance_class" {


### PR DESCRIPTION
## Problem

The **Terraform Plan & Terraform Apply** workflow failed on the `dev` workspace ([run 27998982959](https://github.com/CDCgov/dibbs-query-connector/actions/runs/27998982959)) with:

```
Error: updating RDS DB Instance (qc-db-dev): operation error RDS: ModifyDBInstance,
api error InvalidParameterCombination: Cannot find upgrade path from 16.13 to 16.8.
  with aws_db_instance.qc_db,
  on main.tf line 317, in resource "aws_db_instance" "qc_db":
```

## Root cause

The RDS instance has `auto_minor_version_upgrade` enabled (the AWS default), so AWS auto-upgraded its PostgreSQL minor version from **16.8 → 16.13** during a maintenance window. The Terraform config pinned `db_engine_version = "16.8"` (the default in `_variable.tf`, not overridden by any tfvars), so every apply tried to "modify" the DB back down to 16.8 — a downgrade RDS rejects. Simply bumping to `16.13` would hit the same wall on the next maintenance window.

## Fix

Pin only the **major** version (`"16"`). The AWS provider treats a major-version-only string as a prefix and matches whatever 16.x is actually running, so apply no longer fights AWS's auto-applied minor upgrades. This covers both `dev` and `demo` (neither overrides the default). `terraform fmt` passes.