### PR TITLE
chore: group Dependabot npm updates into minor/patch and majors PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,14 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    open-pull-requests-limit: 10
+    groups:
+      minor-and-patch:
+        applies-to: version-updates
+        update-types: ["minor", "patch"]
+      majors:
+        applies-to: version-updates
+        update-types: ["major"]
     ignore:
       - dependency-name: "jose"
         update-types: ["version-update:semver-major"]


### PR DESCRIPTION
Adds `groups` to the npm Dependabot config so version updates arrive as one weekly PR for all minor/patch bumps and one for majors, instead of trickling out 5 individual PRs at a time. Also raises `open-pull-requests-limit` to 10.

On its next run Dependabot will supersede the currently open individual PRs (#979–#982) with grouped ones — and now that the Dependabot secrets store has `AIDBOX_LICENSE`/`MTLS_CERT_B64`/`MTLS_KEY_B64`/`CODECOV_TOKEN` mirrored, those grouped PRs should pass the full CI suite including e2e.