### PR TITLE
test: Expand e2e test coverage across recent features and untested pages

### DIFF
--- a/e2e/audit_logs.spec.ts
+++ b/e2e/audit_logs.spec.ts
@@ -1,0 +1,60 @@
+import { test, expect, Page } from "@playwright/test";
+import { TEST_URL } from "../playwright-setup";
+import { DEFAULT_FHIR_SERVER } from "./constants";
+import { runAxeAccessibilityChecks } from "./utils";
+
+// A patient discovery query is an audited action ("makePatientDiscoveryRequest").
+// The seed inserts data directly (no audit rows), so generate one entry here to
+// guarantee the log table is populated regardless of what other specs have run.
+async function generateAuditEntry(page: Page) {
+  await page.goto(TEST_URL);
+  await page.getByRole("button", { name: "Fill fields" }).click();
+  await page.getByRole("button", { name: "Advanced" }).click();
+  await page
+    .getByLabel("Healthcare Organization (HCO)")
+    .selectOption(DEFAULT_FHIR_SERVER);
+  await page.getByRole("button", { name: "Search for patient" }).click();
+  await expect(page.getByText("Loading")).toHaveCount(0, { timeout: 10000 });
+}
+
+test.describe("Audit logs", () => {
+  test.beforeEach(async ({ page }) => {
+    await generateAuditEntry(page);
+    await page.goto(`${TEST_URL}/auditLogs`);
+    await expect(
+      page.getByRole("heading", { name: "Audit Log" }),
+    ).toBeVisible();
+  });
+
+  test("loads the audit log table", async ({ page }) => {
+    // At least one audited action is present, so the table shows rows and the
+    // "Showing X - Y of Z actions" summary.
+    await expect(page.locator("tbody tr").first()).toBeVisible();
+    await expect(page.getByText(/Showing/)).toBeVisible();
+    await runAxeAccessibilityChecks(page);
+  });
+
+  test("search filters rows and shows the empty state", async ({ page }) => {
+    await expect(page.locator("tbody tr").first()).toBeVisible();
+
+    // A search term that matches nothing yields the empty state.
+    await page.locator("#search").fill("zzzznomatchzzzz");
+    await expect(page.getByText("No results found.")).toBeVisible();
+
+    // Clearing the filters restores the rows.
+    await page.getByRole("button", { name: "Clear filters" }).click();
+    await expect(page.locator("tbody tr").first()).toBeVisible();
+  });
+
+  test("opens the detail drawer for a log entry", async ({ page }) => {
+    await page.locator("tbody tr").first().click();
+
+    const drawer = page.getByTestId("drawer-title");
+    await expect(drawer).toBeVisible();
+    await expect(drawer).toContainText("Full JSON request");
+    await runAxeAccessibilityChecks(page);
+
+    await page.getByRole("button", { name: "Close drawer" }).click();
+    await expect(drawer).not.toBeVisible();
+  });
+});

--- a/e2e/code_library.spec.ts
+++ b/e2e/code_library.spec.ts
@@ -1,0 +1,55 @@
+import { test, expect } from "@playwright/test";
+import { TEST_URL } from "../playwright-setup";
+import { runAxeAccessibilityChecks } from "./utils";
+
+// The Code library page opens in "manage" mode when navigated to directly
+// (no query context), which renders the "Manage codes" heading and the
+// "table-valuesets-manage" value-set list.
+test.describe("Code library", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto(`${TEST_URL}/codeLibrary`);
+    await expect(
+      page.getByRole("heading", { name: "Manage codes" }),
+    ).toBeVisible();
+  });
+
+  test("loads and lists value sets", async ({ page }) => {
+    const table = page.getByTestId("table-valuesets-manage");
+    await expect(table).toBeVisible();
+    // The skeleton row disappears once the seeded value sets load.
+    await expect(table.getByTestId("loading-skeleton")).toHaveCount(0);
+    await expect(table.locator("tr[id^='vsTableRow--']").first()).toBeVisible();
+    await runAxeAccessibilityChecks(page);
+  });
+
+  test("search filters the value set list", async ({ page }) => {
+    const table = page.getByTestId("table-valuesets-manage");
+    await expect(table.locator("tr[id^='vsTableRow--']").first()).toBeVisible();
+
+    // A known seeded term (the DIBBs Cancer/Leukemia value sets) narrows the
+    // list to matching value sets.
+    await page.locator("#librarySearch").fill("Cancer");
+    await expect(table.getByText("Cancer").first()).toBeVisible();
+
+    // A term that matches nothing shows the empty state.
+    await page.locator("#librarySearch").fill("zzzznomatchzzzz");
+    await expect(page.getByText("No results found.")).toBeVisible();
+  });
+
+  test("shows concept codes for a selected value set", async ({ page }) => {
+    const table = page.getByTestId("table-valuesets-manage");
+    await page.locator("#librarySearch").fill("Cancer");
+    const firstRow = table.locator("tr[id^='vsTableRow--']").first();
+    await expect(firstRow).toBeVisible();
+    await firstRow.click();
+
+    // Selecting a value set renders its concepts in the right-hand codes table.
+    const codesTable = page.getByTestId("table-codes");
+    await expect(codesTable).toBeVisible();
+    await expect(
+      page.getByRole("columnheader", { name: "Code", exact: true }),
+    ).toBeVisible();
+    await expect(codesTable.locator("tr").first()).toBeVisible();
+    await runAxeAccessibilityChecks(page);
+  });
+});

