### PR TITLE
perf: Add server-side pagination to Audit Logs page

### DIFF
--- a/flyway/sql/V01_05__audit_log_indexes.sql
+++ b/flyway/sql/V01_05__audit_log_indexes.sql
@@ -1,0 +1,3 @@
+CREATE INDEX IF NOT EXISTS audit_logs_created_at_index ON audit_logs (created_at DESC);
+CREATE INDEX IF NOT EXISTS audit_logs_author_index ON audit_logs (author);
+CREATE INDEX IF NOT EXISTS audit_logs_action_type_index ON audit_logs (action_type);

--- a/src/app/(pages)/auditLogs/AuditLogs.test.tsx
+++ b/src/app/(pages)/auditLogs/AuditLogs.test.tsx
@@ -2,8 +2,13 @@ import { screen, within, waitFor } from "@testing-library/react";
 import AuditLogs from "./page";
 import { renderWithUser, RootProviderMock } from "@/app/tests/unit/setup";
 import userEvent from "@testing-library/user-event";
-import { auditLogActionTypeMap } from "./components/auditLogMaps";
-import { getAuditLogs, LogEntry } from "@/app/backend/audit-logs/service";
+import {
+  getAuditLogsPaginated,
+  getAuditLogAuthors,
+  getAuditLogActionTypes,
+  LogEntry,
+} from "@/app/backend/audit-logs/service";
+import { AuditLogFilterParams } from "@/app/models/responses/collections";
 import { DEFAULT_DATE_DISPLAY_TEXT } from "@/app/ui/designSystem/timeboxing/DateRangePicker";
 
 jest.mock(
@@ -19,7 +24,6 @@ jest.mock("@/app/backend/user-management", () => ({
 
 const TEST_NAME = "Mario Mario";
 const TEST_ACTION = "makePatientRecordsRequest";
-const TEST_REPORT = auditLogActionTypeMap[TEST_ACTION].label;
 const TEST_REPORT_RENDERED = "Viewed patient record for";
 const NUM_ROWS = 26;
 const CHECKSUM_INPUT = "It's-a-me. Mario!";
@@ -65,19 +69,51 @@ const BASE_TEST_DATA: LogEntry[] = [
 const testData = Array.from({ length: 50 }, (_, index) =>
   BASE_TEST_DATA.map((entry) => ({
     ...entry,
-    date: new Date(entry.createdAt.getTime() + index * 86400000),
+    createdAt: new Date(entry.createdAt.getTime() + index * 86400000),
   })),
 )
   .flat()
-  .sort((a, b) => b.date.getTime() - a.date.getTime());
+  .sort((a, b) => b.createdAt.getTime() - a.createdAt.getTime());
 
-jest.mock("@/app/backend/audit-logs/service", () => {
+jest.mock("@/app/backend/audit-logs/service", () => ({
+  __esModule: true,
+  getAuditLogsPaginated: jest.fn(),
+  getAuditLogAuthors: jest.fn(),
+  getAuditLogActionTypes: jest.fn(),
+}));
+
+// emulates the server-side filtering/pagination against the in-memory testData
+async function mockPaginatedResponse(params: AuditLogFilterParams) {
+  const term = params.textSearch?.toLowerCase();
+  const filtered = testData.filter((log) => {
+    const matchesAuthor = params.author ? log.author === params.author : true;
+    const matchesAction = params.actionType
+      ? log.actionType === params.actionType
+      : true;
+    const matchesSearch =
+      !term ||
+      log.author.toLowerCase().includes(term) ||
+      log.actionType.toLowerCase().includes(term) ||
+      JSON.stringify(log.auditMessage).toLowerCase().includes(term) ||
+      (params.searchedActionTypes ?? []).includes(log.actionType);
+    const matchesDate =
+      (!params.startDate || log.createdAt >= new Date(params.startDate)) &&
+      (!params.endDate || log.createdAt <= new Date(params.endDate));
+    return matchesAuthor && matchesAction && matchesSearch && matchesDate;
+  });
+
+  const start = params.pageIndex * params.pageSize;
+  const totalPages = Math.ceil(filtered.length / params.pageSize);
   return {
-    __esModule: true,
-    ...jest.requireActual("@/app/backend/audit-logs/service"),
-    getAuditLogs: jest.fn(),
+    items: filtered.slice(start, start + params.pageSize),
+    totalItems: filtered.length,
+    pageIndex: params.pageIndex,
+    pageSize: params.pageSize,
+    totalPages,
+    prevPage: Math.max(0, params.pageIndex - 1),
+    nextPage: Math.min(totalPages - 1, params.pageIndex + 1),
   };
-});
+}
 
 /**
  * Creates an enhanced user event with custom helper methods.
@@ -110,7 +146,15 @@ const createUserWithHelpers = (user: ReturnType<typeof userEvent.setup>) => ({
 
 describe("AuditLogs Component", () => {
   let user: ReturnType<typeof createUserWithHelpers>;
-  (getAuditLogs as jest.Mock).mockResolvedValue(testData);
+  (getAuditLogsPaginated as jest.Mock).mockImplementation(
+    mockPaginatedResponse,
+  );
+  (getAuditLogAuthors as jest.Mock).mockResolvedValue(
+    Array.from(new Set(testData.map((log) => log.author))).sort(),
+  );
+  (getAuditLogActionTypes as jest.Mock).mockResolvedValue(
+    Array.from(new Set(testData.map((log) => log.actionType))).sort(),
+  );
 
   beforeEach(async () => {
     const renderResult = renderWithUser(
@@ -134,26 +178,38 @@ describe("AuditLogs Component", () => {
   test("filters by name and clears filter", async () => {
     await user.selectDropdownOption("Name(s)", TEST_NAME);
 
-    const rows = await screen.findAllByRole("row");
-    expect(rows.length).toBeGreaterThan(1);
-    rows.slice(1).forEach((row) => {
-      expect(within(row).getByText(TEST_NAME)).toBeInTheDocument();
+    await waitFor(() => {
+      const rows = screen.getAllByRole("row");
+      expect(rows.length).toBeGreaterThan(1);
+      rows.slice(1).forEach((row) => {
+        expect(within(row).getByText(TEST_NAME)).toBeInTheDocument();
+      });
     });
+
+    expect(getAuditLogsPaginated).toHaveBeenLastCalledWith(
+      expect.objectContaining({ author: TEST_NAME, pageIndex: 0 }),
+    );
 
     await user.selectDropdownOption("Name(s)", "");
   });
 
   test("filters by action and clears filter", async () => {
-    await user.selectDropdownOption("Action(s)", TEST_REPORT);
+    await user.selectDropdownOption("Action(s)", TEST_ACTION);
 
-    const rows = await screen.findAllByRole("row");
-    expect(rows.length).toBeGreaterThan(1);
-    rows.slice(1).forEach((row) => {
-      const matches = within(row).queryAllByText(
-        (_, node) => !!node?.textContent?.includes(TEST_REPORT_RENDERED),
-      );
-      expect(matches.length).toBeGreaterThan(0);
+    await waitFor(() => {
+      const rows = screen.getAllByRole("row");
+      expect(rows.length).toBeGreaterThan(1);
+      rows.slice(1).forEach((row) => {
+        const matches = within(row).queryAllByText(
+          (_, node) => !!node?.textContent?.includes(TEST_REPORT_RENDERED),
+        );
+        expect(matches.length).toBeGreaterThan(0);
+      });
     });
+
+    expect(getAuditLogsPaginated).toHaveBeenLastCalledWith(
+      expect.objectContaining({ actionType: TEST_ACTION, pageIndex: 0 }),
+    );
 
     await user.selectDropdownOption("Action(s)", "");
   });
@@ -161,11 +217,16 @@ describe("AuditLogs Component", () => {
   test("filters by partial search", async () => {
     await user.typeInField(PLACEHOLDER_TEXT, "Mario");
 
-    const rows = await screen.findAllByRole("row");
-    expect(rows.length).toBeGreaterThan(1);
-    rows.slice(1).forEach((row) => {
-      const matches = within(row).queryAllByText(/Mario/i);
-      expect(matches.length).toBeGreaterThan(0);
+    await waitFor(() => {
+      expect(getAuditLogsPaginated).toHaveBeenLastCalledWith(
+        expect.objectContaining({ textSearch: "Mario", pageIndex: 0 }),
+      );
+      const rows = screen.getAllByRole("row");
+      expect(rows.length).toBeGreaterThan(1);
+      rows.slice(1).forEach((row) => {
+        const matches = within(row).queryAllByText(/Mario/i);
+        expect(matches.length).toBeGreaterThan(0);
+      });
     });
   });
 
@@ -178,6 +239,10 @@ describe("AuditLogs Component", () => {
       const pageNumbers = screen.getAllByRole("button", { name: /Page/ });
       expect(pageNumbers[1]).toHaveAttribute("aria-current", "page");
     });
+
+    expect(getAuditLogsPaginated).toHaveBeenLastCalledWith(
+      expect.objectContaining({ pageIndex: 1 }),
+    );
   });
 
   test("pagination allows clicking previous only if it exists", async () => {
@@ -210,11 +275,15 @@ describe("AuditLogs Component", () => {
       const rows = screen.getAllByRole("row");
       expect(rows.length).toBe(NUM_ROWS);
     });
+
+    expect(getAuditLogsPaginated).toHaveBeenLastCalledWith(
+      expect.objectContaining({ pageIndex: 0, pageSize: 25 }),
+    );
   });
 
   test("clear filters resets empty state", async () => {
     await user.selectDropdownOption("Name(s)", "Luigi Mario");
-    await user.selectDropdownOption("Action(s)", TEST_REPORT);
+    await user.selectDropdownOption("Action(s)", TEST_ACTION);
 
     await waitFor(() => {
       expect(
@@ -255,6 +324,17 @@ describe("AuditLogs Component", () => {
       "auditLogDatePicker",
     ) as HTMLInputElement;
     expect(displayInput.value).not.toBe("");
+
+    // The date range should round-trip to the server as ISO strings
+    await waitFor(() => {
+      expect(getAuditLogsPaginated).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          pageIndex: 0,
+          startDate: expect.any(String),
+          endDate: expect.any(String),
+        }),
+      );
+    });
   });
 
   test("updates start and end date inputs", async () => {

--- a/src/app/(pages)/auditLogs/page.tsx
+++ b/src/app/(pages)/auditLogs/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect, ChangeEvent, useMemo, useRef } from "react";
+import { useState, useEffect, useCallback, ChangeEvent, useRef } from "react";
 import styles from "./auditLogs.module.scss";
 import classNames from "classnames";
 import {
@@ -17,11 +17,19 @@ import Skeleton from "react-loading-skeleton";
 import AuditLogDrawer from "./components/auditLogDrawer";
 import {
   auditLogActionTypeMap,
-  labelToActionType,
   auditLogUserMap,
   initializeAuditLogUserMap,
 } from "./components/auditLogMaps";
-import { getAuditLogs, LogEntry } from "@/app/backend/audit-logs/service";
+import {
+  getAuditLogsPaginated,
+  getAuditLogAuthors,
+  getAuditLogActionTypes,
+  LogEntry,
+} from "@/app/backend/audit-logs/service";
+import {
+  AuditLogFilterParams,
+  QCPagedResponse,
+} from "@/app/models/responses/collections";
 
 /**
  * Client component for the Audit Logs page.
@@ -29,6 +37,7 @@ import { getAuditLogs, LogEntry } from "@/app/backend/audit-logs/service";
  */
 const AuditLogs: React.FC = () => {
   const [search, setSearch] = useState("");
+  const [debouncedSearch, setDebouncedSearch] = useState("");
   const [selectedName, setSelectedName] = useState("");
   const [selectedAction, setSelectedAction] = useState("");
   const [dateRange, setDateRange] = useState<DateRangeInfo>({
@@ -39,103 +48,93 @@ const AuditLogs: React.FC = () => {
   const [_, setDateErrors] = useState<DateErrors>({});
   const [currentPage, setCurrentPage] = useState(1);
   const [actionsPerPage, setActionsPerPage] = useState(10);
-  const [logs, setLogs] = useState<LogEntry[]>([]);
+  const [pagedResult, setPagedResult] =
+    useState<QCPagedResponse<LogEntry> | null>(null);
+  const [authors, setAuthors] = useState<string[]>([]);
+  const [actionTypes, setActionTypes] = useState<string[]>([]);
   const [loading, setLoading] = useState<boolean>(true);
   const [drawerOpen, setDrawerOpen] = useState(false);
   const [selectedLog, setSelectedLog] = useState<LogEntry | null>(null);
   const datePickerRef = useRef<DateRangePickerRef>(null);
 
-  useEffect(() => {
-    async function fetchAuditLogs() {
-      const logs = await getAuditLogs();
-      return logs.map((log) => {
-        // Convert createdAt to Date object that works in all browsers in correct timezone
-        let str = String(log.createdAt).trim();
+  const buildFilterParams = useCallback((): AuditLogFilterParams => {
+    // action types whose human-readable label matches the search term, so
+    // label searches (e.g. "sign in") still match rows server-side
+    const searchedActionTypes = debouncedSearch
+      ? Object.entries(auditLogActionTypeMap)
+          .filter(([, config]) =>
+            config.label.toLowerCase().includes(debouncedSearch.toLowerCase()),
+          )
+          .map(([actionType]) => actionType)
+      : [];
 
-        if (!str.includes("T")) str = str.replace(" ", "T");
-        if (!str.endsWith("Z")) str += "Z";
+    return {
+      pageIndex: currentPage - 1,
+      pageSize: actionsPerPage,
+      author: selectedName || undefined,
+      actionType: selectedAction || undefined,
+      textSearch: debouncedSearch || undefined,
+      searchedActionTypes:
+        searchedActionTypes.length > 0 ? searchedActionTypes : undefined,
+      startDate: dateRange.startDate?.toISOString(),
+      endDate: dateRange.endDate?.toISOString(),
+    };
+  }, [
+    currentPage,
+    actionsPerPage,
+    selectedName,
+    selectedAction,
+    debouncedSearch,
+    dateRange,
+  ]);
 
-        return {
-          ...log,
-          createdAt: new Date(str),
-        };
-      });
-    }
-
-    initializeAuditLogUserMap();
-    setLoading(true);
-
-    fetchAuditLogs().then((v) => {
-      setLogs(v);
+  const fetchPage = useCallback(async () => {
+    try {
+      const result = await getAuditLogsPaginated(buildFilterParams());
+      setPagedResult(result);
+    } catch (error) {
+      console.error(`Failed to fetch audit logs: ${error}`);
+    } finally {
       setLoading(false);
-    });
+    }
+  }, [buildFilterParams]);
+
+  // load filter dropdown options and the username -> full name map once
+  useEffect(() => {
+    initializeAuditLogUserMap();
+    getAuditLogAuthors()
+      .then(setAuthors)
+      .catch((error) =>
+        console.error(`Failed to fetch audit log authors: ${error}`),
+      );
+    getAuditLogActionTypes()
+      .then(setActionTypes)
+      .catch((error) =>
+        console.error(`Failed to fetch audit log action types: ${error}`),
+      );
   }, []);
 
-  const [filteredLogs, setFilteredLogs] = useState(logs);
-
-  const uniqueNames = useMemo(
-    () =>
-      Array.from(
-        new Set(logs.map((log) => auditLogUserMap(log.author))),
-      ).sort(),
-    [logs],
-  );
-
-  const uniqueActions = useMemo(
-    () =>
-      Array.from(
-        new Set(
-          logs.map(
-            (log) =>
-              auditLogActionTypeMap[log.actionType]?.label || log.actionType,
-          ),
-        ),
-      ).sort(),
-    [logs],
-  );
-
+  // debounce text search
   useEffect(() => {
-    setFilteredLogs(
-      logs.filter((log) => {
-        const matchesName = selectedName
-          ? auditLogUserMap(log.author) === selectedName
-          : true;
-        const matchesAction = selectedAction
-          ? log.actionType === labelToActionType[selectedAction]
-          : true;
-        const actionLabel =
-          auditLogActionTypeMap[log.actionType]?.label?.toLowerCase() || "";
-        const formattedAction =
-          auditLogActionTypeMap[log.actionType]?.format(log)?.toLowerCase() ||
-          "";
-        const fullName = auditLogUserMap(log.author).toLowerCase();
-        const matchesSearch =
-          search.length === 0 ||
-          log.author.toLowerCase().includes(search.toLowerCase()) ||
-          fullName.includes(search.toLowerCase()) ||
-          log.actionType.toLowerCase().includes(search.toLowerCase()) ||
-          actionLabel.includes(search.toLowerCase()) ||
-          formattedAction.includes(search.toLowerCase()) ||
-          JSON.stringify(log.auditMessage)
-            .toLowerCase()
-            .includes(search.toLowerCase());
-        const matchesDate =
-          (!dateRange.startDate || log.createdAt >= dateRange.startDate) &&
-          (!dateRange.endDate || log.createdAt <= dateRange.endDate);
-        return matchesName && matchesAction && matchesSearch && matchesDate;
-      }),
-    );
+    const timer = setTimeout(() => {
+      setDebouncedSearch(search);
+    }, 300);
+    return () => clearTimeout(timer);
+  }, [search]);
+
+  // reset to page 1 when filters or search change
+  useEffect(() => {
     setCurrentPage(1);
-  }, [selectedName, selectedAction, dateRange, search, logs]);
+  }, [selectedName, selectedAction, dateRange, debouncedSearch]);
 
-  const paginatedLogs = useMemo(() => {
-    return filteredLogs.slice(
-      (currentPage - 1) * actionsPerPage,
-      currentPage * actionsPerPage,
-    );
-  }, [filteredLogs, currentPage, actionsPerPage]);
+  // fetch a page of logs whenever page or filters change
+  useEffect(() => {
+    fetchPage();
+  }, [fetchPage]);
 
-  const totalPages = Math.ceil(filteredLogs.length / actionsPerPage);
+  const logs = pagedResult?.items ?? [];
+  const totalItems = pagedResult?.totalItems ?? 0;
+  const totalPages = pagedResult?.totalPages ?? 0;
 
   return (
     <WithAuth>
@@ -161,9 +160,9 @@ const AuditLogs: React.FC = () => {
               onChange={(e) => setSelectedName(e.target.value)}
             >
               <option value=""></option>
-              {uniqueNames.map((name) => (
-                <option key={name} value={name}>
-                  {name}
+              {authors.map((author) => (
+                <option key={author} value={author}>
+                  {auditLogUserMap(author)}
                 </option>
               ))}
             </Select>
@@ -177,9 +176,9 @@ const AuditLogs: React.FC = () => {
               onChange={(e) => setSelectedAction(e.target.value)}
             >
               <option value=""></option>
-              {uniqueActions.map((action) => (
-                <option key={action} value={action}>
-                  {action}
+              {actionTypes.map((actionType) => (
+                <option key={actionType} value={actionType}>
+                  {auditLogActionTypeMap[actionType]?.label || actionType}
                 </option>
               ))}
             </Select>
@@ -222,7 +221,7 @@ const AuditLogs: React.FC = () => {
         </div>
 
         <>
-          {!loading && filteredLogs.length === 0 ? (
+          {!loading && totalItems === 0 ? (
             <div className={styles.noResultsContainer}>
               <div className={styles.noResultsBackground}>
                 <h3>No results found.</h3>
@@ -259,7 +258,7 @@ const AuditLogs: React.FC = () => {
                   <tbody>{LoadingTable}</tbody>
                 ) : (
                   <tbody>
-                    {paginatedLogs.map((log, index) => (
+                    {logs.map((log, index) => (
                       <tr
                         className={styles.tableRows}
                         key={index}
@@ -283,12 +282,12 @@ const AuditLogs: React.FC = () => {
             </div>
           )}
 
-          {!loading && filteredLogs.length > 0 && (
+          {!loading && totalItems > 0 && (
             <div className={classNames(styles.paginationContainer)}>
               <span>
                 {`Showing ${(currentPage - 1) * actionsPerPage + 1} -
-        ${Math.min(currentPage * actionsPerPage, filteredLogs.length)} of 
-        ${filteredLogs.length} actions`}
+        ${Math.min(currentPage * actionsPerPage, totalItems)} of
+        ${totalItems} actions`}
               </span>
 
               <Pagination

--- a/src/app/(pages)/auditLogs/page.tsx
+++ b/src/app/(pages)/auditLogs/page.tsx
@@ -56,6 +56,7 @@ const AuditLogs: React.FC = () => {
   const [drawerOpen, setDrawerOpen] = useState(false);
   const [selectedLog, setSelectedLog] = useState<LogEntry | null>(null);
   const datePickerRef = useRef<DateRangePickerRef>(null);
+  const fetchIdRef = useRef(0);
 
   const buildFilterParams = useCallback((): AuditLogFilterParams => {
     // action types whose human-readable label matches the search term, so
@@ -89,21 +90,36 @@ const AuditLogs: React.FC = () => {
   ]);
 
   const fetchPage = useCallback(async () => {
+    // ignore out-of-order responses: only the latest request may update state
+    const fetchId = ++fetchIdRef.current;
+    setLoading(true);
     try {
       const result = await getAuditLogsPaginated(buildFilterParams());
-      setPagedResult(result);
+      if (fetchId === fetchIdRef.current) {
+        setPagedResult(result);
+      }
     } catch (error) {
       console.error(`Failed to fetch audit logs: ${error}`);
     } finally {
-      setLoading(false);
+      if (fetchId === fetchIdRef.current) {
+        setLoading(false);
+      }
     }
   }, [buildFilterParams]);
 
-  // load filter dropdown options and the username -> full name map once
+  // load filter dropdown options and the username -> full name map once;
+  // the user map loads first so author options can be sorted by the full
+  // names they render as, not by raw username
   useEffect(() => {
-    initializeAuditLogUserMap();
-    getAuditLogAuthors()
-      .then(setAuthors)
+    initializeAuditLogUserMap()
+      .then(() => getAuditLogAuthors())
+      .then((fetchedAuthors) =>
+        setAuthors(
+          fetchedAuthors.sort((a, b) =>
+            auditLogUserMap(a).localeCompare(auditLogUserMap(b)),
+          ),
+        ),
+      )
       .catch((error) =>
         console.error(`Failed to fetch audit log authors: ${error}`),
       );

--- a/src/app/backend/audit-logs/service.ts
+++ b/src/app/backend/audit-logs/service.ts
@@ -1,6 +1,11 @@
 "use server";
 
+import type {
+  AuditLogFilterParams,
+  QCPagedResponse,
+} from "@/app/models/responses/collections";
 import dbService from "../db/service";
+import { superAdminRequired } from "../db/decorators";
 
 export type LogEntry = {
   actionType: string;
@@ -10,12 +15,174 @@ export type LogEntry = {
   createdAt: Date;
 };
 
+/**
+ * Converts a naive-UTC timestamp from the DB into a Date that parses
+ * consistently across browsers and timezones.
+ * @param createdAt - The raw created_at value from the DB.
+ * @returns The value as a UTC Date.
+ */
+function normalizeCreatedAt(createdAt: unknown): Date {
+  let str = String(createdAt).trim();
+  if (createdAt instanceof Date) {
+    str = createdAt.toISOString();
+  }
+
+  if (!str.includes("T")) str = str.replace(" ", "T");
+  if (!str.endsWith("Z")) str += "Z";
+
+  return new Date(str);
+}
+
 class AuditLogService {
-  static async getAuditLogs() {
-    const auditQuery = "SELECT * FROM audit_logs ORDER BY created_at DESC;";
-    const results = await dbService.query(auditQuery);
-    return results.rows;
+  /**
+   * Retrieves a paginated, filtered list of audit log entries.
+   * @param params - Pagination and filter parameters.
+   * @returns A paged response of audit log entries, newest first.
+   */
+  @superAdminRequired
+  static async getAuditLogsPaginated(
+    params: AuditLogFilterParams,
+  ): Promise<QCPagedResponse<LogEntry>> {
+    try {
+      const conditions: string[] = [];
+      const values: (string | number | string[])[] = [];
+      let paramIndex = 1;
+
+      if (params.author) {
+        conditions.push(`al.author = $${paramIndex}`);
+        values.push(params.author);
+        paramIndex++;
+      }
+
+      if (params.actionType) {
+        conditions.push(`al.action_type = $${paramIndex}`);
+        values.push(params.actionType);
+        paramIndex++;
+      }
+
+      if (params.startDate) {
+        conditions.push(`al.created_at >= $${paramIndex}::timestamp`);
+        values.push(params.startDate);
+        paramIndex++;
+      }
+
+      if (params.endDate) {
+        conditions.push(`al.created_at <= $${paramIndex}::timestamp`);
+        values.push(params.endDate);
+        paramIndex++;
+      }
+
+      if (params.textSearch) {
+        const searchClauses = [
+          `al.author ILIKE $${paramIndex}`,
+          `u.first_name || ' ' || u.last_name ILIKE $${paramIndex}`,
+          `al.action_type ILIKE $${paramIndex}`,
+          `al.audit_message::text ILIKE $${paramIndex}`,
+        ];
+        values.push(`%${params.textSearch}%`);
+        paramIndex++;
+
+        if (
+          params.searchedActionTypes &&
+          params.searchedActionTypes.length > 0
+        ) {
+          searchClauses.push(`al.action_type = ANY($${paramIndex}::text[])`);
+          values.push(params.searchedActionTypes);
+          paramIndex++;
+        }
+
+        conditions.push(`(${searchClauses.join(" OR ")})`);
+      }
+
+      const whereClause =
+        conditions.length > 0 ? `WHERE ${conditions.join(" AND ")}` : "";
+      const fromClause = `
+        FROM audit_logs al
+        LEFT JOIN users u ON al.author = u.username
+      `;
+
+      const countSql = `SELECT COUNT(*) as total ${fromClause} ${whereClause}`;
+      const countResult = await dbService.query(countSql, values);
+      const totalItems = parseInt(countResult.rows[0].total, 10);
+
+      const offset = params.pageIndex * params.pageSize;
+      const dataSql = `
+        SELECT al.id, al.author, al.action_type, al.audit_checksum,
+          al.audit_message, al.created_at
+        ${fromClause}
+        ${whereClause}
+        ORDER BY al.created_at DESC
+        LIMIT $${paramIndex} OFFSET $${paramIndex + 1}
+      `;
+
+      const dataResult = await dbService.query(dataSql, [
+        ...values,
+        params.pageSize,
+        offset,
+      ]);
+
+      const items: LogEntry[] = dataResult.rows.map((row) => ({
+        actionType: row.actionType,
+        auditChecksum: row.auditChecksum,
+        author: row.author,
+        auditMessage: row.auditMessage,
+        createdAt: normalizeCreatedAt(row.createdAt),
+      }));
+
+      const totalPages = Math.ceil(totalItems / params.pageSize);
+
+      return {
+        items,
+        totalItems,
+        pageIndex: params.pageIndex,
+        pageSize: params.pageSize,
+        totalPages,
+        prevPage: Math.max(0, params.pageIndex - 1),
+        nextPage: Math.min(totalPages - 1, params.pageIndex + 1),
+      };
+    } catch (error) {
+      console.error("Error retrieving paginated audit logs:", error);
+      throw error;
+    }
+  }
+
+  /**
+   * Retrieves the distinct authors (usernames) across all audit log entries.
+   * @returns A sorted list of unique author usernames.
+   */
+  @superAdminRequired
+  static async getAuditLogAuthors(): Promise<string[]> {
+    try {
+      const sql = `SELECT DISTINCT author FROM audit_logs ORDER BY author ASC`;
+      const result = await dbService.query(sql);
+      return result.rows
+        .map((row) => row.author)
+        .filter((author): author is string => !!author);
+    } catch (error) {
+      console.error("Error retrieving audit log authors:", error);
+      throw error;
+    }
+  }
+
+  /**
+   * Retrieves the distinct action types across all audit log entries.
+   * @returns A sorted list of unique action types.
+   */
+  @superAdminRequired
+  static async getAuditLogActionTypes(): Promise<string[]> {
+    try {
+      const sql = `SELECT DISTINCT action_type FROM audit_logs ORDER BY action_type ASC`;
+      const result = await dbService.query(sql);
+      return result.rows
+        .map((row) => row.actionType)
+        .filter((actionType): actionType is string => !!actionType);
+    } catch (error) {
+      console.error("Error retrieving audit log action types:", error);
+      throw error;
+    }
   }
 }
 
-export const getAuditLogs = AuditLogService.getAuditLogs;
+export const getAuditLogsPaginated = AuditLogService.getAuditLogsPaginated;
+export const getAuditLogAuthors = AuditLogService.getAuditLogAuthors;
+export const getAuditLogActionTypes = AuditLogService.getAuditLogActionTypes;

--- a/src/app/backend/audit-logs/service.ts
+++ b/src/app/backend/audit-logs/service.ts
@@ -16,16 +16,15 @@ export type LogEntry = {
 };
 
 /**
- * Converts a naive-UTC timestamp from the DB into a Date that parses
- * consistently across browsers and timezones.
+ * Converts a naive-UTC timestamp string from the DB into a UTC Date.
+ * The query selects created_at::text (rather than letting pg parse the
+ * TIMESTAMP column into a Date in the server's local timezone) so the
+ * naive value can be tagged as UTC here regardless of server timezone.
  * @param createdAt - The raw created_at value from the DB.
  * @returns The value as a UTC Date.
  */
 function normalizeCreatedAt(createdAt: unknown): Date {
   let str = String(createdAt).trim();
-  if (createdAt instanceof Date) {
-    str = createdAt.toISOString();
-  }
 
   if (!str.includes("T")) str = str.replace(" ", "T");
   if (!str.endsWith("Z")) str += "Z";
@@ -75,7 +74,7 @@ class AuditLogService {
       if (params.textSearch) {
         const searchClauses = [
           `al.author ILIKE $${paramIndex}`,
-          `u.first_name || ' ' || u.last_name ILIKE $${paramIndex}`,
+          `concat_ws(' ', u.first_name, u.last_name) ILIKE $${paramIndex}`,
           `al.action_type ILIKE $${paramIndex}`,
           `al.audit_message::text ILIKE $${paramIndex}`,
         ];
@@ -108,7 +107,7 @@ class AuditLogService {
       const offset = params.pageIndex * params.pageSize;
       const dataSql = `
         SELECT al.id, al.author, al.action_type, al.audit_checksum,
-          al.audit_message, al.created_at
+          al.audit_message, al.created_at::text AS created_at
         ${fromClause}
         ${whereClause}
         ORDER BY al.created_at DESC

--- a/src/app/models/responses/collections.ts
+++ b/src/app/models/responses/collections.ts
@@ -19,3 +19,16 @@ export interface ValueSetFilterParams {
   codeSystem?: string;
   creatorNames?: string[];
 }
+
+export interface AuditLogFilterParams {
+  pageIndex: number;
+  pageSize: number;
+  author?: string;
+  actionType?: string;
+  textSearch?: string;
+  // action types whose UI label matches textSearch, so searches on
+  // human-readable action labels still hit the raw action_type column
+  searchedActionTypes?: string[];
+  startDate?: string;
+  endDate?: string;
+}


### PR DESCRIPTION
## Problem

The audit logs page loaded the **entire** `audit_logs` table on every visit — `SELECT * FROM audit_logs ORDER BY created_at DESC` with no `LIMIT` — shipping every row (including large `audit_message` JSON blobs: full sessions, profiles, value sets) to the client, which then filtered and paginated in memory. Since the table only grows (ONC triggers forbid deletes) and the only index was on `id`, load time degraded unboundedly.

## Solution

Ports the server-side pagination pattern from #883 (Code Library):

- **`getAuditLogsPaginated(params)`** replaces `getAuditLogs()`: builds a parameterized `WHERE` from the name/action/date-range/search filters, runs `COUNT(*)` + `LIMIT/OFFSET`, and returns a `QCPagedResponse<LogEntry>`. `audit_message` stays in the paged rows (bounded by page size ≤ 50) since the Action column and drawer both render from it.
- **`getAuditLogAuthors()` / `getAuditLogActionTypes()`** feed the filter dropdowns via `SELECT DISTINCT`, replacing the client-side derivation from the full dataset. Dropdowns now filter on raw DB values instead of display labels, fixing lossy label-based matching.
- **Text search** runs server-side against author, user full name (via a `users` join), action type, and the raw message JSON. The client additionally maps search terms matching human-readable action labels (e.g. "Patient discovery") to their raw action types so label searches keep working.
- **`V01_05` migration** adds indexes on `created_at`, `author`, and `action_type`.
- Tests reworked to mock the paginated API and assert filter params propagate.

### Notes for reviewers

- 🔒 The old `getAuditLogs` had **no permission check** — anyone authenticated could pull the full audit table via the server action. The three new actions are gated with `@superAdminRequired`, matching the page's SUPER_ADMIN-only access. This is an intentional tightening.
- Search behavior change: `%` and `_` in the search box now act as SQL `ILIKE` wildcards (same as the Code Library search); the old client-side search treated them literally.

## Verification

Verified end-to-end against a local DB seeded with 20,012 audit rows (~8MB table):

- Page reached "Showing 1 - 10 of 20012 actions" in **~700ms**; largest server-action payload was 112KB (previously the whole ~8MB table shipped on load).
- Pagination, page-size changes, name/action dropdowns, date range, and text search all round-trip to SQL correctly — including a search term that only appears inside a message JSON body (1 exact match) and a label-only search ("Patient discovery").
- Drawer still renders the full JSON request without an extra fetch.
- `EXPLAIN ANALYZE` on the page query: `Index Scan using audit_logs_created_at_index`, 0.07ms execution.
- 45/45 unit tests pass; lint and production build clean.