### PR TITLE
Add Epic query strategy for vendor-compatible patient record searches

### DIFF
--- a/flyway/sql/V01_04__add_query_strategy_to_fhir_servers.sql
+++ b/flyway/sql/V01_04__add_query_strategy_to_fhir_servers.sql
@@ -1,0 +1,10 @@
+-- Per-server query strategy so patient record retrieval can adapt to
+-- vendor-specific FHIR search support (e.g. Epic: no POST
+-- /MedicationStatement/_search, no `code` filtering on MedicationRequest,
+-- text-only Encounter reason-code matching). Orthogonal to endpoint_type,
+-- which routes patient discovery.
+-- Values: 'default' (spec-standard searches), 'epic' (Epic-compatible searches).
+ALTER TABLE fhir_servers
+  ADD COLUMN IF NOT EXISTS query_strategy TEXT NOT NULL DEFAULT 'default';
+
+COMMENT ON COLUMN fhir_servers.query_strategy IS 'Query strategy for patient record retrieval: default or epic';

--- a/src/app/(pages)/fhirServers/fhirServersModal.tsx
+++ b/src/app/(pages)/fhirServers/fhirServersModal.tsx
@@ -19,7 +19,13 @@ import {
   useReducer,
   useState,
 } from "react";
-import { AuthMethodType, EndpointType, FormError, ModalMode } from "./page";
+import {
+  AuthMethodType,
+  EndpointType,
+  FormError,
+  ModalMode,
+  QueryStrategy,
+} from "./page";
 import { FhirServerConfig } from "@/app/models/entities/fhir-servers";
 import {
   AuthData,
@@ -70,6 +76,7 @@ const EMPTY_FHIR_SERVER = {
   disableCertValidation: false,
   defaultServer: false,
   endpointType: "standard",
+  queryStrategy: "default",
 } as FhirServerConfig;
 
 type FhirServersModal = {
@@ -102,6 +109,7 @@ interface UpdateFormAction {
   disableCertValidation?: boolean;
   defaultServer?: boolean;
   endpointType?: EndpointType;
+  queryStrategy?: QueryStrategy;
   hostname?: string;
   headers?: Record<string, string>;
   clientId?: string;
@@ -157,6 +165,7 @@ function formUpdateReducer(server: FhirServerConfig, action: UpdateFormAction) {
         disableCertValidation:
           action.disableCertValidation ?? server.disableCertValidation,
         endpointType: action.endpointType ?? server.endpointType,
+        queryStrategy: action.queryStrategy ?? server.queryStrategy,
         authType: newAuthType,
         defaultServer: action.defaultServer ?? server.defaultServer,
         // Clear caCert when switching away from mutual-tls
@@ -1041,6 +1050,7 @@ export const FhirServersModal: React.FC<FhirServersModal> = ({
         : undefined,
     caCert: server.authType === "mutual-tls" ? server?.caCert : undefined,
     endpointType: server.endpointType ?? "standard",
+    queryStrategy: server.queryStrategy ?? "default",
   });
 
   const resetModalState = () => {
@@ -1160,6 +1170,29 @@ export const FhirServersModal: React.FC<FhirServersModal> = ({
         <option value="standard">Standard FHIR</option>
         <option value="immunization">Immunization Gateway</option>
         <option value="fanout">Fanout (Task)</option>
+      </select>
+
+      <Label htmlFor="query-strategy">Query Strategy</Label>
+      <div className="usa-hint margin-bottom-1 margin-top-05">
+        Adapts patient record queries to vendor-specific FHIR search support.
+        Choose Epic for Epic-based servers, including those reached through a
+        proxy such as eHealthExchange.
+      </div>
+      <select
+        className="usa-select margin-top-05"
+        id="query-strategy"
+        data-testid="query-strategy"
+        name="query-strategy"
+        value={server.queryStrategy ?? "default"}
+        onChange={(e) => {
+          serverDispatch({
+            type: "common",
+            queryStrategy: (e.target.value as QueryStrategy) ?? "default",
+          });
+        }}
+      >
+        <option value="default">Standard (default)</option>
+        <option value="epic">Epic</option>
       </select>
 
       <Label htmlFor="auth-method">Auth Method</Label>

--- a/src/app/(pages)/fhirServers/fhirServersModal.tsx
+++ b/src/app/(pages)/fhirServers/fhirServersModal.tsx
@@ -524,6 +524,11 @@ export const FhirServersModal: React.FC<FhirServersModal> = ({
                   tokenEndpoint: srv.tokenEndpoint,
                   scopes: srv.scopes,
                   headers: srv.headers ?? {},
+                  caCert: srv.caCert,
+                  // updateFhirServer rewrites the full row, so these must be
+                  // passed through or they reset to their defaults
+                  endpointType: srv.endpointType,
+                  queryStrategy: srv.queryStrategy,
                 },
                 patientMatchConfiguration:
                   srv.patientMatchConfiguration ?? DEFAULT_PATIENT_MATCH_DATA,

--- a/src/app/(pages)/fhirServers/page.tsx
+++ b/src/app/(pages)/fhirServers/page.tsx
@@ -18,7 +18,11 @@ import { FhirServersModal } from "./fhirServersModal";
 import { ModalRef } from "@/app/ui/designSystem/modal/Modal";
 
 export type AuthMethodType =
-  "none" | "basic" | "client_credentials" | "SMART" | "mutual-tls";
+  | "none"
+  | "basic"
+  | "client_credentials"
+  | "SMART"
+  | "mutual-tls";
 
 /**
  * The kind of FHIR endpoint a server exposes. Drives which resource the
@@ -36,6 +40,19 @@ const ENDPOINT_TYPE_LABELS: Record<EndpointType, string> = {
   immunization: "Immunization Gateway",
   fanout: "Fanout (Task)",
 };
+
+/**
+ * How patient record searches are built for a server. Orthogonal to
+ * EndpointType, which routes patient discovery:
+ * - "default": spec-standard searches (POST /{Resource}/_search with code
+ *   filters, Encounter searched by reason-code)
+ * - "epic": Epic-compatible searches — GET-based Condition/Encounter/
+ *   MedicationRequest/MedicationStatement queries, medications fetched
+ *   patient-wide and filtered to the query's codes client-side, and
+ *   Encounters found via references to the patient's matching Conditions
+ *   (Epic's reason-code search matches text, not codes)
+ */
+export type QueryStrategy = "default" | "epic";
 
 export type FormError = {
   [tokenField: string]: boolean;

--- a/src/app/(pages)/fhirServers/page.tsx
+++ b/src/app/(pages)/fhirServers/page.tsx
@@ -18,11 +18,7 @@ import { FhirServersModal } from "./fhirServersModal";
 import { ModalRef } from "@/app/ui/designSystem/modal/Modal";
 
 export type AuthMethodType =
-  | "none"
-  | "basic"
-  | "client_credentials"
-  | "SMART"
-  | "mutual-tls";
+  "none" | "basic" | "client_credentials" | "SMART" | "mutual-tls";
 
 /**
  * The kind of FHIR endpoint a server exposes. Drives which resource the

--- a/src/app/backend/db/util.ts
+++ b/src/app/backend/db/util.ts
@@ -16,9 +16,10 @@ INSERT INTO fhir_servers (
   token_expiry,
   ca_cert,
   patient_match_configuration,
-  endpoint_type
+  endpoint_type,
+  query_strategy
 )
-VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17)
+VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18)
 RETURNING *;
 `;
 

--- a/src/app/backend/fhir-servers/fhir-client.ts
+++ b/src/app/backend/fhir-servers/fhir-client.ts
@@ -4,7 +4,7 @@ import { EndpointType } from "@/app/(pages)/fhirServers/page";
 import { createSmartJwt } from "../smart-on-fhir";
 import { fetchWithoutSSL } from "../../utils/utils";
 import dbService from "../db/service";
-import { AuthData, updateFhirServer } from "./service";
+import { AuthData, updateFhirServerAccessToken } from "./service";
 import {
   getOrCreateMtlsCert,
   getOrCreateMtlsKey,
@@ -393,30 +393,15 @@ class FHIRClient {
 
       // Only update database for non-test clients
       if (this.serverConfig.id !== "test") {
-        // Save token to database
-        await updateFhirServer({
-          id: this.serverConfig.id,
-          name: this.serverConfig.name,
-          hostname: this.serverConfig.hostname,
-          disableCertValidation:
-            this.serverConfig.disableCertValidation ?? false,
-          defaultServer: this.serverConfig.defaultServer ?? false,
-          lastConnectionSuccessful:
-            this.serverConfig.lastConnectionSuccessful ?? true,
-          authData: {
-            authType: this.serverConfig.authType as
-              "SMART" | "client_credentials" | "basic" | "none",
-            clientId: this.serverConfig.clientId,
-            clientSecret: this.serverConfig.clientSecret,
-            tokenEndpoint: this.serverConfig.tokenEndpoint,
-            scopes: this.serverConfig.scopes,
-            accessToken: tokenData.access_token, // Pass the access token
-            tokenExpiry: expiryIso, // Pass the token expiry
-            headers: this.serverConfig.headers,
-          },
-          patientMatchConfiguration:
-            this.serverConfig.patientMatchConfiguration,
-        });
+        // Save the token via the narrow token-only update. Going through
+        // updateFhirServer here would rewrite the full row from a partial
+        // authData, silently resetting configuration such as query_strategy
+        // and endpoint_type to their defaults on every token refresh.
+        await updateFhirServerAccessToken(
+          this.serverConfig.id,
+          tokenData.access_token,
+          expiryIso,
+        );
       }
     } catch (error) {
       console.error("Error getting access token:", error);

--- a/src/app/backend/fhir-servers/service.ts
+++ b/src/app/backend/fhir-servers/service.ts
@@ -269,6 +269,62 @@ class FhirServerConfigService extends FhirServerConfigServiceInternal {
   }
 
   /**
+   * Persists a refreshed access token for a FHIR server. Deliberately narrow:
+   * token refresh runs in the background, so it must not rewrite configuration
+   * columns the way updateFhirServer does (a partial authData there would
+   * silently reset fields like query_strategy and endpoint_type to their
+   * defaults).
+   * @param id - The ID of the FHIR server
+   * @param accessToken - The new access token
+   * @param tokenExpiry - ISO timestamp when the token expires
+   * @returns An object indicating success or failure with optional error message
+   */
+  @transaction
+  static async updateFhirServerAccessToken(
+    id: string,
+    accessToken: string,
+    tokenExpiry: string,
+  ) {
+    const updateQuery = `
+    UPDATE fhir_servers
+    SET
+      access_token = $2,
+      token_expiry = $3
+    WHERE id = $1
+    RETURNING *;
+  `;
+
+    try {
+      const result = await dbService.query(updateQuery, [
+        id,
+        accessToken,
+        tokenExpiry,
+      ]);
+
+      // Clear the cache so the next getFhirServerConfigs call will fetch fresh data
+      FhirServerConfigService.cachedFhirServerConfigs = null;
+
+      if (result.rows.length === 0) {
+        return {
+          success: false,
+          error: "Server not found",
+        };
+      }
+
+      return {
+        success: true,
+        server: result.rows[0],
+      };
+    } catch (error) {
+      console.error("Failed to update FHIR server access token:", error);
+      return {
+        success: false,
+        error: "Failed to update the server access token.",
+      };
+    }
+  }
+
+  /**
    * Inserts a new FHIR server configuration into the database.
    * @param name - The name of the FHIR server
    * @param hostname - The URL/hostname of the FHIR server
@@ -431,6 +487,8 @@ export const getFhirServerNames = FhirServerConfigService.getFhirServerNames;
 export const updateFhirServerConnectionStatus =
   FhirServerConfigService.updateFhirServerConnectionStatus;
 export const updateFhirServer = FhirServerConfigService.updateFhirServer;
+export const updateFhirServerAccessToken =
+  FhirServerConfigService.updateFhirServerAccessToken;
 export const insertFhirServer = FhirServerConfigService.insertFhirServer;
 export const deleteFhirServer = FhirServerConfigService.deleteFhirServer;
 export const prepareFhirClient = FhirServerConfigService.prepareFhirClient;

--- a/src/app/backend/fhir-servers/service.ts
+++ b/src/app/backend/fhir-servers/service.ts
@@ -5,7 +5,11 @@ import FHIRClient from "@/app/backend/fhir-servers/fhir-client";
 import dbService from "../db/service";
 import { transaction } from "../db/decorators";
 import { FHIR_SERVER_INSERT_QUERY } from "../db/util";
-import { AuthMethodType, EndpointType } from "@/app/(pages)/fhirServers/page";
+import {
+  AuthMethodType,
+  EndpointType,
+  QueryStrategy,
+} from "@/app/(pages)/fhirServers/page";
 
 // Define an interface for authentication data
 export interface AuthData {
@@ -20,6 +24,7 @@ export interface AuthData {
   headers?: Record<string, string>;
   caCert?: string;
   endpointType?: EndpointType;
+  queryStrategy?: QueryStrategy;
 }
 
 // Define an interface for patient match configuration
@@ -176,7 +181,8 @@ class FhirServerConfigService extends FhirServerConfigServiceInternal {
       token_expiry = $14,
       ca_cert = $15,
       patient_match_configuration = $16,
-      endpoint_type = $17
+      endpoint_type = $17,
+      query_strategy = $18
     WHERE id = $1
     RETURNING *;
   `;
@@ -236,6 +242,7 @@ class FhirServerConfigService extends FhirServerConfigServiceInternal {
         authData?.caCert || null,
         patientMatchConfigObject,
         authData?.endpointType || "standard",
+        authData?.queryStrategy || "default",
       ]);
 
       // Clear the cache so the next getFhirServerConfigs call will fetch fresh data
@@ -339,6 +346,7 @@ class FhirServerConfigService extends FhirServerConfigServiceInternal {
         authData?.caCert || null,
         patientMatchConfigObject,
         authData?.endpointType || "standard",
+        authData?.queryStrategy || "default",
       ]);
 
       // Clear the cache so the next getFhirServerConfigs call will fetch fresh data

--- a/src/app/backend/query-execution/custom-query.test.ts
+++ b/src/app/backend/query-execution/custom-query.test.ts
@@ -152,7 +152,14 @@ describe("CustomQuery epic strategy", () => {
     expect(request.params.get("subject")).toBeNull();
     expect(request.params.get("code")).toBeNull();
     expect(request.params.get("_include")).toBe("MedicationRequest:medication");
-    expect(request.params.get("_revinclude")).toBe(
+    // No _revinclude in epic mode: Epic doesn't document support for it on
+    // MedicationRequest GETs and an unrecognized param could fail the search.
+    expect(request.params.get("_revinclude")).toBeNull();
+
+    const defaultRequest = buildMedicationQuery(undefined, "default").getQuery(
+      "medicationRequest",
+    );
+    expect(defaultRequest.params.get("_revinclude")).toBe(
       "MedicationAdministration:request",
     );
 

--- a/src/app/backend/query-execution/custom-query.test.ts
+++ b/src/app/backend/query-execution/custom-query.test.ts
@@ -8,9 +8,44 @@ import { DibbsValueSet } from "@/app/models/entities/valuesets";
 
 const PATIENT_ID = "patient-123";
 const RXNORM_CODE = "1665005";
+const SNOMED_CODE = "240589008";
+
+function buildConditionQuery(
+  queryStrategy: "default" | "epic" = "default",
+  conditionCodes: string[] = [SNOMED_CODE],
+  timeboxWindows?: QueryTableResult["timeboxWindows"],
+): CustomQuery {
+  const conditionValueSet: DibbsValueSet = {
+    valueSetId: "vs-conditions",
+    valueSetVersion: "1",
+    valueSetName: "Test Conditions",
+    author: "test",
+    system: "http://snomed.info/sct",
+    dibbsConceptType: "conditions",
+    includeValueSet: true,
+    concepts: conditionCodes.map((code) => ({
+      code,
+      display: `Condition ${code}`,
+      include: true,
+    })),
+    userCreated: false,
+  };
+
+  const savedQuery: QueryTableResult = {
+    queryName: "Test Condition Query",
+    queryId: "query-2",
+    queryData: { "condition-1": { "vs-conditions": conditionValueSet } },
+    conditionsList: [],
+    medicalRecordSections: EMPTY_MEDICAL_RECORD_SECTIONS,
+    timeboxWindows,
+  };
+
+  return new CustomQuery(savedQuery, PATIENT_ID, queryStrategy);
+}
 
 function buildMedicationQuery(
   timeboxWindows?: QueryTableResult["timeboxWindows"],
+  queryStrategy: "default" | "epic" = "default",
 ): CustomQuery {
   const medicationValueSet: DibbsValueSet = {
     valueSetId: "vs-meds",
@@ -43,7 +78,7 @@ function buildMedicationQuery(
     timeboxWindows,
   };
 
-  return new CustomQuery(savedQuery, PATIENT_ID);
+  return new CustomQuery(savedQuery, PATIENT_ID, queryStrategy);
 }
 
 describe("CustomQuery medication queries", () => {
@@ -89,6 +124,141 @@ describe("CustomQuery medication queries", () => {
 
     const customQuery = new CustomQuery(savedQuery, PATIENT_ID);
     expect(customQuery.getQuery("medicationStatement").basePath).toBe("");
+  });
+});
+
+describe("CustomQuery epic strategy", () => {
+  it("keeps default-mode query shapes unchanged", () => {
+    const customQuery = buildConditionQuery("default");
+
+    const condition = customQuery.getQuery("condition");
+    expect(condition.basePath).toBe("/Condition/_search");
+    expect(condition.params.get("subject")).toBe(`Patient/${PATIENT_ID}`);
+    expect(condition.params.get("code")).toBe(SNOMED_CODE);
+
+    const encounter = customQuery.getQuery("encounter");
+    expect(encounter.basePath).toBe("/Encounter/_search");
+    expect(encounter.params.get("reason-code")).toBe(SNOMED_CODE);
+
+    expect(customQuery.compileEpicConditionQueries()).toHaveLength(1);
+  });
+
+  it("builds GET-based medication queries without code filters", () => {
+    const customQuery = buildMedicationQuery(undefined, "epic");
+
+    const request = customQuery.getQuery("medicationRequest");
+    expect(request.basePath).toBe("/MedicationRequest");
+    expect(request.params.get("patient")).toBe(`Patient/${PATIENT_ID}`);
+    expect(request.params.get("subject")).toBeNull();
+    expect(request.params.get("code")).toBeNull();
+    expect(request.params.get("_include")).toBe("MedicationRequest:medication");
+    expect(request.params.get("_revinclude")).toBe(
+      "MedicationAdministration:request",
+    );
+
+    const statement = customQuery.getQuery("medicationStatement");
+    expect(statement.basePath).toBe("/MedicationStatement");
+    expect(statement.params.get("patient")).toBe(`Patient/${PATIENT_ID}`);
+    expect(statement.params.get("code")).toBeNull();
+    expect(statement.params.get("_include")).toBe(
+      "MedicationStatement:medication",
+    );
+  });
+
+  it("excludes medication queries from the POST batch in epic mode", () => {
+    const customQuery = buildMedicationQuery(undefined, "epic");
+    const postPaths = customQuery.compileAllPostRequests().map((q) => q.path);
+    expect(postPaths).not.toContain("/MedicationRequest");
+    expect(postPaths).not.toContain("/MedicationStatement");
+
+    const defaultQuery = buildMedicationQuery(undefined, "default");
+    const defaultPaths = defaultQuery
+      .compileAllPostRequests()
+      .map((q) => q.path);
+    expect(defaultPaths).toContain("/MedicationRequest/_search");
+    expect(defaultPaths).toContain("/MedicationStatement/_search");
+  });
+
+  it("keeps medication time filters in epic mode", () => {
+    const customQuery = buildMedicationQuery(
+      {
+        medications: {
+          timeWindowStart: "2024-01-01T00:00:00Z",
+          timeWindowEnd: "2024-12-31T00:00:00Z",
+        },
+      },
+      "epic",
+    );
+
+    expect(
+      customQuery.getQuery("medicationRequest").params.getAll("authoredon"),
+    ).toEqual(["ge2024-01-01", "le2024-12-31"]);
+    expect(
+      customQuery.getQuery("medicationStatement").params.getAll("effective"),
+    ).toEqual(["ge2024-01-01", "le2024-12-31"]);
+  });
+
+  it("does not compile condition or encounter queries into the resource dictionary", () => {
+    const customQuery = buildConditionQuery("epic");
+    expect(customQuery.getQuery("condition").basePath).toBe("");
+    expect(customQuery.getQuery("encounter").basePath).toBe("");
+    const postPaths = customQuery.compileAllPostRequests().map((q) => q.path);
+    expect(postPaths).not.toContain("/Condition/_search");
+    expect(postPaths).not.toContain("/Encounter/_search");
+  });
+
+  it("compiles GET-based Condition queries with the query codes", () => {
+    const customQuery = buildConditionQuery("epic");
+    const conditionQueries = customQuery.compileEpicConditionQueries();
+
+    expect(conditionQueries).toHaveLength(1);
+    expect(conditionQueries[0].basePath).toBe("/Condition");
+    expect(conditionQueries[0].params.get("patient")).toBe(
+      `Patient/${PATIENT_ID}`,
+    );
+    expect(conditionQueries[0].params.get("code")).toBe(SNOMED_CODE);
+  });
+
+  it("chunks long condition code lists across multiple GET queries", () => {
+    const manyCodes = Array.from({ length: 120 }, (_, i) => `code-${i}`);
+    const customQuery = buildConditionQuery("epic", manyCodes);
+    const conditionQueries = customQuery.compileEpicConditionQueries();
+
+    expect(conditionQueries).toHaveLength(3);
+    const allCodes = conditionQueries.flatMap((q) =>
+      (q.params.get("code") ?? "").split(","),
+    );
+    expect(allCodes).toEqual(manyCodes);
+  });
+
+  it("compiles Encounter queries from Condition ids, chunked", () => {
+    const customQuery = buildConditionQuery("epic", [SNOMED_CODE], {
+      conditions: {
+        timeWindowStart: "2024-01-01T00:00:00Z",
+        timeWindowEnd: "2024-12-31T00:00:00Z",
+      },
+    });
+
+    const encounterQueries = customQuery.compileEpicEncounterQueries([
+      "cond-1",
+      "cond-2",
+    ]);
+    expect(encounterQueries).toHaveLength(1);
+    expect(encounterQueries[0].basePath).toBe("/Encounter");
+    expect(encounterQueries[0].params.get("patient")).toBe(
+      `Patient/${PATIENT_ID}`,
+    );
+    expect(encounterQueries[0].params.get("diagnosis")).toBe(
+      "Condition/cond-1,Condition/cond-2",
+    );
+    expect(encounterQueries[0].params.getAll("date")).toEqual([
+      "ge2024-01-01",
+      "le2024-12-31",
+    ]);
+
+    const manyIds = Array.from({ length: 60 }, (_, i) => `cond-${i}`);
+    expect(customQuery.compileEpicEncounterQueries(manyIds)).toHaveLength(3);
+    expect(customQuery.compileEpicEncounterQueries([])).toHaveLength(0);
   });
 });
 

--- a/src/app/backend/query-execution/custom-query.ts
+++ b/src/app/backend/query-execution/custom-query.ts
@@ -5,6 +5,28 @@ import {
   QueryTableTimebox,
   TimeWindow,
 } from "../../(pages)/queryBuilding/utils";
+import { QueryStrategy } from "../../(pages)/fhirServers/page";
+
+// Epic-mode Condition and Encounter queries go out as GETs, so long code /
+// reference lists are chunked across multiple requests to keep URLs well under
+// common proxy limits. Overlapping results are safe: parseFhirSearch dedupes
+// resources by id.
+const EPIC_CONDITION_CODE_CHUNK_SIZE = 50;
+const EPIC_ENCOUNTER_DIAGNOSIS_CHUNK_SIZE = 25;
+
+// Epic-mode medication searches can't filter by code server-side, so they
+// return every medication in the patient's record. We don't follow bundle
+// next-links, so ask for a large page to avoid truncation (servers cap this
+// at their own maximum per the FHIR spec).
+const EPIC_MEDICATION_PAGE_SIZE = "1000";
+
+function chunkArray<T>(items: T[], chunkSize: number): T[][] {
+  const chunks: T[][] = [];
+  for (let i = 0; i < items.length; i += chunkSize) {
+    chunks.push(items.slice(i, i + chunkSize));
+  }
+  return chunks;
+}
 
 function formatTimeFilter(timeWindow: TimeWindow | undefined) {
   if (!timeWindow) return undefined;
@@ -27,6 +49,8 @@ function formatTimeFilter(timeWindow: TimeWindow | undefined) {
  */
 export class CustomQuery {
   patientId: string = "";
+  queryStrategy: QueryStrategy = "default";
+  private timeboxInfo?: QueryTableTimebox;
 
   // Store four types of input codes
   labCodes: string[] = [];
@@ -54,13 +78,22 @@ export class CustomQuery {
    * that has nested information about the conditions / valuesets / concepts
    * relevant to the query
    * @param patientId The ID of the patient to build into query strings.
+   * @param queryStrategy How the target server supports search: "default"
+   * uses spec-standard POST _search queries; "epic" adapts to Epic's
+   * supported search parameters (see QueryStrategy).
    */
-  constructor(savedQuery: QueryTableResult, patientId: string) {
+  constructor(
+    savedQuery: QueryTableResult,
+    patientId: string,
+    queryStrategy: QueryStrategy = "default",
+  ) {
     try {
       this.patientId = patientId;
+      this.queryStrategy = queryStrategy;
       const queryData = savedQuery.queryData;
       const medicalRecordSection = savedQuery.medicalRecordSections;
       const timeboxInfo = savedQuery.timeboxWindows;
+      this.timeboxInfo = timeboxInfo;
 
       this.initializeQueryConceptTypes(queryData);
       this.compileFhirResourceQueries(
@@ -192,7 +225,7 @@ export class CustomQuery {
       };
     }
 
-    if (conditionsFilter !== "") {
+    if (conditionsFilter !== "" && this.queryStrategy !== "epic") {
       const encounterParams = new URLSearchParams();
       encounterParams.append("subject", `Patient/${patientId}`);
       encounterParams.append("reason-code", conditionsFilter);
@@ -220,15 +253,31 @@ export class CustomQuery {
         params: conditionParams,
       };
     }
+    // In Epic mode, Condition and Encounter queries aren't compiled here.
+    // Epic's Encounter reason-code search matches text (not SNOMED codes), so
+    // Encounters are instead found via references to the patient's matching
+    // Conditions — a two-step flow the service layer drives with
+    // compileEpicConditionQueries() and compileEpicEncounterQueries().
 
     if (medicationsFilter !== "") {
+      const isEpic = this.queryStrategy === "epic";
+
       // Medications are representations of drugs independent of patient resources.
       // Sometimes we need the extra info from the medication to display in the
       // UI: that's what the ":medication" is doing and similarly for revinclude
       // for the request <> admin relationship
       const formattedParams = new URLSearchParams();
-      formattedParams.append("subject", `Patient/${patientId}`);
-      formattedParams.append("code", medicationsFilter);
+      if (isEpic) {
+        // Epic only supports GET searches for MedicationRequest with a fixed
+        // parameter set (patient, category, status, authoredon, date, intent)
+        // — no "code". Fetch all of the patient's medication requests; the
+        // service layer filters them to the query's RxNorm codes client-side.
+        formattedParams.append("patient", `Patient/${patientId}`);
+        formattedParams.append("_count", EPIC_MEDICATION_PAGE_SIZE);
+      } else {
+        formattedParams.append("subject", `Patient/${patientId}`);
+        formattedParams.append("code", medicationsFilter);
+      }
       formattedParams.append("_include", "MedicationRequest:medication");
       formattedParams.append("_revinclude", "MedicationAdministration:request");
 
@@ -238,16 +287,24 @@ export class CustomQuery {
       }
 
       this.fhirResourceQueries["medicationRequest"] = {
-        basePath: `/MedicationRequest/_search`,
+        basePath: isEpic ? `/MedicationRequest` : `/MedicationRequest/_search`,
         params: formattedParams,
+        excludeFromPost: isEpic,
       };
 
       // MedicationStatement is a separate resource recording medications a
       // patient is (or was) taking. Query it with the same RXNorm codes; its
       // date search param is "effective" (not "authoredon").
       const statementParams = new URLSearchParams();
-      statementParams.append("subject", `Patient/${patientId}`);
-      statementParams.append("code", medicationsFilter);
+      if (isEpic) {
+        // Epic returns 404 for POST /MedicationStatement/_search and doesn't
+        // support "code" filtering; GET by patient and filter client-side.
+        statementParams.append("patient", `Patient/${patientId}`);
+        statementParams.append("_count", EPIC_MEDICATION_PAGE_SIZE);
+      } else {
+        statementParams.append("subject", `Patient/${patientId}`);
+        statementParams.append("code", medicationsFilter);
+      }
       statementParams.append("_include", "MedicationStatement:medication");
 
       if (medicationsTimeFilter) {
@@ -256,10 +313,72 @@ export class CustomQuery {
       }
 
       this.fhirResourceQueries["medicationStatement"] = {
-        basePath: `/MedicationStatement/_search`,
+        basePath: isEpic
+          ? `/MedicationStatement`
+          : `/MedicationStatement/_search`,
         params: statementParams,
+        excludeFromPost: isEpic,
       };
     }
+  }
+
+  /**
+   * Epic-mode Condition GET queries. Epic's POST _search support is limited
+   * to Observation/DiagnosticReport, so Conditions are searched via GET with
+   * the query's condition codes, chunked to keep URLs bounded.
+   * @returns One GET query spec per chunk of condition codes; empty when the
+   * query has no condition codes.
+   */
+  compileEpicConditionQueries(): {
+    basePath: string;
+    params: URLSearchParams;
+  }[] {
+    const conditionsTimeFilter = formatTimeFilter(this.timeboxInfo?.conditions);
+
+    return chunkArray(this.conditionCodes, EPIC_CONDITION_CODE_CHUNK_SIZE).map(
+      (codes) => {
+        const params = new URLSearchParams();
+        params.append("patient", `Patient/${this.patientId}`);
+        params.append("code", codes.join(","));
+        if (conditionsTimeFilter) {
+          params.append("onset-date", conditionsTimeFilter.startDate);
+          params.append("onset-date", conditionsTimeFilter.endDate);
+        }
+        return { basePath: `/Condition`, params };
+      },
+    );
+  }
+
+  /**
+   * Epic-mode Encounter GET queries, built from the ids of the patient's
+   * Conditions that matched the query codes. Epic recommends searching
+   * Encounters by diagnosis (Condition references) rather than reason-code,
+   * whose Epic search semantics are text matching rather than code matching.
+   * @param conditionIds ids of matching Condition resources returned by the
+   * Epic-mode Condition queries
+   * @returns One GET query spec per chunk of Condition references; empty when
+   * no Condition ids are provided.
+   */
+  compileEpicEncounterQueries(
+    conditionIds: string[],
+  ): { basePath: string; params: URLSearchParams }[] {
+    const conditionsTimeFilter = formatTimeFilter(this.timeboxInfo?.conditions);
+
+    return chunkArray(conditionIds, EPIC_ENCOUNTER_DIAGNOSIS_CHUNK_SIZE).map(
+      (ids) => {
+        const params = new URLSearchParams();
+        params.append("patient", `Patient/${this.patientId}`);
+        params.append(
+          "diagnosis",
+          ids.map((id) => `Condition/${id}`).join(","),
+        );
+        if (conditionsTimeFilter) {
+          params.append("date", conditionsTimeFilter.startDate);
+          params.append("date", conditionsTimeFilter.endDate);
+        }
+        return { basePath: `/Encounter`, params };
+      },
+    );
   }
 
   compilePostRequest(resource: { basePath: string; params: URLSearchParams }) {

--- a/src/app/backend/query-execution/custom-query.ts
+++ b/src/app/backend/query-execution/custom-query.ts
@@ -279,7 +279,18 @@ export class CustomQuery {
         formattedParams.append("code", medicationsFilter);
       }
       formattedParams.append("_include", "MedicationRequest:medication");
-      formattedParams.append("_revinclude", "MedicationAdministration:request");
+      if (!isEpic) {
+        // Epic's MedicationRequest GET doesn't document _revinclude support
+        // and unrecognized search parameters can fail the whole request, which
+        // would lose every medication. Forgo MedicationAdministration in Epic
+        // mode rather than risk that. The _include above is kept because the
+        // client-side code filter needs the referenced Medications (and fails
+        // open if the server ignores it).
+        formattedParams.append(
+          "_revinclude",
+          "MedicationAdministration:request",
+        );
+      }
 
       if (medicationsTimeFilter) {
         formattedParams.append("authoredon", medicationsTimeFilter.startDate);

--- a/src/app/backend/query-execution/epic-strategy.test.ts
+++ b/src/app/backend/query-execution/epic-strategy.test.ts
@@ -1,0 +1,320 @@
+import { patientRecordsQuery } from "./service";
+import {
+  getFhirServerConfigs,
+  prepareFhirClient,
+} from "@/app/backend/fhir-servers/service";
+import { getSavedQueryByName } from "@/app/backend/query-building/service";
+import FHIRClient from "@/app/backend/fhir-servers/fhir-client";
+import {
+  EMPTY_MEDICAL_RECORD_SECTIONS,
+  QueryDataColumn,
+  QueryTableResult,
+} from "@/app/(pages)/queryBuilding/utils";
+import { DibbsValueSet } from "@/app/models/entities/valuesets";
+import { suppressConsoleLogs } from "@/app/tests/integration/fixtures";
+
+jest.mock("@/app/utils/auth", () => ({
+  superAdminAccessCheck: jest.fn().mockReturnValue(true),
+}));
+
+jest.mock("@/app/backend/fhir-servers/service", () => ({
+  prepareFhirClient: jest.fn(),
+  getFhirServerConfigs: jest.fn(),
+  getFhirServerNames: jest.fn(),
+}));
+
+jest.mock("@/app/backend/query-building/service", () => ({
+  getSavedQueryByName: jest.fn(),
+}));
+
+jest.mock("@/app/backend/audit-logs/decorator", () => ({
+  auditable: jest
+    .fn()
+    .mockImplementation(
+      () =>
+        (
+          _target: unknown,
+          _propertyName: string,
+          descriptor: PropertyDescriptor,
+        ) =>
+          descriptor,
+    ),
+}));
+
+const PATIENT_ID = "patient-123";
+const LOINC_CODE = "5199-7";
+const RXNORM_CODE = "1665005";
+const OTHER_RXNORM_CODE = "999999";
+const SNOMED_CODE = "240589008";
+
+function buildSavedQuery(): QueryTableResult {
+  const labsValueSet: DibbsValueSet = {
+    valueSetId: "vs-labs",
+    valueSetVersion: "1",
+    valueSetName: "Test Labs",
+    author: "test",
+    system: "http://loinc.org",
+    dibbsConceptType: "labs",
+    includeValueSet: true,
+    concepts: [{ code: LOINC_CODE, display: "HIV test", include: true }],
+    userCreated: false,
+  };
+
+  const medicationsValueSet: DibbsValueSet = {
+    valueSetId: "vs-meds",
+    valueSetVersion: "1",
+    valueSetName: "Test Medications",
+    author: "test",
+    system: "http://www.nlm.nih.gov/research/umls/rxnorm",
+    dibbsConceptType: "medications",
+    includeValueSet: true,
+    concepts: [{ code: RXNORM_CODE, display: "some drug", include: true }],
+    userCreated: false,
+  };
+
+  const conditionsValueSet: DibbsValueSet = {
+    valueSetId: "vs-conditions",
+    valueSetVersion: "1",
+    valueSetName: "Test Conditions",
+    author: "test",
+    system: "http://snomed.info/sct",
+    dibbsConceptType: "conditions",
+    includeValueSet: true,
+    concepts: [{ code: SNOMED_CODE, display: "some condition", include: true }],
+    userCreated: false,
+  };
+
+  const queryData: QueryDataColumn = {
+    "condition-1": {
+      "vs-labs": labsValueSet,
+      "vs-meds": medicationsValueSet,
+      "vs-conditions": conditionsValueSet,
+    },
+  };
+
+  return {
+    queryName: "HIV screening",
+    queryId: "query-hiv",
+    queryData,
+    conditionsList: [],
+    medicalRecordSections: EMPTY_MEDICAL_RECORD_SECTIONS,
+  };
+}
+
+/**
+ * Builds a mock 200 Response whose clone() re-reads the same bundle.
+ * @param path the request path, echoed into the mock URL
+ * @param bundle the bundle the response body resolves to
+ * @returns a mock Response
+ */
+function mockBundleResponse(path: string, bundle: object): Response {
+  const response = {
+    status: 200,
+    url: `https://example.com/fhir${path}`,
+    json: async () => bundle,
+    clone: () => ({ json: async () => bundle }),
+  };
+  return response as unknown as Response;
+}
+
+const EMPTY_BUNDLE = { resourceType: "Bundle", type: "searchset", entry: [] };
+
+describe("patientRecordsQuery with the epic query strategy", () => {
+  let mockFhirClient: jest.Mocked<FHIRClient>;
+
+  beforeEach(() => {
+    suppressConsoleLogs();
+    jest.clearAllMocks();
+
+    mockFhirClient = {
+      get: jest.fn(),
+      post: jest.fn(),
+      postJson: jest.fn(),
+      getBatch: jest.fn(),
+      getRequestLog: jest.fn().mockReturnValue([]),
+    } as unknown as jest.Mocked<FHIRClient>;
+
+    (prepareFhirClient as jest.Mock).mockResolvedValue(mockFhirClient);
+    (getFhirServerConfigs as jest.Mock).mockResolvedValue([
+      { name: "Epic Server", queryStrategy: "epic" },
+      { name: "Standard Server", queryStrategy: "default" },
+    ]);
+    (getSavedQueryByName as jest.Mock).mockResolvedValue(buildSavedQuery());
+
+    mockFhirClient.get.mockImplementation(async (path: string) =>
+      mockBundleResponse(path, EMPTY_BUNDLE),
+    );
+    mockFhirClient.post.mockImplementation(async (path: string) =>
+      mockBundleResponse(path, EMPTY_BUNDLE),
+    );
+  });
+
+  async function runQuery(fhirServer = "Epic Server") {
+    return patientRecordsQuery({
+      patientId: PATIENT_ID,
+      fhirServer,
+      queryName: "HIV screening",
+    });
+  }
+
+  it("issues GETs (not POST _search) for medications, conditions, and encounters", async () => {
+    const conditionBundle = {
+      resourceType: "Bundle",
+      type: "searchset",
+      entry: [{ resource: { resourceType: "Condition", id: "cond-1" } }],
+    };
+    mockFhirClient.get.mockImplementation(async (path: string) => {
+      if (path.startsWith("/Condition")) {
+        return mockBundleResponse(path, conditionBundle);
+      }
+      return mockBundleResponse(path, EMPTY_BUNDLE);
+    });
+
+    await runQuery();
+
+    const getPaths = mockFhirClient.get.mock.calls.map((c) => c[0] as string);
+    const postPaths = mockFhirClient.post.mock.calls.map((c) => c[0] as string);
+
+    // Epic-incompatible resources go out as GETs...
+    expect(getPaths.find((p) => p.startsWith("/MedicationRequest?"))).toContain(
+      `patient=Patient%2F${PATIENT_ID}`,
+    );
+    expect(
+      getPaths.find((p) => p.startsWith("/MedicationStatement?")),
+    ).toContain(`patient=Patient%2F${PATIENT_ID}`);
+    expect(getPaths.find((p) => p.startsWith("/Condition?"))).toContain(
+      `code=${SNOMED_CODE}`,
+    );
+    // ...with no code filter on the medication searches.
+    expect(
+      getPaths.find((p) => p.startsWith("/MedicationRequest?")),
+    ).not.toContain("code=");
+
+    // The Encounter GET is driven by the returned Condition id.
+    expect(getPaths.find((p) => p.startsWith("/Encounter?"))).toContain(
+      "diagnosis=Condition%2Fcond-1",
+    );
+
+    // None of these resources are POSTed in epic mode; Observation and
+    // DiagnosticReport still use POST _search.
+    expect(postPaths).toEqual(
+      expect.arrayContaining([
+        "/Observation/_search",
+        "/DiagnosticReport/_search",
+      ]),
+    );
+    for (const path of postPaths) {
+      expect(path).not.toMatch(
+        /MedicationRequest|MedicationStatement|Condition|Encounter/,
+      );
+    }
+  });
+
+  it("skips the Encounter search when no Conditions match", async () => {
+    await runQuery();
+
+    const getPaths = mockFhirClient.get.mock.calls.map((c) => c[0] as string);
+    expect(getPaths.some((p) => p.startsWith("/Condition?"))).toBe(true);
+    expect(getPaths.some((p) => p.startsWith("/Encounter?"))).toBe(false);
+  });
+
+  it("still returns other resources when the Condition search fails", async () => {
+    const observation = {
+      resourceType: "Observation",
+      id: "obs-1",
+      status: "final",
+      code: { text: "HIV test" },
+    };
+    mockFhirClient.get.mockImplementation(async (path: string) => {
+      if (path.startsWith("/Condition")) {
+        throw new Error("ECONNRESET");
+      }
+      return mockBundleResponse(path, EMPTY_BUNDLE);
+    });
+    mockFhirClient.post.mockImplementation(async (path: string) => {
+      if (path.startsWith("/Observation")) {
+        return mockBundleResponse(path, {
+          resourceType: "Bundle",
+          type: "searchset",
+          entry: [{ resource: observation }],
+        });
+      }
+      return mockBundleResponse(path, EMPTY_BUNDLE);
+    });
+
+    const result = await runQuery();
+
+    expect(result.Observation).toHaveLength(1);
+    expect(result.Encounter).toBeUndefined();
+  });
+
+  it("filters medication resources to the query's codes client-side", async () => {
+    const medicationBundle = {
+      resourceType: "Bundle",
+      type: "searchset",
+      entry: [
+        {
+          resource: {
+            resourceType: "MedicationRequest",
+            id: "mr-match",
+            status: "active",
+            intent: "order",
+            subject: { reference: `Patient/${PATIENT_ID}` },
+            medicationReference: { reference: "Medication/med-match" },
+          },
+        },
+        {
+          resource: {
+            resourceType: "MedicationRequest",
+            id: "mr-other",
+            status: "active",
+            intent: "order",
+            subject: { reference: `Patient/${PATIENT_ID}` },
+            medicationReference: { reference: "Medication/med-other" },
+          },
+        },
+        {
+          resource: {
+            resourceType: "Medication",
+            id: "med-match",
+            code: { coding: [{ code: RXNORM_CODE }] },
+          },
+        },
+        {
+          resource: {
+            resourceType: "Medication",
+            id: "med-other",
+            code: { coding: [{ code: OTHER_RXNORM_CODE }] },
+          },
+        },
+      ],
+    };
+    mockFhirClient.get.mockImplementation(async (path: string) => {
+      if (path.startsWith("/MedicationRequest")) {
+        return mockBundleResponse(path, medicationBundle);
+      }
+      return mockBundleResponse(path, EMPTY_BUNDLE);
+    });
+
+    const result = await runQuery();
+
+    expect(result.MedicationRequest?.map((r) => r.id)).toEqual(["mr-match"]);
+    expect(result.Medication?.map((m) => m.id)).toEqual(["med-match"]);
+  });
+
+  it("keeps the default POST _search behavior for default-strategy servers", async () => {
+    await runQuery("Standard Server");
+
+    const postPaths = mockFhirClient.post.mock.calls.map((c) => c[0] as string);
+    expect(postPaths).toEqual(
+      expect.arrayContaining([
+        "/MedicationRequest/_search",
+        "/MedicationStatement/_search",
+        "/Condition/_search",
+        "/Encounter/_search",
+      ]),
+    );
+    const getPaths = mockFhirClient.get.mock.calls.map((c) => c[0] as string);
+    expect(getPaths.some((p) => p.startsWith("/Condition?"))).toBe(false);
+  });
+});

--- a/src/app/backend/query-execution/medication-filter.test.ts
+++ b/src/app/backend/query-execution/medication-filter.test.ts
@@ -1,0 +1,245 @@
+import {
+  Medication,
+  MedicationAdministration,
+  MedicationRequest,
+  MedicationStatement,
+} from "fhir/r4";
+import { QueryResponse } from "@/app/models/entities/query";
+import { filterMedicationResourcesByCode } from "./medication-filter";
+
+const MATCHING_CODE = "1665005";
+const OTHER_CODE = "999999";
+
+function makeRequest(
+  id: string,
+  overrides: Partial<MedicationRequest> = {},
+): MedicationRequest {
+  return {
+    resourceType: "MedicationRequest",
+    id,
+    status: "active",
+    intent: "order",
+    subject: { reference: "Patient/p1" },
+    ...overrides,
+  };
+}
+
+function makeStatement(
+  id: string,
+  overrides: Partial<MedicationStatement> = {},
+): MedicationStatement {
+  return {
+    resourceType: "MedicationStatement",
+    id,
+    status: "active",
+    subject: { reference: "Patient/p1" },
+    ...overrides,
+  };
+}
+
+function makeMedication(id: string, code: string): Medication {
+  return {
+    resourceType: "Medication",
+    id,
+    code: {
+      coding: [{ system: "http://www.nlm.nih.gov/research/umls/rxnorm", code }],
+    },
+  };
+}
+
+describe("filterMedicationResourcesByCode", () => {
+  it("keeps requests whose medicationCodeableConcept matches and drops others", () => {
+    const response: QueryResponse = {
+      MedicationRequest: [
+        makeRequest("match", {
+          medicationCodeableConcept: {
+            coding: [{ code: MATCHING_CODE }],
+          },
+        }),
+        makeRequest("no-match", {
+          medicationCodeableConcept: {
+            coding: [{ code: OTHER_CODE }],
+          },
+        }),
+      ],
+    };
+
+    const filtered = filterMedicationResourcesByCode(response, [MATCHING_CODE]);
+    expect(filtered.MedicationRequest?.map((r) => r.id)).toEqual(["match"]);
+  });
+
+  it("resolves medicationReference against returned Medication resources", () => {
+    const response: QueryResponse = {
+      MedicationRequest: [
+        makeRequest("match", {
+          medicationReference: { reference: "Medication/med-1" },
+        }),
+        makeRequest("no-match", {
+          medicationReference: { reference: "Medication/med-2" },
+        }),
+      ],
+      Medication: [
+        makeMedication("med-1", MATCHING_CODE),
+        makeMedication("med-2", OTHER_CODE),
+      ],
+    };
+
+    const filtered = filterMedicationResourcesByCode(response, [MATCHING_CODE]);
+    expect(filtered.MedicationRequest?.map((r) => r.id)).toEqual(["match"]);
+    // Medication for the dropped request should be pruned too
+    expect(filtered.Medication?.map((m) => m.id)).toEqual(["med-1"]);
+  });
+
+  it("resolves absolute-URL medication references", () => {
+    const response: QueryResponse = {
+      MedicationRequest: [
+        makeRequest("match", {
+          medicationReference: {
+            reference: "https://fhir.example.com/api/FHIR/R4/Medication/med-1",
+          },
+        }),
+      ],
+      Medication: [makeMedication("med-1", MATCHING_CODE)],
+    };
+
+    const filtered = filterMedicationResourcesByCode(response, [MATCHING_CODE]);
+    expect(filtered.MedicationRequest?.map((r) => r.id)).toEqual(["match"]);
+  });
+
+  it("resolves contained Medication resources via local references", () => {
+    const response: QueryResponse = {
+      MedicationRequest: [
+        makeRequest("match", {
+          medicationReference: { reference: "#local-med" },
+          contained: [
+            {
+              ...makeMedication("local-med", MATCHING_CODE),
+            },
+          ],
+        }),
+        makeRequest("no-match", {
+          medicationReference: { reference: "#local-med" },
+          contained: [
+            {
+              ...makeMedication("local-med", OTHER_CODE),
+            },
+          ],
+        }),
+      ],
+    };
+
+    const filtered = filterMedicationResourcesByCode(response, [MATCHING_CODE]);
+    expect(filtered.MedicationRequest?.map((r) => r.id)).toEqual(["match"]);
+  });
+
+  it("fails open for resources whose medication codes can't be determined", () => {
+    const warnSpy = jest.spyOn(console, "warn").mockImplementation(() => {});
+    const response: QueryResponse = {
+      MedicationRequest: [
+        makeRequest("unresolvable-ref", {
+          medicationReference: { reference: "Medication/not-returned" },
+        }),
+        makeRequest("no-medication-at-all"),
+      ],
+    };
+
+    const filtered = filterMedicationResourcesByCode(response, [MATCHING_CODE]);
+    expect(filtered.MedicationRequest?.map((r) => r.id)).toEqual([
+      "unresolvable-ref",
+      "no-medication-at-all",
+    ]);
+    expect(warnSpy).toHaveBeenCalled();
+    warnSpy.mockRestore();
+  });
+
+  it("filters MedicationStatements the same way", () => {
+    const response: QueryResponse = {
+      MedicationStatement: [
+        makeStatement("match", {
+          medicationCodeableConcept: { coding: [{ code: MATCHING_CODE }] },
+        }),
+        makeStatement("no-match", {
+          medicationCodeableConcept: { coding: [{ code: OTHER_CODE }] },
+        }),
+      ],
+    };
+
+    const filtered = filterMedicationResourcesByCode(response, [MATCHING_CODE]);
+    expect(filtered.MedicationStatement?.map((s) => s.id)).toEqual(["match"]);
+  });
+
+  it("prunes MedicationAdministrations whose request was dropped", () => {
+    const administrations: MedicationAdministration[] = [
+      {
+        resourceType: "MedicationAdministration",
+        id: "admin-kept",
+        status: "completed",
+        subject: { reference: "Patient/p1" },
+        medicationCodeableConcept: { coding: [{ code: MATCHING_CODE }] },
+        effectiveDateTime: "2024-01-01",
+        request: { reference: "MedicationRequest/match" },
+      },
+      {
+        resourceType: "MedicationAdministration",
+        id: "admin-dropped",
+        status: "completed",
+        subject: { reference: "Patient/p1" },
+        medicationCodeableConcept: { coding: [{ code: OTHER_CODE }] },
+        effectiveDateTime: "2024-01-01",
+        request: { reference: "MedicationRequest/no-match" },
+      },
+    ];
+    const response: QueryResponse = {
+      MedicationRequest: [
+        makeRequest("match", {
+          medicationCodeableConcept: { coding: [{ code: MATCHING_CODE }] },
+        }),
+        makeRequest("no-match", {
+          medicationCodeableConcept: { coding: [{ code: OTHER_CODE }] },
+        }),
+      ],
+      MedicationAdministration: administrations,
+    };
+
+    const filtered = filterMedicationResourcesByCode(response, [MATCHING_CODE]);
+    expect(filtered.MedicationAdministration?.map((a) => a.id)).toEqual([
+      "admin-kept",
+    ]);
+  });
+
+  it("removes resource-type keys whose arrays become empty", () => {
+    const response: QueryResponse = {
+      MedicationRequest: [
+        makeRequest("no-match", {
+          medicationCodeableConcept: { coding: [{ code: OTHER_CODE }] },
+        }),
+      ],
+      Medication: [makeMedication("med-1", OTHER_CODE)],
+    };
+
+    const filtered = filterMedicationResourcesByCode(response, [MATCHING_CODE]);
+    expect(filtered.MedicationRequest).toBeUndefined();
+    expect(filtered.Medication).toBeUndefined();
+  });
+
+  it("leaves other resource types untouched", () => {
+    const response: QueryResponse = {
+      Patient: [{ resourceType: "Patient", id: "p1" }],
+      MedicationRequest: [
+        makeRequest("no-match", {
+          medicationCodeableConcept: { coding: [{ code: OTHER_CODE }] },
+        }),
+      ],
+    };
+
+    const filtered = filterMedicationResourcesByCode(response, [MATCHING_CODE]);
+    expect(filtered.Patient?.map((p) => p.id)).toEqual(["p1"]);
+  });
+
+  it("no-ops when the code list is empty", () => {
+    const response: QueryResponse = {
+      MedicationRequest: [makeRequest("kept")],
+    };
+    expect(filterMedicationResourcesByCode(response, [])).toBe(response);
+  });
+});

--- a/src/app/backend/query-execution/medication-filter.ts
+++ b/src/app/backend/query-execution/medication-filter.ts
@@ -1,0 +1,191 @@
+import {
+  FhirResource,
+  Medication,
+  MedicationAdministration,
+  MedicationRequest,
+  MedicationStatement,
+} from "fhir/r4";
+import { QueryResponse } from "@/app/models/entities/query";
+
+/**
+ * Client-side medication code filtering for servers whose search API can't
+ * filter medications by code (Epic supports only patient/category/status/date
+ * parameters on MedicationRequest and MedicationStatement searches, so those
+ * queries return every medication in the patient's record).
+ *
+ * Filtering fails open: a MedicationRequest/MedicationStatement whose
+ * medication codes can't be determined (e.g. a medicationReference pointing at
+ * a Medication resource the server didn't return because it ignored our
+ * _include) is kept rather than dropped, since over-inclusion is safer for
+ * case investigation than silently discarding records.
+ */
+
+type MedicationOrder = MedicationRequest | MedicationStatement;
+
+function buildMedicationIndex(
+  medications: Medication[],
+): Map<string, Medication> {
+  const index = new Map<string, Medication>();
+  medications.forEach((medication) => {
+    if (medication.id) {
+      index.set(medication.id, medication);
+    }
+  });
+  return index;
+}
+
+/**
+ * Resolves the Medication a request/statement refers to, checking contained
+ * resources for local (#id) references and the fetched Medication resources
+ * otherwise. Handles relative (Medication/{id}) and absolute URL references.
+ * @param resource the medication order to resolve
+ * @param medicationIndex fetched Medication resources indexed by id
+ * @returns the referenced Medication, or undefined if it can't be resolved
+ */
+function resolveMedication(
+  resource: MedicationOrder,
+  medicationIndex: Map<string, Medication>,
+): Medication | undefined {
+  const reference = resource.medicationReference?.reference;
+  if (!reference) return undefined;
+
+  if (reference.startsWith("#")) {
+    const localId = reference.slice(1);
+    return resource.contained?.find(
+      (contained): contained is Medication =>
+        (contained as FhirResource).resourceType === "Medication" &&
+        contained.id === localId,
+    );
+  }
+
+  const idMatch = reference.match(/(?:^|\/)Medication\/([^/?]+)/);
+  const id = idMatch ? idMatch[1] : reference;
+  return medicationIndex.get(id);
+}
+
+/**
+ * Determines whether a medication order matches the filter codes, or null when
+ * its codes can't be determined at all (unresolvable reference / no coding).
+ * @param resource the medication order to check
+ * @param codeSet the query's medication codes
+ * @param medicationIndex fetched Medication resources indexed by id
+ * @returns true/false when a match could be evaluated, null when it couldn't
+ */
+function medicationOrderMatches(
+  resource: MedicationOrder,
+  codeSet: Set<string>,
+  medicationIndex: Map<string, Medication>,
+): boolean | null {
+  // The default query path's server-side `code=` filter is also system-less,
+  // so matching on bare coding values keeps behavior consistent across paths.
+  const inlineCodings = resource.medicationCodeableConcept?.coding;
+  if (inlineCodings && inlineCodings.length > 0) {
+    return inlineCodings.some(
+      (c) => c.code !== undefined && codeSet.has(c.code),
+    );
+  }
+
+  const medication = resolveMedication(resource, medicationIndex);
+  const medicationCodings = medication?.code?.coding;
+  if (medicationCodings && medicationCodings.length > 0) {
+    return medicationCodings.some(
+      (c) => c.code !== undefined && codeSet.has(c.code),
+    );
+  }
+
+  return null;
+}
+
+function referencedMedicationKey(
+  resource: MedicationOrder,
+): string | undefined {
+  const reference = resource.medicationReference?.reference;
+  if (!reference || reference.startsWith("#")) return undefined;
+  const idMatch = reference.match(/(?:^|\/)Medication\/([^/?]+)/);
+  return idMatch ? idMatch[1] : reference;
+}
+
+/**
+ * Filters the MedicationRequest and MedicationStatement resources in a query
+ * response down to those matching the given medication (RxNorm) codes, and
+ * prunes Medication / MedicationAdministration resources that were only
+ * present in support of dropped orders. Resources whose medication codes
+ * can't be determined are kept (fail open). Resource-type keys whose arrays
+ * become empty are removed, matching how absent resource types are
+ * represented elsewhere.
+ * @param queryResponse parsed query response to filter
+ * @param medicationCodes the query's medication codes
+ * @returns a new QueryResponse with non-matching medication resources removed
+ */
+export function filterMedicationResourcesByCode(
+  queryResponse: QueryResponse,
+  medicationCodes: string[],
+): QueryResponse {
+  if (medicationCodes.length === 0) return queryResponse;
+
+  const codeSet = new Set(medicationCodes);
+  const medicationIndex = buildMedicationIndex(queryResponse.Medication ?? []);
+
+  let unresolvableCount = 0;
+  const filterOrders = <T extends MedicationOrder>(orders: T[]): T[] =>
+    orders.filter((order) => {
+      const matches = medicationOrderMatches(order, codeSet, medicationIndex);
+      if (matches === null) {
+        unresolvableCount += 1;
+        return true;
+      }
+      return matches;
+    });
+
+  const keptRequests = filterOrders(queryResponse.MedicationRequest ?? []);
+  const keptStatements = filterOrders(queryResponse.MedicationStatement ?? []);
+
+  if (unresolvableCount > 0) {
+    console.warn(
+      "Medication code filtering kept %s medication resource(s) whose codes could not be determined (unresolvable or missing medication reference)",
+      unresolvableCount,
+    );
+  }
+
+  // Keep a Medication only when a kept order still references it.
+  const referencedMedicationIds = new Set(
+    [...keptRequests, ...keptStatements]
+      .map(referencedMedicationKey)
+      .filter((id): id is string => id !== undefined),
+  );
+  const keptMedications = (queryResponse.Medication ?? []).filter(
+    (medication) =>
+      medication.id !== undefined && referencedMedicationIds.has(medication.id),
+  );
+
+  // MedicationAdministrations arrive via _revinclude on their request; keep
+  // them only when that request was kept. Fail open for any without a
+  // resolvable request reference.
+  const keptRequestIds = new Set(
+    keptRequests
+      .map((request) => request.id)
+      .filter((id): id is string => id !== undefined),
+  );
+  const keptAdministrations = (
+    queryResponse.MedicationAdministration ?? []
+  ).filter((administration: MedicationAdministration) => {
+    const requestRef = administration.request?.reference;
+    if (!requestRef) return true;
+    const idMatch = requestRef.match(/(?:^|\/)MedicationRequest\/([^/?]+)/);
+    if (!idMatch) return true;
+    return keptRequestIds.has(idMatch[1]);
+  });
+
+  const filtered: QueryResponse = { ...queryResponse };
+  if (keptRequests.length > 0) filtered.MedicationRequest = keptRequests;
+  else delete filtered.MedicationRequest;
+  if (keptStatements.length > 0) filtered.MedicationStatement = keptStatements;
+  else delete filtered.MedicationStatement;
+  if (keptMedications.length > 0) filtered.Medication = keptMedications;
+  else delete filtered.Medication;
+  if (keptAdministrations.length > 0)
+    filtered.MedicationAdministration = keptAdministrations;
+  else delete filtered.MedicationAdministration;
+
+  return filtered;
+}

--- a/src/app/backend/query-execution/patient-records-resilience.test.ts
+++ b/src/app/backend/query-execution/patient-records-resilience.test.ts
@@ -1,5 +1,8 @@
 import { patientRecordsQuery } from "./service";
-import { prepareFhirClient } from "@/app/backend/fhir-servers/service";
+import {
+  getFhirServerConfigs,
+  prepareFhirClient,
+} from "@/app/backend/fhir-servers/service";
 import { getSavedQueryByName } from "@/app/backend/query-building/service";
 import FHIRClient from "@/app/backend/fhir-servers/fhir-client";
 import {
@@ -100,6 +103,9 @@ describe("patientRecordsQuery fault isolation", () => {
     } as unknown as jest.Mocked<FHIRClient>;
 
     (prepareFhirClient as jest.Mock).mockResolvedValue(mockFhirClient);
+    (getFhirServerConfigs as jest.Mock).mockResolvedValue([
+      { name: "Test Server", queryStrategy: "default" },
+    ]);
     (getSavedQueryByName as jest.Mock).mockResolvedValue(buildSavedQuery());
   });
 

--- a/src/app/backend/query-execution/service.ts
+++ b/src/app/backend/query-execution/service.ts
@@ -572,8 +572,10 @@ class QueryService {
       .filter((v): v is Response => !!v);
 
     // Pull matching Condition ids out of the successful responses. Bodies are
-    // cloned because parseFhirSearch reads them again downstream.
-    const conditionIds: string[] = [];
+    // cloned because parseFhirSearch reads them again downstream. A Set
+    // dedupes Conditions returned by more than one chunked code query (a
+    // Condition with several codings can match codes in different chunks).
+    const conditionIds = new Set<string>();
     for (const response of conditionResponses) {
       if (response.status !== 200) continue;
       try {
@@ -581,7 +583,7 @@ class QueryService {
         bundle.entry?.forEach((entry) => {
           const resource = entry.resource as FhirResource | undefined;
           if (resource?.resourceType === "Condition" && resource.id) {
-            conditionIds.push(resource.id);
+            conditionIds.add(resource.id);
           }
         });
       } catch (error) {
@@ -592,7 +594,7 @@ class QueryService {
       }
     }
 
-    if (conditionIds.length === 0) {
+    if (conditionIds.size === 0) {
       console.log(
         "Epic query strategy: no Conditions matched the query codes; skipping the Encounter search",
       );
@@ -601,7 +603,7 @@ class QueryService {
 
     const encounterResults = await Promise.allSettled(
       builtQuery
-        .compileEpicEncounterQueries(conditionIds)
+        .compileEpicEncounterQueries([...conditionIds])
         .map(({ basePath, params }) => fhirClient.get(`${basePath}?${params}`)),
     );
     const encounterResponses = encounterResults

--- a/src/app/backend/query-execution/service.ts
+++ b/src/app/backend/query-execution/service.ts
@@ -4,6 +4,7 @@ import { Bundle, FhirResource, Patient, Task } from "fhir/r4";
 import { isFhirResource } from "../../constants";
 
 import { CustomQuery } from "./custom-query";
+import { filterMedicationResourcesByCode } from "./medication-filter";
 import { GetPhoneQueryFormats } from "../../utils/format-service";
 import { auditable } from "../audit-logs/decorator";
 import type { QueryTableResult } from "../../(pages)/queryBuilding/utils";
@@ -417,8 +418,13 @@ class QueryService {
     fhirServer: string,
   ) {
     const fhirClient = await prepareFhirClient(fhirServer);
+    const serverConfigs = await getFhirServerConfigs();
+    const serverConfig = serverConfigs.find(
+      (config) => config.name === fhirServer,
+    );
+    const queryStrategy = serverConfig?.queryStrategy ?? "default";
     const medicalRecordSections = savedQuery.medicalRecordSections;
-    const builtQuery = new CustomQuery(savedQuery, patientId);
+    const builtQuery = new CustomQuery(savedQuery, patientId, queryStrategy);
 
     const medicalRecordSectionResults: Response[] = [];
     // Each medical-record-section request is isolated in its own try/catch so a
@@ -461,17 +467,35 @@ class QueryService {
       }
     }
 
-    const postPromises = builtQuery.compileAllPostRequests().map((req) => {
-      return fhirClient.post(req.path, req.params);
-    });
+    const postPromises: Promise<Response | Response[]>[] = builtQuery
+      .compileAllPostRequests()
+      .map((req) => {
+        return fhirClient.post(req.path, req.params);
+      });
+
+    if (queryStrategy === "epic") {
+      // Epic doesn't support POST _search (or server-side code filtering) for
+      // these resources, so they're issued as GETs alongside the POST batch.
+      // Medication results are filtered to the query's codes downstream.
+      for (const key of ["medicationRequest", "medicationStatement"]) {
+        const { basePath, params } = builtQuery.getQuery(key);
+        if (basePath !== "") {
+          postPromises.push(fhirClient.get(`${basePath}?${params}`));
+        }
+      }
+      postPromises.push(
+        QueryService.runEpicConditionEncounterChain(fhirClient, builtQuery),
+      );
+    }
 
     const postResults = await Promise.allSettled(postPromises);
     const fulfilledResults = postResults
-      .map((r) => {
+      .flatMap((r) => {
         if (r.status === "fulfilled") {
-          return r.value;
+          return Array.isArray(r.value) ? r.value : [r.value];
         } else {
-          console.error("POST to FHIR query promise rejected: ", r.reason);
+          console.error("FHIR query promise rejected: ", r.reason);
+          return [];
         }
       })
       .filter((v): v is Response => !!v);
@@ -510,7 +534,84 @@ class QueryService {
     return {
       responses: successfulResults,
       requests: fhirClient.getRequestLog(),
+      medicationFilterCodes:
+        queryStrategy === "epic" ? builtQuery.medicationCodes : undefined,
     };
+  }
+
+  /**
+   * Epic-mode two-step Encounter retrieval. Epic's Encounter reason-code
+   * search matches text rather than SNOMED codes, so Encounters are found by
+   * first fetching the patient's Conditions that match the query codes, then
+   * searching Encounters whose diagnosis references those Conditions. The
+   * Condition responses are returned alongside the Encounter responses (they
+   * replace the default-mode Condition POST _search).
+   * @param fhirClient - client for the FHIR server being queried
+   * @param builtQuery - the compiled CustomQuery
+   * @returns the Condition and Encounter responses that succeeded
+   */
+  private static async runEpicConditionEncounterChain(
+    fhirClient: FHIRClient,
+    builtQuery: CustomQuery,
+  ): Promise<Response[]> {
+    const conditionQueries = builtQuery.compileEpicConditionQueries();
+    if (conditionQueries.length === 0) {
+      return [];
+    }
+
+    const conditionResults = await Promise.allSettled(
+      conditionQueries.map(({ basePath, params }) =>
+        fhirClient.get(`${basePath}?${params}`),
+      ),
+    );
+    const conditionResponses = conditionResults
+      .map((r) => {
+        if (r.status === "fulfilled") return r.value;
+        console.error("Epic Condition FHIR query rejected: ", r.reason);
+      })
+      .filter((v): v is Response => !!v);
+
+    // Pull matching Condition ids out of the successful responses. Bodies are
+    // cloned because parseFhirSearch reads them again downstream.
+    const conditionIds: string[] = [];
+    for (const response of conditionResponses) {
+      if (response.status !== 200) continue;
+      try {
+        const bundle = (await response.clone().json()) as Bundle;
+        bundle.entry?.forEach((entry) => {
+          const resource = entry.resource as FhirResource | undefined;
+          if (resource?.resourceType === "Condition" && resource.id) {
+            conditionIds.push(resource.id);
+          }
+        });
+      } catch (error) {
+        console.error(
+          "Failed to parse Epic Condition response for Encounter chaining: ",
+          error,
+        );
+      }
+    }
+
+    if (conditionIds.length === 0) {
+      console.log(
+        "Epic query strategy: no Conditions matched the query codes; skipping the Encounter search",
+      );
+      return conditionResponses;
+    }
+
+    const encounterResults = await Promise.allSettled(
+      builtQuery
+        .compileEpicEncounterQueries(conditionIds)
+        .map(({ basePath, params }) => fhirClient.get(`${basePath}?${params}`)),
+    );
+    const encounterResponses = encounterResults
+      .map((r) => {
+        if (r.status === "fulfilled") return r.value;
+        console.error("Epic Encounter FHIR query rejected: ", r.reason);
+      })
+      .filter((v): v is Response => !!v);
+
+    return [...conditionResponses, ...encounterResponses];
   }
 
   @auditable
@@ -780,14 +881,23 @@ class QueryService {
       throw new Error(`Unable to query of name ${request?.queryName}`);
     }
 
-    const { responses, requests } =
+    const { responses, requests, medicationFilterCodes } =
       await QueryService.makePatientRecordsRequest(
         savedQuery,
         request.patientId,
         request.fhirServer,
       );
 
-    const queryResponse = await QueryService.parseFhirSearch(responses);
+    let queryResponse = await QueryService.parseFhirSearch(responses);
+
+    // Set when the server's search API couldn't filter medications by code
+    // (Epic); apply the query's medication codes client-side instead.
+    if (medicationFilterCodes && medicationFilterCodes.length > 0) {
+      queryResponse = filterMedicationResourcesByCode(
+        queryResponse,
+        medicationFilterCodes,
+      );
+    }
 
     return { ...queryResponse, fhirRequests: requests };
   }

--- a/src/app/models/entities/fhir-servers.ts
+++ b/src/app/models/entities/fhir-servers.ts
@@ -1,6 +1,10 @@
 // Add this to your FhirServerConfig interface in models/entities/fhir-servers.ts
 
-import { AuthMethodType, EndpointType } from "@/app/(pages)/fhirServers/page";
+import {
+  AuthMethodType,
+  EndpointType,
+  QueryStrategy,
+} from "@/app/(pages)/fhirServers/page";
 
 export interface FhirServerConfig {
   id: string;
@@ -9,6 +13,7 @@ export interface FhirServerConfig {
   disableCertValidation: boolean;
   defaultServer: boolean;
   endpointType?: EndpointType;
+  queryStrategy?: QueryStrategy;
   lastConnectionSuccessful?: boolean;
   lastConnectionAttempt?: string;
   headers?: Record<string, string>;

--- a/src/app/tests/integration/fhir-servers.test.ts
+++ b/src/app/tests/integration/fhir-servers.test.ts
@@ -58,6 +58,7 @@ describe("FHIR Servers tests", () => {
     expect(newServer?.name).toBe(TEST_FHIR_SERVER.name);
     expect(newServer?.hostname).toBe(TEST_FHIR_SERVER.hostname);
     expect(newServer?.authType).toBe("none");
+    expect(newServer?.queryStrategy).toBe("default");
 
     //update works
     const NEW_NAME = "Kongo Jungle Two";
@@ -70,12 +71,14 @@ describe("FHIR Servers tests", () => {
       defaultServer: false,
       authData: {
         authType: "none",
+        queryStrategy: "epic",
       },
     });
     newFhirServers = await getFhirServerConfigs(true);
     const shouldBeUpdated = newFhirServers.find((v) => v.name === NEW_NAME);
     expect(shouldBeUpdated?.name).toBe(NEW_NAME);
     expect(shouldBeUpdated?.hostname).toBe(NEW_HOSTNAME);
+    expect(shouldBeUpdated?.queryStrategy).toBe("epic");
 
     // deletion works
     await deleteFhirServer(newServer?.id as string);

--- a/src/docs/fhir-connection-guide.mdx
+++ b/src/docs/fhir-connection-guide.mdx
@@ -160,10 +160,35 @@ On the "New server" page, complete the following fields:
 
 1. Server name: a clear label (e.g., Stanford (Non-Prod) or Cedars (Prod)).
 2. URL: the HCO's Epic FHIR base URL for the correct environment
-3. Auth Method: SMART on FHIR
-4. Custom Headers:
+3. Query Strategy: Epic (see below)
+4. Auth Method: SMART on FHIR
+5. Custom Headers:
    - Accept: application/fhir+json
    - Content-Type: application/fhir+json; charset=UTF-8
+
+#### Query Strategy: Epic
+
+Set Query Strategy to "Epic" for any Epic-based FHIR server, whether QC
+connects to it directly or through a proxy such as eHealthExchange. Epic's
+FHIR search API differs from the FHIR specification defaults in a few ways
+that would otherwise cause queries to silently return incomplete records:
+
+- Epic does not support `POST /MedicationStatement/_search` (it returns
+  404), and its MedicationRequest/MedicationStatement searches can't filter
+  by medication code. With the Epic strategy, QC retrieves all of the
+  patient's medication records via GET and filters them to the query's
+  RxNorm codes within QC itself. If Epic doesn't return the referenced
+  Medication resources needed to determine a record's code, QC keeps the
+  record rather than dropping it (over-inclusion is safer than silently
+  missing medications).
+- Epic's Encounter `reason-code` search matches display text rather than
+  SNOMED codes. With the Epic strategy, QC instead searches the patient's
+  Conditions for the query's codes, then finds Encounters whose diagnosis
+  references those Conditions. If no Conditions match, the Encounter search
+  is skipped.
+
+Observation and DiagnosticReport queries are unaffected — Epic supports
+code-filtered searches for those natively.
 
 Optional settings:
 


### PR DESCRIPTION
## Context

Southern Nevada Health District's test queries against UMC's Epic FHIR server (through the eHealthExchange proxy) returned patient demographics but no medications, and no encounter/treatment data. eHealthExchange (Keith Brick) confirmed three Epic search incompatibilities:

1. Epic returns **404 for `POST /MedicationStatement/_search`** — only GET search is supported ([Epic docs](https://fhir.epic.com/Specifications?api=997)).
2. Epic's **MedicationRequest search supports only** `patient, subject, category, status, authoredon, date, intent` — no `code` param, so filtering to specific medications must happen after retrieval.
3. Epic's **Encounter `reason-code` search matches display text**, not SNOMED codes, so our code-list search silently returns nothing. Epic's recommended flow is to search the patient's Conditions first, then search Encounters by `diagnosis={Condition references}`.

Epic's POST `_search` support is only reliable for Observation and DiagnosticReport (native LOINC code params), so those queries are unchanged.

## What this PR does

Adds a per-server **Query Strategy** setting (`Standard` / `Epic`) in the FHIR Servers modal, stored in a new `query_strategy` column (migration `V01_04`). It is orthogonal to Endpoint Type, which routes patient discovery. When set to Epic:

| Resource | Default behavior | Epic behavior |
|---|---|---|
| MedicationRequest | POST `_search` with `code` filter | GET, patient-scoped, `_count=1000`, no `code`; results filtered to the query's RxNorm codes client-side |
| MedicationStatement | POST `_search` (404s on Epic) | GET, patient-scoped, same client-side filtering |
| Condition | POST `_search` | GET with chunked `code` lists |
| Encounter | POST `_search` by `reason-code` | Two-step: Condition GETs first, then GET `Encounter?patient=...&diagnosis=Condition/{id},...` (chunked); skipped with a log line when no Conditions match |
| Observation / DiagnosticReport / others | unchanged | unchanged |

The new `medication-filter.ts` module matches records via `medicationCodeableConcept`, contained Medications, or `_include`d Medication resources, and prunes orphaned Medication/MedicationAdministration companions. It **fails open**: records whose codes can't be determined (e.g. Epic ignored our `_include`) are kept with a warning, so medications are never silently dropped. Default-strategy servers behave exactly as before (regression-tested), and each Epic request keeps the existing per-resource fault isolation.

## Testing

- `custom-query.test.ts`: Epic vs default query shapes, chunking, default-mode regression assertions
- `medication-filter.test.ts` (new): matching paths, fail-open, companion pruning
- `epic-strategy.test.ts` (new): end-to-end `patientRecordsQuery` with a mocked FHIR client — GET/POST dispatch, Condition→Encounter chaining, skip-on-no-conditions, fault isolation, client-side filtering
- Integration: `fhir-servers.test.ts` round-trips `queryStrategy` persistence through the real DB/migration
- Full suites pass: lint, 242 unit tests, 104 integration tests

## Known limitations / follow-ups

- Query Connector doesn't follow bundle `next` links; `_count=1000` mitigates truncation of the broad Epic medication searches but a patient with more records than Epic's page cap would be truncated.
- If Epic ignores `_include`/`_revinclude`, medication filtering fails open (unfiltered list + warning) and MedicationAdministration may be empty; a follow-up could batch-GET unresolved Medication references.
- Scenario 2 (HIV) test data is flagged sensitive in Epic — retrieving it also depends on UMC authorizing the eHealthExchange Background User for those categories, which is outside QC's control.