--- a/e2e/fhir_servers.spec.ts
+++ b/e2e/fhir_servers.spec.ts
@@ -1,0 +1,141 @@
+import { test, expect, Page } from "@playwright/test";
+import { TEST_URL } from "../playwright-setup";
+
+// Covers the FHIR-server config dimensions not already exercised by
+// smart_on_fhir.spec.ts (SMART), custom_headers.spec.ts and mtls.spec.ts:
+// the None/Basic auth methods, server deletion, the connection-failure state,
+// the Immunization Gateway endpoint type, and Epic query-strategy persistence.
+const rand = () => Math.floor(Math.random() * 1_000_000);
+const AIDBOX_FHIR = `${process.env.AIDBOX_BASE_URL}/fhir`;
+
+/** Opens the "New server" modal and fills the name + URL. Returns the name. */
+async function openNewServer(page: Page, url = AIDBOX_FHIR): Promise<string> {
+  const serverName = `E2E Server ${rand()}`;
+  await page.getByRole("button", { name: "New server" }).click();
+  await expect(page.getByRole("heading", { name: "New server" })).toBeVisible();
+  await page.getByTestId("server-name").fill(serverName);
+  await page.getByTestId("server-url").fill(url);
+  return serverName;
+}
+
+/** Hovers a server row and opens its edit modal. */
+async function openEdit(page: Page, serverName: string) {
+  const row = page.getByRole("row").filter({ hasText: serverName });
+  await row.hover();
+  await row.getByRole("button", { name: `Edit ${serverName}` }).click();
+  await expect(
+    page.getByRole("heading", { name: "Edit server" }),
+  ).toBeVisible();
+}
+
+test.describe("FHIR server configuration", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto(`${TEST_URL}/fhirServers`);
+    await expect(
+      page.getByRole("heading", { name: "FHIR server configuration" }),
+    ).toBeVisible();
+  });
+
+  test("adds a server with no auth and persists it", async ({ page }) => {
+    const serverName = await openNewServer(page);
+    await page.getByTestId("auth-method").selectOption("none");
+
+    // Aidbox requires auth, so a no-auth connection test won't report success;
+    // the server still saves. Confirm it persists with the None auth method.
+    await page.getByRole("button", { name: "Add server" }).click();
+    await expect(
+      page.getByRole("row").filter({ hasText: serverName }),
+    ).toBeVisible();
+
+    await openEdit(page, serverName);
+    await expect(page.getByTestId("auth-method")).toHaveValue("none");
+    await page.getByRole("button", { name: "Cancel" }).click();
+  });
+
+  test("adds a server with basic (bearer token) auth and persists it", async ({
+    page,
+  }) => {
+    const serverName = await openNewServer(page);
+    await page.getByTestId("auth-method").selectOption("basic");
+    const token = `e2e-token-${rand()}`;
+    await page.locator("#bearer-token").fill(token);
+
+    // The connection test would fail with a dummy token, but a server still
+    // saves (the result is only recorded as its connection status).
+    await page.getByRole("button", { name: "Add server" }).click();
+    await expect(
+      page.getByRole("heading", { name: "New server" }),
+    ).not.toBeVisible();
+
+    const row = page.getByRole("row").filter({ hasText: serverName });
+    await expect(row).toBeVisible();
+
+    // Re-open to confirm the auth method persisted. (The bearer token itself is
+    // not echoed back into the edit form.)
+    await openEdit(page, serverName);
+    await expect(page.getByTestId("auth-method")).toHaveValue("basic");
+    await page.getByRole("button", { name: "Cancel" }).click();
+  });
+
+  test("deletes a server", async ({ page }) => {
+    const serverName = await openNewServer(page);
+    await page.getByTestId("auth-method").selectOption("none");
+    await page.getByRole("button", { name: "Add server" }).click();
+
+    const row = page.getByRole("row").filter({ hasText: serverName });
+    await expect(row).toBeVisible();
+
+    await openEdit(page, serverName);
+    await page.locator("#modal-delete-button").click();
+
+    await expect(
+      page.getByRole("heading", { name: "Edit server" }),
+    ).not.toBeVisible();
+    await expect(
+      page.getByRole("row").filter({ hasText: serverName }),
+    ).toHaveCount(0);
+  });
+
+  test("shows an error state for an unreachable server", async ({ page }) => {
+    await openNewServer(page, "http://127.0.0.1:9/fhir");
+    await page.getByTestId("auth-method").selectOption("none");
+
+    await page.getByRole("button", { name: "Test connection" }).click();
+    // A failed connection sets an error message, which the modal footer renders
+    // with an "Error" icon; the connection never reports success.
+    await expect(page.locator('[aria-label="Error"]')).toBeVisible({
+      timeout: 30000,
+    });
+    await expect(page.getByRole("button", { name: "Success" })).toHaveCount(0);
+  });
+
+  test("persists the Immunization Gateway endpoint type", async ({ page }) => {
+    const serverName = await openNewServer(page);
+    await page.getByTestId("auth-method").selectOption("none");
+    await page.getByTestId("endpoint-type").selectOption("immunization");
+
+    await page.getByRole("button", { name: "Add server" }).click();
+    await expect(
+      page.getByRole("row").filter({ hasText: serverName }),
+    ).toBeVisible();
+
+    await openEdit(page, serverName);
+    await expect(page.getByTestId("endpoint-type")).toHaveValue("immunization");
+    await page.getByRole("button", { name: "Cancel" }).click();
+  });
+
+  test("persists the Epic query strategy", async ({ page }) => {
+    const serverName = await openNewServer(page);
+    await page.getByTestId("auth-method").selectOption("none");
+    await page.getByTestId("query-strategy").selectOption("epic");
+
+    await page.getByRole("button", { name: "Add server" }).click();
+    await expect(
+      page.getByRole("row").filter({ hasText: serverName }),
+    ).toBeVisible();
+
+    await openEdit(page, serverName);
+    await expect(page.getByTestId("query-strategy")).toHaveValue("epic");
+    await page.getByRole("button", { name: "Cancel" }).click();
+  });
+});

