### PR TITLE
Fix Immunization patient scoping (IZ Gateway) and isolate per-resource query failures (UMC)

### DIFF
--- a/src/app/backend/query-execution/custom-query.test.ts
+++ b/src/app/backend/query-execution/custom-query.test.ts
@@ -91,3 +91,25 @@ describe("CustomQuery medication queries", () => {
     expect(customQuery.getQuery("medicationStatement").basePath).toBe("");
   });
 });
+
+describe("CustomQuery immunization queries", () => {
+  it("scopes Immunization with the FHIR R4 'patient' search param, not 'subject'", () => {
+    const savedQuery: QueryTableResult = {
+      queryName: "Immunization Query",
+      queryId: "query-imm",
+      queryData: {},
+      conditionsList: [],
+      medicalRecordSections: {
+        ...EMPTY_MEDICAL_RECORD_SECTIONS,
+        immunizations: true,
+      },
+    };
+
+    const customQuery = new CustomQuery(savedQuery, PATIENT_ID);
+    const immunization = customQuery.getQuery("immunization");
+
+    expect(immunization.basePath).toBe("/Immunization");
+    expect(immunization.params.get("patient")).toBe(`Patient/${PATIENT_ID}`);
+    expect(immunization.params.get("subject")).toBeNull();
+  });
+});

