### PR TITLE
fix: persist SMART on FHIR signing keys in the database

### DIFF
--- a/flyway/sql/V01_06__create_signing_keys.sql
+++ b/flyway/sql/V01_06__create_signing_keys.sql
@@ -1,0 +1,12 @@
+-- Persist SMART on FHIR signing keys in the database so they survive container
+-- restarts/redeploys and are shared across replicas. Previously keys were
+-- generated on the ephemeral container filesystem, which silently rotated the
+-- key (and its kid) on every restart, breaking external JWKS registrations.
+CREATE TABLE IF NOT EXISTS signing_keys (
+    kid TEXT PRIMARY KEY,
+    alg TEXT NOT NULL DEFAULT 'RS384',
+    private_key_pem TEXT NOT NULL,
+    public_jwk JSONB NOT NULL,
+    active BOOLEAN NOT NULL DEFAULT TRUE,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);

--- a/setup-scripts/gen-keys.ts
+++ b/setup-scripts/gen-keys.ts
@@ -1,4 +1,3 @@
-import { importPKCS8, SignJWT } from "jose";
 import { generateKeyPair, exportJWK, exportPKCS8 } from "jose";
 import path from "path";
 import fs from "fs";
@@ -6,119 +5,10 @@ import crypto from "crypto";
 
 // This file is here to generate the JWKS keys needed for our SMART on FHIR
 // e2e test. It's invoked in our bash scripts for our e2e's.
