### PR TITLE
Release v1.1.1

### DIFF
--- a/app_version.yml
+++ b/app_version.yml
@@ -1,1 +1,1 @@
-version: 1.1.0
+version: 1.1.1

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "query-connector",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "query-connector",
-      "version": "1.1.0",
+      "version": "1.1.1",
       "dependencies": {
         "@aws-sdk/client-secrets-manager": "^3.1081.0",
         "@axe-core/playwright": "^4.12.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "query-connector",
   "description": "DIBBs Query Connector: a Next.js full-stack application for public health staff to query healthcare organizations for patient records via FHIR and TEFCA networks.",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "private": true,
   "scripts": {
     "dev": "docker compose -f docker-compose-dev.yaml up -d && next dev --turbopack; docker compose -f docker-compose-dev.yaml down --remove-orphans",


### PR DESCRIPTION
## Summary
Bumps the app version to **v1.1.1** to trigger a release.

Patch release containing:
- #994 — fix: persist SMART on FHIR signing keys in the database
- #995 — fix: mutual-TLS requests broken in v1.1.0 by undici 8 bump
- #996 — fix: replace ts-node with native Node type stripping in e2e setup