### PR TITLE
perf: Speed up Select Query step with lightweight query summaries

### DIFF
--- a/src/app/(pages)/query/components/SelectQuery.tsx
+++ b/src/app/(pages)/query/components/SelectQuery.tsx
@@ -22,6 +22,7 @@ interface SelectQueryProps {
     React.SetStateAction<PatientRecordsResponse | undefined>
   >;
   fhirServer: string;
+  fhirServers: string[];
   setFhirServer: React.Dispatch<React.SetStateAction<string>>;
   setLoading: (isLoading: boolean) => void;
   selectedQuery: CustomUserQuery;
@@ -38,6 +39,7 @@ interface SelectQueryProps {
  * @param root0.setResultsQueryResponse - Callback function to update selected
  * query
  * @param root0.fhirServer - the FHIR server that we're running the query against
+ * @param root0.fhirServers - list of available FHIR server names
  * @param root0.setFhirServer - callback function to update the FHIR server
  * @param root0.setLoading - callback to set the loading state
  * @returns - The selectQuery component.
@@ -45,6 +47,7 @@ interface SelectQueryProps {
 const SelectQuery: React.FC<SelectQueryProps> = ({
   patientForQuery,
   fhirServer,
+  fhirServers,
   goForward,
   goBack,
   setResultsQueryResponse,
@@ -97,6 +100,7 @@ const SelectQuery: React.FC<SelectQueryProps> = ({
       <SelectSavedQuery
         selectedQuery={selectedQuery}
         fhirServer={fhirServer}
+        fhirServers={fhirServers}
         goBack={goBack}
         setSelectedQuery={setSelectedQuery}
         handleSubmit={onSubmit}

--- a/src/app/(pages)/query/components/selectQuery/QueryRedirectDisplay.tsx
+++ b/src/app/(pages)/query/components/selectQuery/QueryRedirectDisplay.tsx
@@ -22,7 +22,10 @@ const QueryRedirectInfo: React.FC<QueryRedirectInfoProps> = ({ userRole }) => {
       const adminNames = admins.map((a) => `${a.firstName} ${a.lastName}`);
       setAdminNames(adminNames);
     }
-    fetchAdminNames();
+    // the admin contact list is only shown to standard users
+    if (userRole === UserRole.STANDARD) {
+      fetchAdminNames();
+    }
   }, []);
   return (
     <div className="padding-3 bg-info display-flex flex-align-start">

--- a/src/app/(pages)/query/components/selectQuery/QueryRedirectDisplay.tsx
+++ b/src/app/(pages)/query/components/selectQuery/QueryRedirectDisplay.tsx
@@ -22,11 +22,12 @@ const QueryRedirectInfo: React.FC<QueryRedirectInfoProps> = ({ userRole }) => {
       const adminNames = admins.map((a) => `${a.firstName} ${a.lastName}`);
       setAdminNames(adminNames);
     }
-    // the admin contact list is only shown to standard users
+    // the admin contact list is only shown to standard users; re-run if the
+    // role resolves after mount (e.g. the session was still loading)
     if (userRole === UserRole.STANDARD) {
       fetchAdminNames();
     }
-  }, []);
+  }, [userRole]);
   return (
     <div className="padding-3 bg-info display-flex flex-align-start">
       <Icon.Info

--- a/src/app/(pages)/query/components/selectQuery/SelectSavedQuery.test.tsx
+++ b/src/app/(pages)/query/components/selectQuery/SelectSavedQuery.test.tsx
@@ -1,0 +1,168 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import { fireEvent } from "@testing-library/react";
+import { RootProviderMock } from "@/app/tests/unit/setup";
+import SelectSavedQuery from "./SelectSavedQuery";
+import { getSavedQuerySummaries } from "@/app/backend/query-building/service";
+import { showToastConfirmation } from "@/app/ui/designSystem/toast/Toast";
+import { useSession } from "next-auth/react";
+import { UserRole } from "@/app/models/entities/users";
+import { CustomUserQuery } from "@/app/models/entities/query";
+
+jest.mock("@/app/backend/query-building/service", () => ({
+  getSavedQuerySummaries: jest.fn(),
+}));
+
+jest.mock("@/app/ui/designSystem/toast/Toast", () => ({
+  showToastConfirmation: jest.fn(),
+}));
+
+jest.mock("next-auth/react", () => ({
+  useSession: jest.fn(),
+}));
+
+// mocked so the import chains through userManagement/utils and
+// QueryRedirectDisplay don't pull in the real db pool, which keeps jest's
+// process alive after the run
+jest.mock("@/app/utils/auth", () => ({
+  isAuthDisabledClientCheck: jest.fn(() => false),
+}));
+
+jest.mock("@/app/backend/user-management", () => ({
+  getAllAdmins: jest.fn().mockResolvedValue([]),
+}));
+
+jest.mock("./NoQueriesDisplay", () => ({
+  __esModule: true,
+  default: () => <div data-testid="no-queries-display" />,
+}));
+
+const mockGetSavedQuerySummaries = getSavedQuerySummaries as jest.Mock;
+const mockUseSession = useSession as jest.Mock;
+
+const TEST_QUERIES = [
+  { queryId: "q1", queryName: "Chlamydia case investigation" },
+  { queryId: "q2", queryName: "Syphilis case investigation" },
+];
+
+const TEST_FHIR_SERVERS = ["HELIOS Meld", "Direwolf"];
+
+const blankQuery: CustomUserQuery = {
+  queryId: "",
+  queryName: "",
+  valuesets: [],
+};
+
+const defaultProps = {
+  selectedQuery: blankQuery,
+  setSelectedQuery: jest.fn(),
+  fhirServer: TEST_FHIR_SERVERS[0],
+  fhirServers: TEST_FHIR_SERVERS,
+  goBack: jest.fn(),
+  handleSubmit: jest.fn(),
+  setFhirServer: jest.fn(),
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockUseSession.mockReturnValue({
+    data: { user: { username: "tester", role: UserRole.SUPER_ADMIN } },
+  });
+  mockGetSavedQuerySummaries.mockResolvedValue(TEST_QUERIES);
+});
+
+describe("SelectSavedQuery", () => {
+  it("renders the available queries as dropdown options", async () => {
+    render(
+      <RootProviderMock currentPage="/query">
+        <SelectSavedQuery {...defaultProps} />
+      </RootProviderMock>,
+    );
+
+    await waitFor(() =>
+      expect(screen.getByLabelText("Query")).toBeInTheDocument(),
+    );
+
+    expect(mockGetSavedQuerySummaries).toHaveBeenCalledTimes(1);
+    expect(
+      screen.getByRole("option", { name: "Chlamydia case investigation" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("option", { name: "Syphilis case investigation" }),
+    ).toBeInTheDocument();
+  });
+
+  it("selects a query with empty valuesets when an option is chosen", async () => {
+    const setSelectedQuery = jest.fn();
+    render(
+      <RootProviderMock currentPage="/query">
+        <SelectSavedQuery
+          {...defaultProps}
+          setSelectedQuery={setSelectedQuery}
+        />
+      </RootProviderMock>,
+    );
+
+    await waitFor(() =>
+      expect(screen.getByLabelText("Query")).toBeInTheDocument(),
+    );
+
+    fireEvent.change(screen.getByLabelText("Query"), {
+      target: { value: "Syphilis case investigation" },
+    });
+
+    expect(setSelectedQuery).toHaveBeenCalledWith({
+      queryId: "q2",
+      queryName: "Syphilis case investigation",
+      valuesets: [],
+    });
+  });
+
+  it("shows the FHIR servers from props behind the advanced toggle", async () => {
+    render(
+      <RootProviderMock currentPage="/query">
+        <SelectSavedQuery {...defaultProps} />
+      </RootProviderMock>,
+    );
+
+    await waitFor(() =>
+      expect(screen.getByLabelText("Query")).toBeInTheDocument(),
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Advanced..." }));
+
+    TEST_FHIR_SERVERS.forEach((server) => {
+      expect(screen.getByRole("option", { name: server })).toBeInTheDocument();
+    });
+  });
+
+  it("shows the no-queries display when no queries are available", async () => {
+    mockGetSavedQuerySummaries.mockResolvedValue([]);
+
+    render(
+      <RootProviderMock currentPage="/query">
+        <SelectSavedQuery {...defaultProps} />
+      </RootProviderMock>,
+    );
+
+    await waitFor(() =>
+      expect(screen.getByTestId("no-queries-display")).toBeInTheDocument(),
+    );
+  });
+
+  it("shows an error toast when fetching queries fails", async () => {
+    mockGetSavedQuerySummaries.mockRejectedValue(new Error("boom"));
+
+    render(
+      <RootProviderMock currentPage="/query">
+        <SelectSavedQuery {...defaultProps} />
+      </RootProviderMock>,
+    );
+
+    await waitFor(() =>
+      expect(showToastConfirmation).toHaveBeenCalledWith({
+        body: "An error occurred. Please try again later",
+        variant: "error",
+      }),
+    );
+  });
+});

--- a/src/app/(pages)/query/components/selectQuery/SelectSavedQuery.tsx
+++ b/src/app/(pages)/query/components/selectQuery/SelectSavedQuery.tsx
@@ -1,30 +1,22 @@
 import { Select, Button } from "@trussworks/react-uswds";
 import Backlink from "../../../../ui/designSystem/backLink/Backlink";
 import styles from "./selectQuery.module.scss";
-import { useContext, useEffect, useState } from "react";
+import { useEffect, useState } from "react";
 import { RETURN_LABEL } from "@/app/(pages)/query/components/stepIndicator/StepIndicator";
 import TitleBox from "../stepIndicator/TitleBox";
 import { showToastConfirmation } from "../../../../ui/designSystem/toast/Toast";
-import { CustomUserQuery } from "@/app/models/entities/query";
-import {
-  getCustomQueries,
-  getQueriesForUser,
-} from "@/app/backend/query-building/service";
-import { User, UserRole } from "@/app/models/entities/users";
+import { CustomUserQuery, QuerySummary } from "@/app/models/entities/query";
+import { getSavedQuerySummaries } from "@/app/backend/query-building/service";
 import { getRole } from "@/app/(pages)/userManagement/utils";
-import { getUserByUsername } from "@/app/backend/user-management";
-import { useSession } from "next-auth/react";
-import { isAuthDisabledClientCheck } from "@/app/utils/auth";
-import { DataContext } from "@/app/utils/DataProvider";
 import NoQueriesDisplay from "./NoQueriesDisplay";
 import QueryRedirectInfo from "./QueryRedirectDisplay";
 import Skeleton from "react-loading-skeleton";
-import { getFhirServerNames } from "@/app/backend/fhir-servers/service";
 
 type SelectSavedQueryProps = {
   selectedQuery: CustomUserQuery;
   setSelectedQuery: React.Dispatch<React.SetStateAction<CustomUserQuery>>;
   fhirServer: string;
+  fhirServers: string[];
   goBack: () => void;
   handleSubmit: () => void;
   setFhirServer: React.Dispatch<React.SetStateAction<string>>;
@@ -39,58 +31,36 @@ type SelectSavedQueryProps = {
  * @param root0.setSelectedQuery - callback function for specified query
  * @param root0.handleSubmit - submit handler
  * @param root0.fhirServer - fhir server to apply a query against
+ * @param root0.fhirServers - list of available fhir server names
  * @param root0.setFhirServer - function to update the fhir server
  * @returns SelectedSavedQuery component
  */
 const SelectSavedQuery: React.FC<SelectSavedQueryProps> = ({
   selectedQuery,
   fhirServer,
+  fhirServers,
   goBack,
   setSelectedQuery,
   handleSubmit,
   setFhirServer,
 }) => {
   const [showAdvanced, setShowAdvanced] = useState(false);
-  const [fhirServers, setFhirServers] = useState<string[]>([]);
-  const [queryOptions, setQueryOptions] = useState<CustomUserQuery[]>([]);
+  const [queryOptions, setQueryOptions] = useState<QuerySummary[]>([]);
   const [loading, setLoading] = useState<boolean>(true);
-  const [_, setCurrentUser] = useState<User>();
 
-  const { data: session } = useSession();
-  const username = session?.user?.username || "";
   const userRole = getRole();
 
-  const ctx = useContext(DataContext);
-  const authDisabled = isAuthDisabledClientCheck(ctx?.runtimeConfig);
-
-  const restrictedQueryList =
-    !authDisabled &&
-    userRole !== UserRole.SUPER_ADMIN &&
-    userRole !== UserRole.ADMIN;
-
-  // Retrieve and store current logged-in user's data on page load
+  // Retrieve the queries available to the logged-in user on page load
   useEffect(() => {
     const fetchPageData = async () => {
       try {
-        const currentUser = await getUserByUsername(username);
-        setCurrentUser(currentUser.items[0]);
-
-        const servers = await getFhirServerNames();
-        setFhirServers(servers);
-
-        const queries = restrictedQueryList
-          ? await getQueriesForUser(currentUser.items[0] as User)
-          : await getCustomQueries();
-
-        const loaded = queries && (authDisabled || !!currentUser);
-        !!loaded && setQueryOptions(queries);
-      } catch (error) {
-        if (error == "Error: Unauthorized") {
-          showToastConfirmation({
-            body: "An error occurred. Please try again later",
-            variant: "error",
-          });
-        }
+        const queries = await getSavedQuerySummaries();
+        setQueryOptions(queries);
+      } catch {
+        showToastConfirmation({
+          body: "An error occurred. Please try again later",
+          variant: "error",
+        });
       } finally {
         setLoading(false);
       }
@@ -102,7 +72,11 @@ const SelectSavedQuery: React.FC<SelectSavedQueryProps> = ({
   function handleQuerySelection(queryName: string) {
     const selectedQuery = queryOptions.filter((q) => q.queryName === queryName);
     if (selectedQuery[0]) {
-      setSelectedQuery(selectedQuery[0]);
+      setSelectedQuery({
+        queryId: selectedQuery[0].queryId,
+        queryName: selectedQuery[0].queryName,
+        valuesets: [],
+      });
     } else {
       showToastConfirmation({
         body: "Please try again, or contact us if the error persists",

--- a/src/app/(pages)/query/page.tsx
+++ b/src/app/(pages)/query/page.tsx
@@ -132,6 +132,7 @@ const Query: React.FC = () => {
             patientDiscoveryResponse={patientDiscoveryQueryResponse}
             setResultsQueryResponse={setResultsQueryResponse}
             fhirServer={fhirServer}
+            fhirServers={fhirServers}
             setFhirServer={setFhirServer}
             setLoading={setLoading}
             selectedQuery={selectedQuery}

--- a/src/app/backend/fhir-servers/service.ts
+++ b/src/app/backend/fhir-servers/service.ts
@@ -72,12 +72,13 @@ class FhirServerConfigService extends FhirServerConfigServiceInternal {
   }
 
   static async getFhirServerNames(): Promise<string[]> {
-    const configs = await super.getFhirServerConfigs();
-    // Sort so that the default server is always first
-    configs.sort((a, b) =>
+    const configs = await FhirServerConfigService.getFhirServerConfigs();
+    // Sort a copy so that the default server is always first, without
+    // mutating the cached config array
+    const sortedConfigs = [...configs].sort((a, b) =>
       b.defaultServer === true ? 1 : a.defaultServer === true ? -1 : 0,
     );
-    return configs.map((config) => config.name);
+    return sortedConfigs.map((config) => config.name);
   }
 
   /**

--- a/src/app/backend/fhir-servers/service.ts
+++ b/src/app/backend/fhir-servers/service.ts
@@ -53,6 +53,10 @@ class FhirServerConfigServiceInternal {
 
 class FhirServerConfigService extends FhirServerConfigServiceInternal {
   private static cachedFhirServerConfigs: FhirServerConfig[] | null = null;
+  private static cacheFetchedAt = 0;
+  // Mutations clear the cache in-process, but other instances in a
+  // multi-instance deployment won't see them; the TTL bounds that staleness
+  private static readonly CACHE_TTL_MS = 60_000;
 
   /**
    * Fetches the configuration for a FHIR server from the database.
@@ -61,12 +65,17 @@ class FhirServerConfigService extends FhirServerConfigServiceInternal {
    */
   // @superAdminRequired
   static async getFhirServerConfigs(forceRefresh = false) {
+    const cacheExpired =
+      Date.now() - FhirServerConfigService.cacheFetchedAt >
+      FhirServerConfigService.CACHE_TTL_MS;
     if (
       forceRefresh ||
+      cacheExpired ||
       FhirServerConfigService.cachedFhirServerConfigs === null
     ) {
       const newServerConfigs = await super.getFhirServerConfigs();
       FhirServerConfigService.cachedFhirServerConfigs = newServerConfigs;
+      FhirServerConfigService.cacheFetchedAt = Date.now();
     }
     return FhirServerConfigService.cachedFhirServerConfigs;
   }

--- a/src/app/backend/query-building/service.ts
+++ b/src/app/backend/query-building/service.ts
@@ -15,8 +15,10 @@ import {
 } from "./lib";
 import dbService from "../db/service";
 import { getAllGroupQueries } from "../usergroup-management";
-import { User } from "@/app/models/entities/users";
-import { CustomUserQuery } from "@/app/models/entities/query";
+import { getUserRole } from "../user-management";
+import { User, UserRole } from "@/app/models/entities/users";
+import { CustomUserQuery, QuerySummary } from "@/app/models/entities/query";
+import { getLoggedInUser, isAuthDisabledServerCheck } from "@/app/utils/auth";
 import { DibbsValueSet } from "@/app/models/entities/valuesets";
 import { auditable } from "../audit-logs/decorator";
 import { linkTimeboxRangesToQuery } from "../query-timefiltering";
@@ -220,6 +222,43 @@ class QueryBuildingService {
   }
 
   /**
+   * Retrieves lightweight summaries of the saved queries available to the
+   * currently logged-in user, for rendering query lists/dropdowns without
+   * shipping the full nested valueset data. Admins and super admins (or
+   * auth-disabled mode) see all queries; standard users see only queries
+   * assigned to a user group they belong to, resolved in a single SQL query.
+   * @returns An array of QuerySummary objects sorted by query name
+   */
+  static async getSavedQuerySummaries(): Promise<QuerySummary[]> {
+    let unrestricted = true;
+    let username = "";
+
+    if (!isAuthDisabledServerCheck()) {
+      const user = await getLoggedInUser();
+      username = user?.username ?? "";
+      const role = await getUserRole(username);
+      unrestricted = role === UserRole.SUPER_ADMIN || role === UserRole.ADMIN;
+    }
+
+    const query = `
+      SELECT DISTINCT q.id AS query_id, q.query_name
+      FROM query q
+      WHERE $2 = TRUE
+        OR EXISTS (
+          SELECT 1
+          FROM usergroup_to_query ugtq
+          JOIN usergroup_to_users ugtu ON ugtu.usergroup_id = ugtq.usergroup_id
+          JOIN users u ON u.id = ugtu.user_id
+          WHERE ugtq.query_id = q.id AND u.username = $1
+        )
+      ORDER BY q.query_name ASC;
+    `;
+
+    const result = await dbService.query(query, [username, unrestricted]);
+    return result.rows as QuerySummary[];
+  }
+
+  /**
    * @param currentUser - Method to retrieve all queries assigned to groups that
    * the given user is a member of
    * @returns an array of CustomUserQuery objects
@@ -316,6 +355,8 @@ export const getCustomQueries = QueryBuildingService.getCustomQueries;
 export const getQueryList = QueryBuildingService.getQueryList;
 export const getQueryById = QueryBuildingService.getQueryById;
 export const getQueriesForUser = QueryBuildingService.getQueriesForUser;
+export const getSavedQuerySummaries =
+  QueryBuildingService.getSavedQuerySummaries;
 export const getConditionsData = QueryBuildingService.getConditionsData;
 export const getValueSetsAndConceptsByConditionIDs =
   QueryBuildingService.getValueSetsAndConceptsByConditionIDs;

--- a/src/app/backend/usergroup-management.ts
+++ b/src/app/backend/usergroup-management.ts
@@ -4,7 +4,6 @@ import { getSingleUserWithGroupMemberships } from "./user-management";
 
 import { QCResponse } from "../models/responses/collections";
 import { CustomUserQuery } from "../models/entities/query";
-import { QueryResult } from "pg";
 import dbService from "./db/service";
 import { adminRequired } from "./db/decorators";
 import { auditable } from "./audit-logs/decorator";
@@ -370,26 +369,46 @@ class UserGroupManagementService {
         groupId,
       ]);
 
-      const groupQueries = await Promise.all(
-        result.rows.map(async (row) => {
-          const groupAssignments =
-            await UserGroupManagementService.fetchQueryGroupAssignmentDetails(
-              result,
-            );
-          const { queryId, queryName, queryData, conditionsList } = row;
+      const queryIds = result.rows.map((row) => row.queryId);
+      const assignmentsByQueryId: Record<string, UserGroupMembership[]> = {};
 
-          const formattedQuery: CustomUserQuery = {
-            queryId,
-            queryName,
-            valuesets: queryData,
-            conditionsList,
-            groupAssignments: groupAssignments,
-          };
+      if (queryIds.length > 0) {
+        const selectAssignmentsQuery = `
+      SELECT ugtq.query_id, ugtq.id AS membership_id, ug.name AS usergroup_name, ug.id AS usergroup_id
+      FROM usergroup_to_query ugtq
+      JOIN usergroup ug ON ug.id = ugtq.usergroup_id
+      WHERE ugtq.query_id = ANY($1::uuid[]);
+      `;
+        const assignmentResults = await dbService.query(
+          selectAssignmentsQuery,
+          [queryIds],
+        );
 
-          await dbService.query("COMMIT");
-          return formattedQuery;
-        }),
-      );
+        assignmentResults.rows.forEach((row) => {
+          const { queryId, membershipId, usergroupName, usergroupId } = row;
+          assignmentsByQueryId[queryId] ??= [];
+          assignmentsByQueryId[queryId].push({
+            membershipId,
+            usergroupName,
+            usergroupId,
+            isMember: true,
+          });
+        });
+      }
+
+      const groupQueries = result.rows.map((row) => {
+        const { queryId, queryName, queryData, conditionsList } = row;
+
+        const formattedQuery: CustomUserQuery = {
+          queryId,
+          queryName,
+          valuesets: queryData,
+          conditionsList,
+          groupAssignments: assignmentsByQueryId[queryId] ?? [],
+        };
+
+        return formattedQuery;
+      });
 
       return {
         totalItems: result.rowCount,
@@ -547,29 +566,6 @@ class UserGroupManagementService {
       console.error("Error fetching groups for query:", error);
       throw error;
     }
-  }
-
-  /**
-   * Retrieves group assignment data for the given queries and formats it on the CustomUserQuery object
-   * @param queryList - The queries whose group assignments we are retrieving
-   * @returns The updated query record list or an error if the update fails.
-   */
-  static async fetchQueryGroupAssignmentDetails(queryList: QueryResult) {
-    const queries = await Promise.all(
-      queryList.rows.map(async (query) => {
-        try {
-          const groupWithQuery = await getSingleQueryGroupAssignments(
-            query.queryId,
-          );
-          return groupWithQuery.items[0];
-        } catch (error) {
-          console.error(error);
-          throw error;
-        }
-      }),
-    );
-
-    return queries;
   }
 }
 

--- a/src/app/models/entities/query.ts
+++ b/src/app/models/entities/query.ts
@@ -4,6 +4,15 @@ import { DibbsValueSet } from "./valuesets";
 import { MedicalRecordSections } from "@/app/(pages)/queryBuilding/utils";
 import { PatientMatchData } from "@/app/backend/fhir-servers/service";
 
+/**
+ * Minimal saved-query representation for list/dropdown rendering, where the
+ * full nested valueset data isn't needed.
+ */
+export interface QuerySummary {
+  queryId: string;
+  queryName: string;
+}
+
 export interface CustomUserQuery {
   queryId: string;
   queryName: string;

--- a/src/app/tests/integration/usergroup-query-filtering.test.ts
+++ b/src/app/tests/integration/usergroup-query-filtering.test.ts
@@ -1,5 +1,6 @@
 import {
   addQueriesToGroup,
+  addUsersToGroup,
   getAllGroupQueries,
 } from "@/app/backend/usergroup-management";
 import { getAllUsersWithSingleGroupStatus } from "@/app/backend/user-management";
@@ -7,14 +8,21 @@ import { dontUseOutsideConfigOrTests_getDbPool } from "@/app/backend/db/config";
 import { User } from "@/app/models/entities/users";
 import { suppressConsoleLogs } from "./fixtures";
 import { QueryDataColumn } from "@/app/(pages)/queryBuilding/utils";
-import { getQueriesForUser } from "@/app/backend/query-building/service";
+import {
+  getQueriesForUser,
+  getSavedQuerySummaries,
+} from "@/app/backend/query-building/service";
 import { CustomUserQuery } from "@/app/models/entities/query";
 
 const dbClient = dontUseOutsideConfigOrTests_getDbPool();
 
+const mockGetLoggedInUser = jest.fn();
+
 jest.mock("@/app/utils/auth", () => ({
   superAdminAccessCheck: jest.fn(() => Promise.resolve(true)),
   adminAccessCheck: jest.fn(() => Promise.resolve(true)),
+  isAuthDisabledServerCheck: jest.fn(() => false),
+  getLoggedInUser: () => mockGetLoggedInUser(),
 }));
 
 const TEST_GROUP_ID = "00000000-0000-0000-0000-000000000007";
@@ -163,6 +171,39 @@ describe("User Group and Query Membership Tests", () => {
     ).toBe(true);
   });
 
-  //tests for superAdmins and them seeing evertyhing
-  //tests for other logged in users to make sure they do NOT see everything
+  /**
+   * Tests that query summaries for a standard user only include queries
+   * assigned to a group the user belongs to.
+   */
+  test("should restrict query summaries for a standard user to their group's queries", async () => {
+    // mamaTroi is a Standard user; add them to the test group, which has
+    // queries 2 and 3 assigned by the previous test
+    await addUsersToGroup(TEST_GROUP_ID, [TEST_USER_2_ID]);
+    await dbClient.query("COMMIT");
+
+    mockGetLoggedInUser.mockResolvedValue({ username: "mamaTroi" });
+
+    const summaries = await getSavedQuerySummaries();
+
+    expect(summaries.length).toBe(2);
+    expect(summaries.map((s) => s.queryId).sort()).toEqual(
+      [TEST_QUERY_2_ID, TEST_QUERY_3_ID].sort(),
+    );
+    // summaries are lightweight: no valuesets / query data included
+    expect(Object.keys(summaries[0]).sort()).toEqual(["queryId", "queryName"]);
+  });
+
+  /**
+   * Tests that super admins see all queries in their summaries.
+   */
+  test("should return all queries in summaries for a super admin", async () => {
+    mockGetLoggedInUser.mockResolvedValue({ username: "QtheMagnificent" });
+
+    const summaries = await getSavedQuerySummaries();
+
+    const summaryIds = summaries.map((s) => s.queryId);
+    [TEST_QUERY_1_ID, TEST_QUERY_2_ID, TEST_QUERY_3_ID].forEach((queryId) => {
+      expect(summaryIds).toContain(queryId);
+    });
+  });
 });


### PR DESCRIPTION
## Problem

Step 3 of the query flow ("Select a query") loaded slowly. On mount it ran **three sequential server actions**:

1. `getUserByUsername` (itself ~3 sequential DB queries) — only needed to feed the non-admin path
2. `getFhirServerNames` — an uncached `SELECT * FROM fhir_servers`, duplicating a fetch the parent page already made
3. The query list:
   - Admin path: `getCustomQueries()` shipped **every query's full valueset/concept JSONB** to the browser — ~124 KB with just the 5 demo queries — to render a dropdown that only needs names
   - Standard-user path: `getQueriesForUser` → `getAllGroupQueries`, which was **O(N²) in DB round trips** and issued a no-op `COMMIT` per row

## Changes

- **New `getSavedQuerySummaries` server action**: returns only `{queryId, queryName}`, with the admin/standard-user restriction resolved server-side in a single SQL query (group-membership `EXISTS` filter). Step 3 now makes exactly **one ~0.5 KB call** instead of a 4-call, ~124 KB waterfall. Side benefit: the role check was previously computed on the client and is now enforced server-side.
- **`fhirServers` threaded down as props** from `page.tsx` (which already fetches it) through `SelectQuery` to `SelectSavedQuery`, removing the duplicate fetch.
- **`getFhirServerNames` uses the cached configs** (`cachedFhirServerConfigs`, invalidated on all mutations and now with a **60s TTL** so other instances in a multi-instance deployment pick up server mutations without a restart) and sorts a copy instead of mutating the cached array.
- **`getAllGroupQueries` fixed**: one batched assignments query (`WHERE query_id = ANY($1)`) replaces the per-row N² lookups + per-row `COMMIT`s. This also fixes a data bug — every query in a group previously received the identical, truncated `groupAssignments` array. Removed the now-dead `fetchQueryGroupAssignmentDetails`. This also speeds up User Management and the query-building repository.
- **`QueryRedirectInfo`** only fetches admin contact names for standard users (the only role shown the list). The effect depends on `userRole`, so it still runs if the session resolves after mount.

## Verification

- Drove the full flow with Playwright against the dev stack: step 3 load went from 4 sequential POSTs / ~124 KB to 1 POST / 532 bytes; dropdown, Advanced HCO toggle (zero extra fetches), submit → Patient Record, and back-navigation remount all work.
- User Management "Assigned Queries" drawer shows correct per-query assignments (2 of 5 checked for a seeded group).
- 613/613 unit tests (incl. new `SelectSavedQuery.test.tsx`), 106/106 integration tests (incl. new coverage asserting standard users only see group-assigned query summaries and admins see all), lint clean.

## Notes for review

- `selectedQuery.valuesets` is now always `[]` on the client during the flow — verified nothing downstream reads it (submit sends `queryName`; the server resolves the full query; `ResultsView` uses only `queryName`).
- `getCustomQueries` / `getQueriesForUser` are unchanged for their other callers (query building, user management), which consume the full payloads.