-
-export const DEFAULT_LOCAL_JWKS_HOSTNAME =
-  "http://host.docker.internal:3000/.well-known/jwks.json";
-
-/**
- * Get the JWKS data from the file system
- * @returns The JWKS data
- */
-export function getJwks() {
-  try {
-    const jwksPath = path.join(process.cwd(), "keys", "jwks.json");
-    const jwksContent = fs.readFileSync(jwksPath, "utf-8");
-    return JSON.parse(jwksContent);
-  } catch (error) {
-    console.error("Error loading JWKS:", error);
-    throw new Error("Failed to load JWKS");
-  }
-}
-
-/**
- * Get the private key for signing JWTs
- * @returns The private key
- */
-export function getPrivateKey() {
-  try {
-    const keyPath = path.join(process.cwd(), "keys", "rsa-private.pem");
-    return fs.readFileSync(keyPath, "utf-8");
-  } catch (error) {
-    console.error("Error loading private key:", error);
-    throw new Error("Failed to load private key");
-  }
-}
-
-/**
- * Get the public key for verifying JWTs
- * @returns The public key
- */
-export function getPublicKey() {
-  try {
-    const keyPath = path.join(process.cwd(), "keys", "rsa-public.pem");
-    return fs.readFileSync(keyPath, "utf-8");
-  } catch (error) {
-    console.error("Error loading public key:", error);
-    throw new Error("Failed to load public key");
-  }
-}
-
-/**
- * Get the kid (Key ID) from the JWKS
- * @returns The key ID
- */
-export function getKeyId() {
-  const jwks = getJwks();
-  if (jwks.keys && jwks.keys.length > 0) {
-    return jwks.keys[0].kid;
-  }
-  throw new Error("No key ID found in JWKS");
-}
-
-/**
- * Create and sign a JWT for SMART on FHIR authentication
- * @param clientId - The client ID
- * @param tokenEndpoint - The token endpoint URL
- * @returns The signed JWT
- */
-export async function createSmartJwt(clientId: string, tokenEndpoint: string) {
-  try {
-    // Get the private key and key ID
-    const privateKeyPem = getPrivateKey();
-    const kid = getKeyId();
-    const alg = "RS384";
-
-    // Convert PEM to private key
-    const privateKey = await importPKCS8(privateKeyPem, alg);
-
-    // Create unique JWT ID
-    const jti = crypto.randomUUID();
-
-    // Get current time and expiry
-    const now = Math.floor(Date.now() / 1000);
-    const exp = now + 300; // 5 minutes
-
-    // Determine the JWKS URL - make sure this is an absolute URL that Aidbox can reach
-    const jku = process.env.APP_HOSTNAME
-      ? `${process.env.APP_HOSTNAME}/.well-known/jwks.json`
-      : DEFAULT_LOCAL_JWKS_HOSTNAME;
-
-    // Create payload
-    const payload = {
-      iss: clientId, // Issuer (your client ID)
-      sub: clientId, // Subject (your client ID)
-      aud: tokenEndpoint, // Audience (token endpoint URL)
-      exp, // Expiration time
-      jti, // Unique identifier
-      iat: now, // Issued at time
-    };
-
-    // Create and sign the JWT
-    const jwt = await new SignJWT(payload)
-      .setProtectedHeader({
-        alg, // Algorithm (RSA with SHA-384)
-        typ: "JWT", // Type
-        kid, // Key ID from your JWKS
-        jku, // JWK Set URL
-      })
-      .sign(privateKey);
-
-    return jwt;
-  } catch (error) {
-    console.error("Error creating JWT:", error);
-    throw new Error("Failed to create JWT");
-  }
-}
+//
+// At runtime the app persists its signing key in the database (see
+// src/app/backend/signing-keys.ts); keys generated here are picked up by that
+// service's legacy disk-import path on first run.
 
 // Ensure keys directory exists
 function ensureKeysDirectory() {

--- a/src/app/(pages)/.well-known/jwks.json/route.ts
+++ b/src/app/(pages)/.well-known/jwks.json/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from "next/server";
-import { getOrCreateKeys } from "../../../../../setup-scripts/gen-keys";
+import { getSigningJwks } from "@/app/backend/signing-keys";
 
 /**
  * API endpoint for the SMART on FHIR auth flow
@@ -8,7 +8,7 @@ import { getOrCreateKeys } from "../../../../../setup-scripts/gen-keys";
 export async function GET() {
   try {
     // Get or create JWKS
-    const jwks = await getOrCreateKeys();
+    const jwks = await getSigningJwks();
 
     // Return the JWKS as JSON with appropriate headers
     return NextResponse.json(jwks, {

--- a/src/app/backend/signing-keys.ts
+++ b/src/app/backend/signing-keys.ts
@@ -1,0 +1,199 @@
+import fs from "fs";
+import path from "path";
+import crypto from "crypto";
+import { exportJWK, exportPKCS8, generateKeyPair, JWK } from "jose";
+import dbService, { DbClient } from "./db/service";
+
+export type SigningKey = {
+  kid: string;
+  alg: string;
+  privateKeyPem: string;
+  publicJwk: JWK;
+};
+
+const SIGNING_KEY_ALG = "RS384";
+
+// Arbitrary constant naming the Postgres advisory lock that serializes
+// first-time key creation, so concurrent replicas can't each generate a
+// different key.
+const SIGNING_KEYS_LOCK_ID = 728394001;
+
+const SELECT_CURRENT_KEY = `
+  SELECT kid, alg, private_key_pem, public_jwk
+  FROM signing_keys
+  WHERE active = TRUE
+  ORDER BY created_at DESC, kid
+  LIMIT 1;
+`;
+
+// The signing key is immutable for the lifetime of the process (rotation adds
+// a new row and only takes effect on restart), so a module-level cache avoids
+// a DB round trip per token request.
+let cachedSigningKey: SigningKey | undefined;
+
+/**
+ * Clear the in-memory signing key cache. Only intended for tests that need to
+ * exercise the DB read/create paths repeatedly within one process.
+ */
+export function clearSigningKeyCache() {
+  cachedSigningKey = undefined;
+}
+
+/**
+ * Get the signing key for SMART on FHIR JWT assertions, creating and
+ * persisting one if none exists yet. Keys live in the database so they
+ * survive restarts and are shared across replicas. On first run, any key
+ * pair already present on disk (from a previous version of the app, which
+ * stored keys on the container filesystem) is imported so external JWKS
+ * registrations keep working.
+ * @param keysDir - Directory searched for legacy on-disk keys to import.
+ * Defaults to the `keys` directory the previous file-based implementation
+ * wrote to.
+ * @returns The active signing key
+ */
+export async function getOrCreateSigningKey(
+  keysDir: string = path.join(process.cwd(), "keys"),
+): Promise<SigningKey> {
+  if (cachedSigningKey) {
+    return cachedSigningKey;
+  }
+
+  const existing = await dbService.query(SELECT_CURRENT_KEY);
+  if (existing.rows.length > 0) {
+    cachedSigningKey = existing.rows[0] as SigningKey;
+    return cachedSigningKey;
+  }
+
+  await createSigningKey(keysDir);
+
+  // Re-read rather than trusting the insert result: if a concurrent replica
+  // won the race, its key is the one we must sign with.
+  const persisted = await dbService.query(SELECT_CURRENT_KEY);
+  if (persisted.rows.length === 0) {
+    throw new Error("Failed to load or create signing key");
+  }
+  cachedSigningKey = persisted.rows[0] as SigningKey;
+  return cachedSigningKey;
+}
+
+/**
+ * Get the JWKS containing the public keys of all active signing keys, for
+ * serving at /.well-known/jwks.json. Ensures a key exists so that partners
+ * can register the JWKS URL before the app has ever signed a JWT.
+ * @returns The JWKS key set
+ */
+export async function getSigningJwks(): Promise<{ keys: JWK[] }> {
+  await getOrCreateSigningKey();
+
+  const result = await dbService.query(
+    `SELECT public_jwk FROM signing_keys WHERE active = TRUE ORDER BY created_at, kid;`,
+  );
+  return { keys: result.rows.map((r) => r.publicJwk as JWK) };
+}
+
+/**
+ * Insert a signing key inside a transaction guarded by an advisory lock,
+ * importing legacy on-disk keys when present and generating a fresh key pair
+ * otherwise. No-ops if another caller already inserted a key.
+ * @param keysDir - Directory searched for legacy on-disk keys
+ */
+async function createSigningKey(keysDir: string): Promise<void> {
+  const client = new DbClient();
+  await client.connect();
+  try {
+    await client.query("BEGIN");
+    await client.query("SELECT pg_advisory_xact_lock($1)", [
+      SIGNING_KEYS_LOCK_ID,
+    ]);
+
+    // Another replica may have created the key while we waited on the lock
+    const existing = await client.query(SELECT_CURRENT_KEY);
+    if (existing.rows.length === 0) {
+      const material =
+        importKeysFromDisk(keysDir) ?? (await generateKeyMaterial());
+      const inserted = await client.query(
+        `INSERT INTO signing_keys (kid, alg, private_key_pem, public_jwk)
+         VALUES ($1, $2, $3, $4)
+         RETURNING kid;`,
+        [
+          material.kid,
+          material.alg,
+          material.privateKeyPem,
+          JSON.stringify(material.publicJwk),
+        ],
+      );
+      if (inserted.rows.length === 0) {
+        throw new Error("Signing key insert returned no rows");
+      }
+      console.info("Persisted new signing key. Key ID:", material.kid);
+    }
+
+    await client.query("COMMIT");
+  } catch (error) {
+    await client.query("ROLLBACK");
+    throw error;
+  } finally {
+    await client.disconnect();
+  }
+}
+
+/**
+ * Generate a fresh RSA key pair as signing key material.
+ * @returns The generated key
+ */
+async function generateKeyMaterial(): Promise<SigningKey> {
+  const { privateKey, publicKey } = await generateKeyPair(SIGNING_KEY_ALG, {
+    modulusLength: 2048,
+    extractable: true,
+  });
+
+  const kid = crypto.randomUUID();
+  const publicJwk = await exportJWK(publicKey);
+  publicJwk.kid = kid;
+  publicJwk.alg = SIGNING_KEY_ALG;
+  publicJwk.use = "sig";
+
+  return {
+    kid,
+    alg: SIGNING_KEY_ALG,
+    privateKeyPem: await exportPKCS8(privateKey),
+    publicJwk,
+  };
+}
+
+/**
+ * Read a legacy file-based key pair (keys/jwks.json + keys/rsa-private.pem)
+ * if one exists, so deployments upgrading from the file-based implementation
+ * keep the key their partners have registered.
+ * @param keysDir - Directory to search
+ * @returns The imported key, or undefined if no usable key pair was found
+ */
+function importKeysFromDisk(keysDir: string): SigningKey | undefined {
+  try {
+    const jwksPath = path.join(keysDir, "jwks.json");
+    const privateKeyPath = path.join(keysDir, "rsa-private.pem");
+    if (!fs.existsSync(jwksPath) || !fs.existsSync(privateKeyPath)) {
+      return undefined;
+    }
+
+    const jwks = JSON.parse(fs.readFileSync(jwksPath, "utf-8"));
+    const publicJwk: JWK | undefined = jwks?.keys?.[0];
+    if (!publicJwk?.kid) {
+      return undefined;
+    }
+
+    console.info("Importing signing key from disk. Key ID:", publicJwk.kid);
+    return {
+      kid: publicJwk.kid,
+      alg: publicJwk.alg ?? SIGNING_KEY_ALG,
+      privateKeyPem: fs.readFileSync(privateKeyPath, "utf-8"),
+      publicJwk,
+    };
+  } catch (error) {
+    console.error(
+      "Found on-disk keys but could not import them; generating a new key instead:",
+      error,
+    );
+    return undefined;
+  }
+}

--- a/src/app/backend/signing-keys.ts
+++ b/src/app/backend/signing-keys.ts
@@ -88,6 +88,13 @@ export async function getSigningJwks(): Promise<{ keys: JWK[] }> {
   const result = await dbService.query(
     `SELECT public_jwk FROM signing_keys WHERE active = TRUE ORDER BY created_at, kid;`,
   );
+  // getOrCreateSigningKey guarantees at least one active key, so an empty
+  // result means the read failed (dbService.query swallows errors into an
+  // empty result set). Verifiers that refetch our JWKS must get an error
+  // response, never a 200 with no keys they could cache.
+  if (result.rows.length === 0) {
+    throw new Error("Failed to load signing keys for JWKS");
+  }
   return { keys: result.rows.map((r) => r.publicJwk as JWK) };
 }
 
@@ -102,9 +109,16 @@ async function createSigningKey(keysDir: string): Promise<void> {
   await client.connect();
   try {
     await client.query("BEGIN");
-    await client.query("SELECT pg_advisory_xact_lock($1)", [
+    // DbClient.query swallows errors into an empty result set, so a failed
+    // BEGIN wouldn't throw. The lock statement errors outside a transaction
+    // and returns exactly one row inside one, so an empty result here means
+    // we do NOT hold the lock (or the transaction) and must not proceed.
+    const lock = await client.query("SELECT pg_advisory_xact_lock($1)", [
       SIGNING_KEYS_LOCK_ID,
     ]);
+    if (lock.rows.length !== 1) {
+      throw new Error("Failed to acquire signing key advisory lock");
+    }
 
     // Another replica may have created the key while we waited on the lock
     const existing = await client.query(SELECT_CURRENT_KEY);
@@ -182,11 +196,36 @@ function importKeysFromDisk(keysDir: string): SigningKey | undefined {
       return undefined;
     }
 
+    // A mismatched pair persisted here would be permanent: every assertion
+    // would be signed with a key the served JWKS can't verify, and unlike the
+    // old file-based flow a restart wouldn't heal it.
+    const privateKeyPem = fs.readFileSync(privateKeyPath, "utf-8");
+    const probe = Buffer.from("signing-key-pair-check");
+    const signature = crypto.sign(
+      "sha384",
+      probe,
+      crypto.createPrivateKey(privateKeyPem),
+    );
+    const pairMatches = crypto.verify(
+      "sha384",
+      probe,
+      crypto.createPublicKey({
+        key: publicJwk as crypto.JsonWebKey,
+        format: "jwk",
+      }),
+      signature,
+    );
+    if (!pairMatches) {
+      throw new Error(
+        "On-disk private key does not match the public JWK in jwks.json",
+      );
+    }
+
     console.info("Importing signing key from disk. Key ID:", publicJwk.kid);
     return {
       kid: publicJwk.kid,
       alg: publicJwk.alg ?? SIGNING_KEY_ALG,
-      privateKeyPem: fs.readFileSync(privateKeyPath, "utf-8"),
+      privateKeyPem,
       publicJwk,
     };
   } catch (error) {

--- a/src/app/backend/smart-on-fhir.ts
+++ b/src/app/backend/smart-on-fhir.ts
@@ -1,63 +1,11 @@
-import fs from "fs";
-import path from "path";
 import { importPKCS8, SignJWT } from "jose";
 import crypto from "crypto";
-import { DEFAULT_LOCAL_JWKS_HOSTNAME } from "../../../setup-scripts/gen-keys";
+import { getOrCreateSigningKey } from "./signing-keys";
 
-/**
- * Get the JWKS data from the file system
- * @returns The JWKS data
- */
-export function getJwks() {
-  try {
-    const jwksPath = path.join(process.cwd(), "keys", "jwks.json");
-    const jwksContent = fs.readFileSync(jwksPath, "utf-8");
-    return JSON.parse(jwksContent);
-  } catch (error) {
-    console.error("Error loading JWKS:", error);
-    throw new Error("Failed to load JWKS");
-  }
-}
-
-/**
- * Get the private key for signing JWTs
- * @returns The private key
- */
-export function getPrivateKey() {
-  try {
-    const keyPath = path.join(process.cwd(), "keys", "rsa-private.pem");
-    return fs.readFileSync(keyPath, "utf-8");
-  } catch (error) {
-    console.error("Error loading private key:", error);
-    throw new Error("Failed to load private key");
-  }
-}
-
-/**
- * Get the public key for verifying JWTs
- * @returns The public key
- */
-export function getPublicKey() {
-  try {
-    const keyPath = path.join(process.cwd(), "keys", "rsa-public.pem");
-    return fs.readFileSync(keyPath, "utf-8");
-  } catch (error) {
-    console.error("Error loading public key:", error);
-    throw new Error("Failed to load public key");
-  }
-}
-
-/**
- * Get the kid (Key ID) from the JWKS
- * @returns The key ID
- */
-export function getKeyId() {
-  const jwks = getJwks();
-  if (jwks.keys && jwks.keys.length > 0) {
-    return jwks.keys[0].kid;
-  }
-  throw new Error("No key ID found in JWKS");
-}
+// Epic (and the SMART spec) reject assertions whose exp is more than 5
+// minutes in the future at the time the request is *received*; 4 minutes
+// leaves margin for clock skew and network latency.
+const JWT_EXPIRY_SECONDS = 240;
 
 /**
  * Create and sign a JWT for SMART on FHIR authentication
@@ -67,43 +15,28 @@ export function getKeyId() {
  */
 export async function createSmartJwt(clientId: string, tokenEndpoint: string) {
   try {
-    // Get the private key and key ID
-    const privateKeyPem = getPrivateKey();
-    const kid = getKeyId();
-    const alg = "RS384";
-
-    // Convert PEM to private key
+    const { kid, alg, privateKeyPem } = await getOrCreateSigningKey();
     const privateKey = await importPKCS8(privateKeyPem, alg);
 
-    // Create unique JWT ID
-    const jti = crypto.randomUUID();
-
-    // Get current time and expiry
     const now = Math.floor(Date.now() / 1000);
-    const exp = now + 300; // 5 minutes
 
-    // Determine the JWKS URL - make sure this is an absolute URL that Aidbox can reach
-    const jku = process.env.APP_HOSTNAME
-      ? `${process.env.APP_HOSTNAME}/.well-known/jwks.json`
-      : DEFAULT_LOCAL_JWKS_HOSTNAME;
-
-    // Create payload
     const payload = {
       iss: clientId, // Issuer (your client ID)
       sub: clientId, // Subject (your client ID)
       aud: tokenEndpoint, // Audience (token endpoint URL)
-      exp, // Expiration time
-      jti, // Unique identifier
+      exp: now + JWT_EXPIRY_SECONDS,
+      jti: crypto.randomUUID(), // Unique identifier
       iat: now, // Issued at time
     };
 
-    // Create and sign the JWT
+    // No jku header: token servers must verify against the JWKS URL (or
+    // static key) registered for the client, and Epic rejects assertions
+    // whose jku differs from the registered JWK Set URL.
     const jwt = await new SignJWT(payload)
       .setProtectedHeader({
-        alg, // Algorithm (RSA with SHA-384)
-        typ: "JWT", // Type
-        kid, // Key ID from your JWKS
-        jku, // JWK Set URL
+        alg,
+        typ: "JWT",
+        kid,
       })
       .sign(privateKey);
 

--- a/src/app/tests/integration/api-query.test.ts
+++ b/src/app/tests/integration/api-query.test.ts
@@ -61,7 +61,6 @@ jest.mock("@/app/backend/fhir-servers/fhir-client", () => {
 });
 
 import { validateServiceToken } from "@/app/api/api-auth";
-import { getOrCreateKeys } from "../../../../setup-scripts/gen-keys";
 import { createSmartJwt } from "@/app/backend/smart-on-fhir";
 import { E2E_SMART_TEST_CLIENT_ID } from "../../../../e2e/constants";
 import { decodeJwt, decodeProtectedHeader } from "jose";
@@ -462,9 +461,6 @@ describe("SMART on FHIR JWT creation", () => {
   it("generates the correct token and signing creates the right request payload", async () => {
     const tokenEndpoint = `${process.env.AIDBOX_BASE_URL}/auth/token`;
 
-    // make sure key pair exist, and create them if they don't
-    await getOrCreateKeys();
-
     const outputJWT = await createSmartJwt(
       E2E_SMART_TEST_CLIENT_ID,
       tokenEndpoint,
@@ -473,12 +469,15 @@ describe("SMART on FHIR JWT creation", () => {
     const header = decodeProtectedHeader(outputJWT);
     expect(header.alg).toBe("RS384");
     expect(header.typ).toBe("JWT");
-    expect(header.jku).toBe(
-      `${process.env.APP_HOSTNAME}/.well-known/jwks.json`,
-    );
+    // Epic rejects assertions whose jku differs from the registered JWK Set
+    // URL, so we must not send one
+    expect(header.jku).toBeUndefined();
     const claims = decodeJwt(outputJWT);
     expect(claims.aud).toBe(tokenEndpoint);
     expect(claims.iss).toBe(E2E_SMART_TEST_CLIENT_ID);
     expect(claims.sub).toBe(E2E_SMART_TEST_CLIENT_ID);
+    // Epic rejects assertions expiring more than 5 minutes out; we sign with
+    // a 4-minute lifetime to leave clock-skew margin
+    expect(claims.exp! - claims.iat!).toBe(240);
   });
 });

--- a/src/app/tests/integration/signing-keys.test.ts
+++ b/src/app/tests/integration/signing-keys.test.ts
@@ -1,0 +1,126 @@
+import fs from "fs";
+import os from "os";
+import path from "path";
+import crypto from "crypto";
+import {
+  exportJWK,
+  exportPKCS8,
+  generateKeyPair,
+  importJWK,
+  jwtVerify,
+} from "jose";
+import dbService from "@/app/backend/db/service";
+import {
+  clearSigningKeyCache,
+  getOrCreateSigningKey,
+  getSigningJwks,
+} from "@/app/backend/signing-keys";
+import { createSmartJwt } from "@/app/backend/smart-on-fhir";
+import { suppressConsoleLogs } from "./fixtures";
+
+// A scratch keys dir with no key files, so tests exercise the
+// generate-in-db path rather than importing any local dev keys/ dir
+const EMPTY_KEYS_DIR = fs.mkdtempSync(
+  path.join(os.tmpdir(), "signing-keys-empty-"),
+);
+
+async function resetKeys() {
+  clearSigningKeyCache();
+  await dbService.query("DELETE FROM signing_keys;");
+}
+
+describe("signing key persistence", () => {
+  beforeEach(async () => {
+    suppressConsoleLogs();
+    await resetKeys();
+  });
+
+  afterAll(async () => {
+    // leave a key behind for any suites that run after this one
+    clearSigningKeyCache();
+  });
+
+  it("generates and persists a key when none exists, then reuses it", async () => {
+    const first = await getOrCreateSigningKey(EMPTY_KEYS_DIR);
+    expect(first.kid).toBeDefined();
+    expect(first.alg).toBe("RS384");
+    expect(first.privateKeyPem).toContain("BEGIN PRIVATE KEY");
+    expect(first.publicJwk.kid).toBe(first.kid);
+
+    // Same key comes back on subsequent calls, including across a cache clear
+    // (i.e. a simulated restart / second replica)
+    const second = await getOrCreateSigningKey(EMPTY_KEYS_DIR);
+    expect(second.kid).toBe(first.kid);
+
+    clearSigningKeyCache();
+    const afterRestart = await getOrCreateSigningKey(EMPTY_KEYS_DIR);
+    expect(afterRestart.kid).toBe(first.kid);
+    expect(afterRestart.privateKeyPem).toBe(first.privateKeyPem);
+
+    const rows = await dbService.query("SELECT kid FROM signing_keys;");
+    expect(rows.rows).toHaveLength(1);
+    expect(rows.rows[0].kid).toBe(first.kid);
+  });
+
+  it("creates exactly one key under concurrent access", async () => {
+    const results = await Promise.all(
+      Array.from({ length: 5 }, () => getOrCreateSigningKey(EMPTY_KEYS_DIR)),
+    );
+
+    const kids = new Set(results.map((r) => r.kid));
+    expect(kids.size).toBe(1);
+
+    const rows = await dbService.query("SELECT kid FROM signing_keys;");
+    expect(rows.rows).toHaveLength(1);
+  });
+
+  it("imports a legacy on-disk key pair instead of generating a new one", async () => {
+    // Lay down a key pair in the format the previous file-based
+    // implementation (setup-scripts/gen-keys.ts) wrote
+    const keysDir = fs.mkdtempSync(path.join(os.tmpdir(), "signing-keys-"));
+    const { privateKey, publicKey } = await generateKeyPair("RS384", {
+      modulusLength: 2048,
+      extractable: true,
+    });
+    const kid = crypto.randomUUID();
+    const publicJwk = await exportJWK(publicKey);
+    publicJwk.kid = kid;
+    publicJwk.alg = "RS384";
+    publicJwk.use = "sig";
+    fs.writeFileSync(
+      path.join(keysDir, "jwks.json"),
+      JSON.stringify({ keys: [publicJwk] }),
+    );
+    fs.writeFileSync(
+      path.join(keysDir, "rsa-private.pem"),
+      await exportPKCS8(privateKey),
+    );
+
+    const imported = await getOrCreateSigningKey(keysDir);
+    expect(imported.kid).toBe(kid);
+
+    const rows = await dbService.query("SELECT kid FROM signing_keys;");
+    expect(rows.rows).toHaveLength(1);
+    expect(rows.rows[0].kid).toBe(kid);
+  });
+
+  it("serves the persisted public key as a JWKS that verifies SMART JWTs", async () => {
+    const jwt = await createSmartJwt(
+      "test-client-id",
+      "https://example.org/oauth2/token",
+    );
+
+    const jwks = await getSigningJwks();
+    expect(jwks.keys).toHaveLength(1);
+    expect(jwks.keys[0].kty).toBe("RSA");
+    // Private material must never appear in the served JWKS
+    expect(jwks.keys[0]).not.toHaveProperty("d");
+
+    const publicKey = await importJWK(jwks.keys[0], "RS384");
+    const { payload, protectedHeader } = await jwtVerify(jwt, publicKey, {
+      audience: "https://example.org/oauth2/token",
+    });
+    expect(protectedHeader.kid).toBe(jwks.keys[0].kid);
+    expect(payload.iss).toBe("test-client-id");
+  });
+});

--- a/src/app/tests/integration/signing-keys.test.ts
+++ b/src/app/tests/integration/signing-keys.test.ts
@@ -104,6 +104,42 @@ describe("signing key persistence", () => {
     expect(rows.rows[0].kid).toBe(kid);
   });
 
+  it("generates a fresh key instead of importing a mismatched on-disk pair", async () => {
+    // jwks.json and rsa-private.pem from two different key pairs, as could
+    // result from a partial volume restore or hand-edited keys dir
+    const keysDir = fs.mkdtempSync(
+      path.join(os.tmpdir(), "signing-keys-mismatch-"),
+    );
+    const { publicKey } = await generateKeyPair("RS384", {
+      modulusLength: 2048,
+      extractable: true,
+    });
+    const { privateKey: unrelatedPrivateKey } = await generateKeyPair("RS384", {
+      modulusLength: 2048,
+      extractable: true,
+    });
+    const kid = crypto.randomUUID();
+    const publicJwk = await exportJWK(publicKey);
+    publicJwk.kid = kid;
+    publicJwk.alg = "RS384";
+    publicJwk.use = "sig";
+    fs.writeFileSync(
+      path.join(keysDir, "jwks.json"),
+      JSON.stringify({ keys: [publicJwk] }),
+    );
+    fs.writeFileSync(
+      path.join(keysDir, "rsa-private.pem"),
+      await exportPKCS8(unrelatedPrivateKey),
+    );
+
+    const key = await getOrCreateSigningKey(keysDir);
+    expect(key.kid).not.toBe(kid);
+
+    const rows = await dbService.query("SELECT kid FROM signing_keys;");
+    expect(rows.rows).toHaveLength(1);
+    expect(rows.rows[0].kid).not.toBe(kid);
+  });
+
   it("serves the persisted public key as a JWKS that verifies SMART JWTs", async () => {
     const jwt = await createSmartJwt(
       "test-client-id",


### PR DESCRIPTION
## Problem

SMART on FHIR signing keys were generated at startup on the container filesystem (`keys/`). Because that filesystem is ephemeral, **every restart or redeploy silently rotated the key pair and its `kid`**. Any partner that registered our JWKS — e.g. an Epic backend app registration pointing at a hosted snapshot of our JWKS — would then start rejecting our client assertions with `invalid_client`. Deployments running multiple replicas were worse: each replica generated its own divergent key.

Two additional JWT details also conflicted with Epic's documented requirements and could each independently cause `invalid_client`:

- We sent a `jku` header pointing at `${APP_HOSTNAME}/.well-known/jwks.json`. Epic rejects assertions whose `jku` differs from the JWK Set URL registered for the client (and verifiers use their registered JWKS regardless).
- We signed assertions with `exp` exactly 5 minutes out. Epic rejects `exp` more than 5 minutes in the future *at the time the request is received*, leaving zero margin for clock skew.

## Changes

- **New `signing_keys` table** (Flyway `V01_06`): the key pair is persisted in PostgreSQL — the one store every deployment already has — so keys survive restarts and are shared across replicas. No new setup steps for operators.
- **`src/app/backend/signing-keys.ts`**: gets the active key, generating and persisting one if none exists. First-time creation runs inside a transaction guarded by a Postgres advisory lock so concurrently booting replicas converge on a single key.
- **Legacy disk import**: on first run, an existing `keys/jwks.json` + `keys/rsa-private.pem` pair is imported into the DB instead of generating a fresh key, so external registrations made against the current key keep working across this upgrade. (Deployments whose container has restarted since the partner registration will still need one final JWKS re-share — the on-disk key has already drifted.)
- **`/.well-known/jwks.json`** now serves all active public keys from the DB, leaving room for a rotation flow later (add new key → JWKS serves both → retire old).
- **`createSmartJwt`**: no more `jku` header; `exp` is now `iat + 240s`; keys come from the DB.
- **`setup-scripts/gen-keys.ts`** trimmed to just the on-disk generation the e2e setup uses (it previously contained a stale duplicate of `createSmartJwt`); the app imports those keys into the DB via the legacy path.

## Testing

- New integration suite `signing-keys.test.ts`: generate-once semantics across cache clears (simulated restart), single key under concurrent access, legacy disk import, and end-to-end verify of a `createSmartJwt` token against the served JWKS.
- Updated the SMART JWT assertions in `api-query.test.ts` (no `jku`, 240s expiry).
- `npm run test:unit`: 613 passed. `npm run test:integration`: 110 passed across 21 suites.