--- a/src/app/backend/query-execution/custom-query.ts
+++ b/src/app/backend/query-execution/custom-query.ts
@@ -137,7 +137,10 @@ export class CustomQuery {
 
     if (medicalRecordSections && medicalRecordSections.immunizations) {
       const formattedParams = new URLSearchParams();
-      formattedParams.append("subject", `Patient/${patientId}`);
+      // FHIR R4 Immunization has no "subject" search param; the patient-scoping
+      // param is "patient". Using "subject" leaves the query unscoped and the IZ
+      // Gateway rejects it ("must contain patient.identifier or name+birthDate").
+      formattedParams.append("patient", `Patient/${patientId}`);
 
       this.fhirResourceQueries["immunization"] = {
         basePath: `/Immunization`,

--- a/src/app/backend/query-execution/patient-records-resilience.test.ts
+++ b/src/app/backend/query-execution/patient-records-resilience.test.ts
@@ -1,0 +1,166 @@
+import { patientRecordsQuery } from "./service";
+import { prepareFhirClient } from "@/app/backend/fhir-servers/service";
+import { getSavedQueryByName } from "@/app/backend/query-building/service";
+import FHIRClient from "@/app/backend/fhir-servers/fhir-client";
+import {
+  EMPTY_MEDICAL_RECORD_SECTIONS,
+  QueryDataColumn,
+  QueryTableResult,
+} from "@/app/(pages)/queryBuilding/utils";
+import { DibbsValueSet } from "@/app/models/entities/valuesets";
+import { suppressConsoleLogs } from "@/app/tests/integration/fixtures";
+
+jest.mock("@/app/utils/auth", () => ({
+  superAdminAccessCheck: jest.fn().mockReturnValue(true),
+}));
+
+jest.mock("@/app/backend/fhir-servers/service", () => ({
+  prepareFhirClient: jest.fn(),
+  getFhirServerConfigs: jest.fn(),
+  getFhirServerNames: jest.fn(),
+}));
+
+jest.mock("@/app/backend/query-building/service", () => ({
+  getSavedQueryByName: jest.fn(),
+}));
+
+jest.mock("@/app/backend/audit-logs/decorator", () => ({
+  auditable: jest
+    .fn()
+    .mockImplementation(
+      () =>
+        (
+          _target: unknown,
+          _propertyName: string,
+          descriptor: PropertyDescriptor,
+        ) =>
+          descriptor,
+    ),
+}));
+
+const PATIENT_ID = "patient-123";
+const LOINC_CODE = "5199-7";
+const RXNORM_CODE = "1665005";
+
+function buildSavedQuery(): QueryTableResult {
+  const labsValueSet: DibbsValueSet = {
+    valueSetId: "vs-labs",
+    valueSetVersion: "1",
+    valueSetName: "Test Labs",
+    author: "test",
+    system: "http://loinc.org",
+    dibbsConceptType: "labs",
+    includeValueSet: true,
+    concepts: [{ code: LOINC_CODE, display: "HIV test", include: true }],
+    userCreated: false,
+  };
+
+  const medicationsValueSet: DibbsValueSet = {
+    valueSetId: "vs-meds",
+    valueSetVersion: "1",
+    valueSetName: "Test Medications",
+    author: "test",
+    system: "http://www.nlm.nih.gov/research/umls/rxnorm",
+    dibbsConceptType: "medications",
+    includeValueSet: true,
+    concepts: [{ code: RXNORM_CODE, display: "some drug", include: true }],
+    userCreated: false,
+  };
+
+  const queryData: QueryDataColumn = {
+    "condition-1": { "vs-labs": labsValueSet, "vs-meds": medicationsValueSet },
+  };
+
+  return {
+    queryName: "HIV screening",
+    queryId: "query-hiv",
+    queryData,
+    conditionsList: [],
+    // Immunizations on so the (throwing) Immunization GET is exercised too.
+    medicalRecordSections: {
+      ...EMPTY_MEDICAL_RECORD_SECTIONS,
+      immunizations: true,
+    },
+  };
+}
+
+describe("patientRecordsQuery fault isolation", () => {
+  let mockFhirClient: jest.Mocked<FHIRClient>;
+
+  beforeEach(() => {
+    suppressConsoleLogs();
+    jest.clearAllMocks();
+
+    mockFhirClient = {
+      get: jest.fn(),
+      post: jest.fn(),
+      postJson: jest.fn(),
+      getBatch: jest.fn(),
+      getRequestLog: jest.fn().mockReturnValue([]),
+    } as unknown as jest.Mocked<FHIRClient>;
+
+    (prepareFhirClient as jest.Mock).mockResolvedValue(mockFhirClient);
+    (getSavedQueryByName as jest.Mock).mockResolvedValue(buildSavedQuery());
+  });
+
+  it("returns resources that succeeded even when other resources throw or 404", async () => {
+    const observation = {
+      resourceType: "Observation",
+      id: "obs-1",
+      status: "final",
+      code: { text: "HIV test" },
+    };
+    const observationBundle = {
+      resourceType: "Bundle",
+      type: "searchset",
+      entry: [{ resource: observation }],
+    };
+
+    // The Immunization GET fails at the network level (connection reset on an
+    // unsupported endpoint) — this previously aborted the whole record.
+    mockFhirClient.get.mockRejectedValue(new Error("ECONNRESET"));
+
+    // POST _search batch: MedicationStatement 404s (unsupported), Observation
+    // succeeds, everything else returns an empty 200 bundle.
+    mockFhirClient.post.mockImplementation(async (path: string) => {
+      if (path.includes("MedicationStatement")) {
+        return {
+          status: 404,
+          url: `https://example.com/fhir${path}`,
+          text: async () => "<html>Not found</html>",
+        } as Response;
+      }
+      if (path.includes("Observation")) {
+        return {
+          status: 200,
+          url: `https://example.com/fhir${path}`,
+          json: async () => observationBundle,
+        } as Response;
+      }
+      return {
+        status: 200,
+        url: `https://example.com/fhir${path}`,
+        json: async () => ({ resourceType: "Bundle", entry: [] }),
+      } as Response;
+    });
+
+    const result = await patientRecordsQuery({
+      patientId: PATIENT_ID,
+      fhirServer: "Test Server",
+      queryName: "HIV screening",
+    });
+
+    // The successful Observation is still returned...
+    expect(result.Observation).toHaveLength(1);
+    expect(result.Observation?.[0]).toEqual(observation);
+    // ...and the failed resources are simply absent rather than aborting.
+    expect(result.MedicationStatement).toBeUndefined();
+    expect(result.Immunization).toBeUndefined();
+
+    // The Immunization GET is scoped with the FHIR R4 `patient` param and is
+    // actually serialized into the URL (regression for the dropped-params bug).
+    expect(mockFhirClient.get).toHaveBeenCalledWith(
+      expect.stringContaining("patient=Patient"),
+    );
+  });
+});

--- a/src/app/backend/query-execution/service.ts
+++ b/src/app/backend/query-execution/service.ts
@@ -421,27 +421,44 @@ class QueryService {
     const builtQuery = new CustomQuery(savedQuery, patientId);
 
     const medicalRecordSectionResults: Response[] = [];
+    // Each medical-record-section request is isolated in its own try/catch so a
+    // network-level failure (e.g. an unsupported endpoint that resets the
+    // connection) on one section can't abort the whole patient record. Non-OK
+    // HTTP responses are filtered out further down.
     if (medicalRecordSections && medicalRecordSections.immunizations) {
-      const { basePath, params } = builtQuery.getQuery("immunization");
-      let fetchString = basePath;
-      Object.entries(params).forEach(([k, v]) => {
-        fetchString += `?${k}=${v}`;
-      });
-      medicalRecordSectionResults.push(await fhirClient.get(fetchString));
+      try {
+        const { basePath, params } = builtQuery.getQuery("immunization");
+        // params is a URLSearchParams; stringify it directly. Object.entries()
+        // on a URLSearchParams returns [] and would drop the patient filter.
+        const fetchString = `${basePath}?${params}`;
+        medicalRecordSectionResults.push(await fhirClient.get(fetchString));
+      } catch (error) {
+        console.error("Immunization FHIR query failed: ", error);
+      }
     }
 
     if (medicalRecordSections && medicalRecordSections.socialDeterminants) {
-      const { basePath, params } = builtQuery.getQuery("socialHistory");
-      medicalRecordSectionResults.push(await fhirClient.post(basePath, params));
+      try {
+        const { basePath, params } = builtQuery.getQuery("socialHistory");
+        medicalRecordSectionResults.push(
+          await fhirClient.post(basePath, params),
+        );
+      } catch (error) {
+        console.error("Social history FHIR query failed: ", error);
+      }
     }
 
     if (medicalRecordSections && medicalRecordSections.serviceRequests) {
-      const { basePath, params } = builtQuery.getQuery("serviceRequest");
+      try {
+        const { basePath, params } = builtQuery.getQuery("serviceRequest");
 
-      let fetchString = `${basePath}?${params}`;
+        const fetchString = `${basePath}?${params}`;
 
-      // todo: see if we can get this to work with post requests
-      medicalRecordSectionResults.push(await fhirClient.get(fetchString));
+        // todo: see if we can get this to work with post requests
+        medicalRecordSectionResults.push(await fhirClient.get(fetchString));
+      } catch (error) {
+        console.error("Service request FHIR query failed: ", error);
+      }
     }
 
     const postPromises = builtQuery.compileAllPostRequests().map((req) => {
@@ -463,12 +480,20 @@ class QueryService {
     const successfulResults = allResults
       .map((response) => {
         if (response.status !== 200) {
-          response.text().then((reason) => {
-            console.error(
-              `FHIR query failed from ${response.url}.
+          response
+            .text()
+            .then((reason) => {
+              console.error(
+                `FHIR query failed from ${response.url}.
               Status: ${response.status} \n Response: ${reason}`,
-            );
-          });
+              );
+            })
+            .catch((error) => {
+              console.error(
+                `FHIR query failed from ${response.url} with status ${response.status}; reading the error body also failed: `,
+                error,
+              );
+            });
         } else {
           return response;
         }
@@ -847,9 +872,21 @@ class QueryService {
 
     // Process the responses and flatten them
     if (Array.isArray(response)) {
-      resourceArray = (
-        await Promise.all(response.map(processFhirResponse))
-      ).flat();
+      // Parse each response independently so one unparseable response can't
+      // abort the others (allSettled instead of all). processFhirResponse is
+      // already guarded, so rejections here are defense-in-depth.
+      const settled = await Promise.allSettled(
+        response.map(processFhirResponse),
+      );
+      resourceArray = settled
+        .map((r) => {
+          if (r.status === "fulfilled") {
+            return r.value;
+          }
+          console.error("Parsing a FHIR response failed: ", r.reason);
+          return [];
+        })
+        .flat();
       // if response is a Bundle, extract the resource
     } else if (isFanoutSearch) {
       const resources =
@@ -917,7 +954,18 @@ class QueryService {
     let resourceIds: string[] = [];
 
     if (response.status === 200) {
-      const body = (await response.json()) as Bundle;
+      let body: Bundle;
+      try {
+        body = (await response.json()) as Bundle;
+      } catch (error) {
+        // A 200 with a malformed/non-JSON body shouldn't abort parsing of the
+        // other resources — log and treat this response as empty.
+        console.error(
+          `Failed to parse FHIR response body from ${response.url}: `,
+          error,
+        );
+        return resourceArray;
+      }
       if (body.entry) {
         for (const entry of body.entry) {
           if (entry.resource && isFhirResource(entry.resource)) {

--- a/src/app/backend/query-execution/service.ts
+++ b/src/app/backend/query-execution/service.ts
@@ -483,14 +483,21 @@ class QueryService {
           response
             .text()
             .then((reason) => {
+              // Externally-controlled values (URL, status, response body) are
+              // passed as %s args rather than interpolated into the format
+              // string so they can't inject format specifiers.
               console.error(
-                `FHIR query failed from ${response.url}.
-              Status: ${response.status} \n Response: ${reason}`,
+                "FHIR query failed from %s.\n              Status: %s \n Response: %s",
+                response.url,
+                response.status,
+                reason,
               );
             })
             .catch((error) => {
               console.error(
-                `FHIR query failed from ${response.url} with status ${response.status}; reading the error body also failed: `,
+                "FHIR query failed from %s with status %s; reading the error body also failed: ",
+                response.url,
+                response.status,
                 error,
               );
             });
@@ -954,19 +961,25 @@ class QueryService {
     let resourceIds: string[] = [];
 
     if (response.status === 200) {
-      let body: Bundle;
+      let body: Bundle | null;
       try {
-        body = (await response.json()) as Bundle;
+        body = (await response.json()) as Bundle | null;
       } catch (error) {
         // A 200 with a malformed/non-JSON body shouldn't abort parsing of the
-        // other resources — log and treat this response as empty.
+        // other resources — log and treat this response as empty. response.url
+        // is passed as a %s arg (not interpolated into the format string) so an
+        // externally-controlled URL can't smuggle in format specifiers.
         console.error(
-          `Failed to parse FHIR response body from ${response.url}: `,
+          "Failed to parse FHIR response body from %s: ",
+          response.url,
           error,
         );
         return resourceArray;
       }
-      if (body.entry) {
+      // A body that parses to JSON null or a non-object is still valid JSON (so
+      // it slips past the catch above) but has no entries; optional chaining
+      // keeps the body.entry access from throwing on those values.
+      if (body?.entry) {
         for (const entry of body.entry) {
           if (entry.resource && isFhirResource(entry.resource)) {
             // Add the resource only if the ID is unique to the resources being returned for the query

--- a/src/app/tests/unit/query-service.test.tsx
+++ b/src/app/tests/unit/query-service.test.tsx
@@ -69,6 +69,16 @@ describe("process response", () => {
 
     await expect(processFhirResponse(response)).resolves.toEqual([]);
   });
+
+  it("returns an empty array when a 200 response body parses to JSON null", async () => {
+    const response = {
+      status: 200,
+      url: "https://example.com/fhir/MedicationStatement",
+      json: async () => null,
+    } as unknown as Response;
+
+    await expect(processFhirResponse(response)).resolves.toEqual([]);
+  });
 });
 
 // Test case for parseFhirSearch

--- a/src/app/tests/unit/query-service.test.tsx
+++ b/src/app/tests/unit/query-service.test.tsx
@@ -57,6 +57,18 @@ describe("process response", () => {
       resourceArray.filter((r) => r.resourceType === "Observation").length,
     ).toEqual(2);
   });
+
+  it("returns an empty array when a 200 response has an unparseable body", async () => {
+    const response = {
+      status: 200,
+      url: "https://example.com/fhir/MedicationStatement",
+      json: async () => {
+        throw new Error("Unexpected token < in JSON");
+      },
+    } as unknown as Response;
+
+    await expect(processFhirResponse(response)).resolves.toEqual([]);
+  });
 });
 
 // Test case for parseFhirSearch
@@ -106,5 +118,35 @@ describe("parse fhir search", () => {
     queryResponse.Observation?.forEach((o: Observation) => {
       expect(observationResources).toContain(o);
     });
+  });
+
+  it("keeps resources from good responses when one response in the array fails to parse", async () => {
+    const patientBundle = readJsonFile(
+      "./src/app/tests/assets/BundlePatient.json",
+    );
+
+    const goodResponse = {
+      status: 200,
+      json: async () => patientBundle,
+    } as unknown as Response;
+
+    // Simulates a resource (e.g. MedicationStatement) whose 200 body is not
+    // valid JSON. It must not abort parsing of the other responses.
+    const throwingResponse = {
+      status: 200,
+      url: "https://example.com/fhir/MedicationStatement",
+      json: async () => {
+        throw new Error("Unexpected token < in JSON");
+      },
+    } as unknown as Response;
+
+    const queryResponse: QueryResponse = await parseFhirSearch([
+      goodResponse,
+      throwingResponse,
+    ]);
+
+    expect((queryResponse.Patient || [{}])[0]).toEqual(
+      patientBundle?.entry[0]?.resource,
+    );
   });
 });


### PR DESCRIPTION
## Context

Two issues surfaced during a joint SNHD testing session covering the **IZ Gateway** and **UMC** projects.

### 1. IZ Gateway — Immunization query rejected (HTTP 400)
Immunization searches returned `OperationOutcome: "A query must contain either a patient.identifier or the patient name and birthDate"`, so no vaccine resources came back.

Two compounding bugs:
- The query scoped Immunization with `subject=Patient/{id}`, but **FHIR R4 Immunization has no `subject` search parameter** — the patient-scoping param is `patient`.
- The Immunization GET URL was built with `Object.entries(params)` where `params` is a `URLSearchParams`. `Object.entries()` on a `URLSearchParams` returns `[]`, so **no params were appended at all** — the request went out as a bare, unscoped `/Immunization`, which is exactly what triggers the gateway's 400.

**Fix:** scope with `patient` and serialize the params via `` `${basePath}?${params}` `` (mirroring the working ServiceRequest path). Both changes are required — the rename alone is a no-op.

### 2. UMC — one failed resource aborted the whole record
For an HIV-test patient, a `MedicationStatement/_search` request failed (server returns 404 — endpoint unsupported) and **only Demographics rendered**.

**Fix:** harden the records pipeline so no single resource failure can abort the rest:
- wrap each inline medical-record-section request (Immunization, social history, ServiceRequest) in its own try/catch
- `parseFhirSearch` parses the response array with `Promise.allSettled` instead of fast-fail `Promise.all`
- guard `response.json()` in `processFhirResponse` so a malformed 200 body yields an empty list instead of throwing
- add a `.catch` to the previously-floating non-200 `response.text()` logging

Failed resources continue to degrade silently (logged server-side and visible in the existing "View FHIR response" drawer); successful resources and demographics render as normal.

## Testing
- `npm run test:unit` — full suite passes.
- New coverage: Immunization uses `patient` (not `subject`); `processFhirResponse` survives a malformed body; `parseFhirSearch` keeps good resources when one response fails; and an end-to-end fault-isolation regression test proving that when the Immunization GET throws **and** MedicationStatement 404s, the successful Observation still comes back and the Immunization URL carries `patient=Patient`.

## Note for reviewers / deploy
The original IZ Gateway error screenshot showed a **POST** to `/Immunization` with medication params, which doesn't match current `main` (where Immunization is a GET) — suggesting SNHD tested an **older deployed build**. Worth confirming the deployed version on rollout, and ideally checking SNHD's server logs to confirm whether MedicationStatement returns a clean 404 vs. a connection-level error (the fixes cover both).