--- a/e2e/query_execution.spec.ts
+++ b/e2e/query_execution.spec.ts
@@ -161,6 +161,18 @@ test.describe("querying with the Query Connector", () => {
         .getByRole("row")
         .filter({ hasText: "azithromycin 1000 MG" }),
     ).toHaveCount(2);
+    // The "Medications" section renders both a "Medication Requests" and a
+    // "Medication Statements" sub-table (#951). The Chlamydia query's RxNorm
+    // codes include ceftriaxone (1665005), which the demo patient carries as a
+    // MedicationStatement, so the statements sub-table renders that row.
+    await expect(page.getByText("Medication Statements")).toBeVisible();
+    await expect(
+      page
+        .getByRole("table")
+        .getByRole("row")
+        .filter({ hasText: "ceftriaxone 500 MG Injection" })
+        .first(),
+    ).toBeVisible();
     await runAxeAccessibilityChecks(page);
 
     // Check that the drawer works
@@ -177,6 +189,17 @@ test.describe("querying with the Query Connector", () => {
     await expect(page.locator("pre")).toContainText("Patient");
     await runAxeAccessibilityChecks(page);
 
+    // The Request tab (#959) lists the outgoing FHIR requests as "METHOD url".
+    await page.getByRole("button", { name: "Request", exact: true }).click();
+    await expect(page.locator("pre")).not.toContainText(
+      "No FHIR requests recorded.",
+    );
+    await expect(page.locator("pre")).toContainText(/GET|POST/);
+    await expect(page.locator("pre")).toContainText("Patient");
+    // Toggling back to Response restores the payload view.
+    await page.getByRole("button", { name: "Response", exact: true }).click();
+    await expect(page.locator("pre")).toContainText("Patient");
+
     await page.getByRole("button", { name: "Close drawer" }).click();
     await expect(drawer).not.toBeVisible();
 
@@ -188,6 +211,33 @@ test.describe("querying with the Query Connector", () => {
         exact: true,
       }),
     ).toBeVisible();
+    // "New patient search" clears the form (contrast with "Revise", below).
+    await expect(page.getByLabel("First name")).toHaveValue("");
+  });
+
+  test("preserves patient search inputs when revising a search", async ({
+    page,
+  }) => {
+    // Prefill the demo values, then override the name with something that
+    // matches no patient so we land on the "No Records Found" page.
+    await page.getByRole("button", { name: "Fill fields" }).click();
+    const firstName = "Nomatch";
+    const lastName = "Persistedname";
+    await page.getByLabel("First name").fill(firstName);
+    await page.getByLabel("Last name").fill(lastName);
+
+    await page.getByRole("button", { name: "Search for patient" }).click();
+    await expect(
+      page.getByRole("heading", { name: "No Records Found" }),
+    ).toBeVisible();
+
+    // Revise should repopulate the form with the previously entered values
+    // rather than resetting to a blank form (#958).
+    await page
+      .getByRole("button", { name: "Revise your patient search" })
+      .click();
+    await expect(page.getByLabel("First name")).toHaveValue(firstName);
+    await expect(page.getByLabel("Last name")).toHaveValue(lastName);
   });
 });
 

--- a/e2e/user_management.spec.ts
+++ b/e2e/user_management.spec.ts
@@ -1,22 +1,149 @@
-import { test, expect } from "@playwright/test";
+import { test, expect, Page } from "@playwright/test";
 import { TEST_URL } from "../playwright-setup";
 import { runAxeAccessibilityChecks } from "./utils";
 
+// Users/groups created here are randomized and left in place: there is no
+// user-deletion path in the app or backend, and the existing FHIR-server specs
+// follow the same create-with-random-name convention (workers=3 run in
+// parallel, so names must not collide).
+const rand = () => Math.floor(Math.random() * 1_000_000);
+
+/**
+ * Fills the "New user" modal and submits it. If user groups exist, the modal
+ * advances to an "Add to user groups" step; pass a groupName to check that group
+ * before finalizing, otherwise the step is simply confirmed.
+ */
+async function createUser(
+  page: Page,
+  user: { firstName: string; lastName: string; email: string },
+  groupName?: string,
+) {
+  await page.getByRole("button", { name: "Add user" }).click();
+  await expect(page.getByRole("heading", { name: "New user" })).toBeVisible();
+
+  // Label htmlFor attributes don't all match their input ids in this modal, so
+  // target the inputs by id directly.
+  await page.locator("#firstName").fill(user.firstName);
+  await page.locator("#lastName").fill(user.lastName);
+  await page.locator("#email").fill(user.email);
+
+  await page.locator("#modal-step-button").click();
+
+  // The "Add to user groups" step only appears when at least one group exists.
+  const groupStep = page.getByRole("heading", { name: "Add to user groups" });
+  const stepAppeared = await groupStep
+    .waitFor({ state: "visible", timeout: 3000 })
+    .then(() => true)
+    .catch(() => false);
+  if (stepAppeared) {
+    if (groupName) {
+      // The USWDS checkbox input is visually hidden; click its label (scoped to
+      // the modal) to toggle it, matching how other specs drive checkboxes.
+      await page.locator("#user-mgmt-modal").getByText(groupName).click();
+    }
+    await page.locator("#modal-step-button").click();
+  }
+}
+
+/**
+ * Creates a user group from the "User groups" tab and returns its name.
+ */
+async function createGroup(page: Page): Promise<string> {
+  const groupName = `E2E Group ${rand()}`;
+  await page.getByRole("button", { name: "User groups" }).click();
+  await page.getByRole("button", { name: "Create group" }).click();
+  await expect(
+    page.getByRole("heading", { name: "Create user group" }),
+  ).toBeVisible();
+  await page.locator("#group-name").fill(groupName);
+  await page.locator("#modal-step-button").click();
+  await expect(
+    page.getByRole("heading", { name: "Create user group" }),
+  ).not.toBeVisible();
+  return groupName;
+}
+
 test.describe("User management", () => {
   test.beforeEach(async ({ page }) => {
-    // Start every test on our main landing page
     await page.goto(`${TEST_URL}/userManagement`);
-  });
-
-  test("Users tab loads list of users", async ({ page }) => {
     await expect(
       page.getByRole("heading", { name: "User management" }),
     ).toBeVisible();
+  });
+
+  test("Users tab loads list of users", async ({ page }) => {
     // Users tab is selected by default
     await expect(page.getByRole("button", { name: "Users" })).toHaveClass(
       /tab__active/,
     );
     await expect(page.getByText("Admin, QC")).toBeVisible();
     await runAxeAccessibilityChecks(page);
+  });
+
+  test("creates a new user", async ({ page }) => {
+    const firstName = `Test${rand()}`;
+    const lastName = `User${rand()}`;
+    await createUser(page, {
+      firstName,
+      lastName,
+      email: `qc-${rand()}@example.com`,
+    });
+
+    // New users render as "Last, First" in the users table.
+    await expect(
+      page.getByRole("row").filter({ hasText: `${lastName}, ${firstName}` }),
+    ).toBeVisible();
+    await runAxeAccessibilityChecks(page);
+  });
+
+  test("creates a new user group", async ({ page }) => {
+    const groupName = await createGroup(page);
+
+    await expect(
+      page.getByRole("row").filter({ hasText: groupName }),
+    ).toBeVisible();
+    await runAxeAccessibilityChecks(page);
+  });
+
+  test("assigns a user to a group during creation", async ({ page }) => {
+    // Create a group first so the "Add to user groups" step is guaranteed.
+    const groupName = await createGroup(page);
+
+    // Back to the Users tab to add a user and assign it to that group.
+    await page.getByRole("button", { name: "Users" }).click();
+    const firstName = `Grouped${rand()}`;
+    const lastName = `User${rand()}`;
+    await createUser(
+      page,
+      { firstName, lastName, email: `qc-${rand()}@example.com` },
+      groupName,
+    );
+
+    // The user's row should list the assigned group in the "User groups" column.
+    const userRow = page
+      .getByRole("row")
+      .filter({ hasText: `${lastName}, ${firstName}` });
+    await expect(userRow).toBeVisible();
+    await expect(userRow.getByText(groupName)).toBeVisible();
+  });
+
+  test("changes a user's role", async ({ page }) => {
+    const firstName = `Role${rand()}`;
+    const lastName = `User${rand()}`;
+    await createUser(page, {
+      firstName,
+      lastName,
+      email: `qc-${rand()}@example.com`,
+    });
+
+    const userRow = page
+      .getByRole("row")
+      .filter({ hasText: `${lastName}, ${firstName}` });
+    await expect(userRow).toBeVisible();
+
+    // Non-self users render an inline role dropdown; change it and confirm the
+    // success toast (updateUserRole persists immediately).
+    await userRow.getByRole("combobox").selectOption("Admin");
+    await expect(page.getByText("Role successfully updated.")).toBeVisible();
   });
 });


### PR DESCRIPTION
## What

Extends the Playwright e2e suite to cover recently-merged features that shipped with only partial/unit coverage, plus three pages that had little or no e2e coverage. **17 new tests** (2 specs extended, 3 new).

### `query_execution.spec.ts` (extended)
- Assert the results-drawer **Request** tab lists outgoing FHIR requests (#959)
- New test: patient search inputs are **preserved on "Revise"** (#958); "New patient search" still clears the form
- Assert the **MedicationStatement** sub-table renders (#951)

### `user_management.spec.ts` (extended)
Previously only "Users tab loads". Adds: create user, create group, assign a user to a group on creation, and change a user's role.

### `code_library.spec.ts` (new)
Load/list value sets, search filter + empty state, view concept codes for a selected value set.

### `audit_logs.spec.ts` (new)
Generates an audited action, then covers the log table, search + empty state, and the detail drawer.

### `fhir_servers.spec.ts` (new)
Dimensions not covered by the existing SMART/custom-headers/mTLS specs: None/Basic auth persistence, delete server, connection-failure state, Immunization Gateway endpoint type, and **Epic query-strategy** persistence (#966).

## Testing

All **24 new/changed tests pass locally on Firefox** (containerized Aidbox stack via `test:playwright`). CI covers Edge/Chrome. The remaining 2 Firefox failures in the full suite (`smart_on_fhir`, `custom_headers`) are **pre-existing** — they fail on an Axe color-contrast a11y check in the SMART "Success" flow and are unrelated to this change (those files are untouched).

## Notes / out of scope
- Per-role RBAC gating and IdP login aren't covered — the harness runs with `AUTH_DISABLED=true` (fixed SUPER_ADMIN session).
- Created users/groups are randomized and left in place (no user-delete path exists; matches the existing FHIR-server specs' convention).