### PR TITLE
fix: IZ Gateway immunization retrieval via chained patient demographics

### DIFF
--- a/src/app/(pages)/fhirServers/page.tsx
+++ b/src/app/(pages)/fhirServers/page.tsx
@@ -18,11 +18,7 @@ import { FhirServersModal } from "./fhirServersModal";
 import { ModalRef } from "@/app/ui/designSystem/modal/Modal";
 
 export type AuthMethodType =
-  | "none"
-  | "basic"
-  | "client_credentials"
-  | "SMART"
-  | "mutual-tls";
+  "none" | "basic" | "client_credentials" | "SMART" | "mutual-tls";
 
 /**
  * The kind of FHIR endpoint a server exposes. Drives which resource the

--- a/src/app/(pages)/fhirServers/page.tsx
+++ b/src/app/(pages)/fhirServers/page.tsx
@@ -18,14 +18,22 @@ import { FhirServersModal } from "./fhirServersModal";
 import { ModalRef } from "@/app/ui/designSystem/modal/Modal";
 
 export type AuthMethodType =
-  "none" | "basic" | "client_credentials" | "SMART" | "mutual-tls";
+  | "none"
+  | "basic"
+  | "client_credentials"
+  | "SMART"
+  | "mutual-tls";
 
 /**
  * The kind of FHIR endpoint a server exposes. Drives which resource the
  * connection check probes and how patient discovery is routed:
  * - "standard": direct /Patient search and clinical record queries
  * - "immunization": an Immunization Gateway (probes /Immunization), discovery
- *   still uses the standard /Patient path
+ *   still uses the standard /Patient path. Record queries send only the
+ *   Immunization search, built from the patient's demographics
+ *   (patient.given/patient.family/patient.birthdate) — the gateway
+ *   translates it into an HL7v2 QBP query and can't resolve FHIR patient
+ *   ids or answer other resource searches
  * - "fanout": TEFCA-style fanout via /Task resources (POST + polling)
  */
 export type EndpointType = "standard" | "immunization" | "fanout";

--- a/src/app/(pages)/query/components/SelectQuery.tsx
+++ b/src/app/(pages)/query/components/SelectQuery.tsx
@@ -69,6 +69,9 @@ const SelectQuery: React.FC<SelectQueryProps> = ({
         queryName: queryName,
         patientId: patientForQuery.id ?? hyperUnluckyPatient.Id,
         fhirServer: fhirServer,
+        // Immunization Gateway servers build the Immunization search from the
+        // patient's demographics rather than the FHIR id.
+        patient: patientForQuery,
       };
       setLoadingResultResponse(true);
       const queryResponse = await patientRecordsQuery(newRequest);

--- a/src/app/backend/query-execution/custom-query.test.ts
+++ b/src/app/backend/query-execution/custom-query.test.ts
@@ -1,10 +1,11 @@
-import { CustomQuery } from "./custom-query";
+import { CustomQuery, extractChainedPatientDemographics } from "./custom-query";
 import {
   EMPTY_MEDICAL_RECORD_SECTIONS,
   QueryDataColumn,
   QueryTableResult,
 } from "../../(pages)/queryBuilding/utils";
 import { DibbsValueSet } from "@/app/models/entities/valuesets";
+import { Patient } from "fhir/r4";
 
 const PATIENT_ID = "patient-123";
 const RXNORM_CODE = "1665005";
@@ -272,19 +273,24 @@ describe("CustomQuery epic strategy", () => {
 });
 
 describe("CustomQuery immunization queries", () => {
-  it("scopes Immunization with the FHIR R4 'patient' search param, not 'subject'", () => {
-    const savedQuery: QueryTableResult = {
-      queryName: "Immunization Query",
-      queryId: "query-imm",
-      queryData: {},
-      conditionsList: [],
-      medicalRecordSections: {
-        ...EMPTY_MEDICAL_RECORD_SECTIONS,
-        immunizations: true,
-      },
-    };
+  const immunizationSavedQuery: QueryTableResult = {
+    queryName: "Immunization Query",
+    queryId: "query-imm",
+    queryData: {},
+    conditionsList: [],
+    medicalRecordSections: {
+      ...EMPTY_MEDICAL_RECORD_SECTIONS,
+      immunizations: true,
+    },
+  };
+  const DEMOGRAPHICS = {
+    given: "WayneTWOIZG",
+    family: "WatersSNHDIZGTWO",
+    birthDate: "2018-02-19",
+  };
 
-    const customQuery = new CustomQuery(savedQuery, PATIENT_ID);
+  it("scopes Immunization with the FHIR R4 'patient' search param, not 'subject'", () => {
+    const customQuery = new CustomQuery(immunizationSavedQuery, PATIENT_ID);
     const immunization = customQuery.getQuery("immunization");
 
     expect(immunization.basePath).toBe("/Immunization");
@@ -293,10 +299,125 @@ describe("CustomQuery immunization queries", () => {
 
     // Epic's search expects a bare patient id, not a Patient/ reference.
     const epicImmunization = new CustomQuery(
-      savedQuery,
+      immunizationSavedQuery,
       PATIENT_ID,
       "epic",
     ).getQuery("immunization");
     expect(epicImmunization.params.get("patient")).toBe(PATIENT_ID);
+  });
+
+  it("uses chained demographic params for immunization endpoints", () => {
+    const immunization = new CustomQuery(
+      immunizationSavedQuery,
+      PATIENT_ID,
+      "default",
+      { endpointType: "immunization", patientDemographics: DEMOGRAPHICS },
+    ).getQuery("immunization");
+
+    expect(immunization.basePath).toBe("/Immunization");
+    expect(immunization.params.get("patient.given")).toBe("WayneTWOIZG");
+    expect(immunization.params.get("patient.family")).toBe("WatersSNHDIZGTWO");
+    expect(immunization.params.get("patient.birthdate")).toBe("2018-02-19");
+    expect(immunization.params.get("patient")).toBeNull();
+
+    // Still a GET-only query.
+    const postPaths = new CustomQuery(
+      immunizationSavedQuery,
+      PATIENT_ID,
+      "default",
+      { endpointType: "immunization", patientDemographics: DEMOGRAPHICS },
+    )
+      .compileAllPostRequests()
+      .map((r) => r.path);
+    expect(postPaths).not.toContain("/Immunization");
+  });
+
+  it("falls back to the patient param on immunization endpoints without demographics", () => {
+    const immunization = new CustomQuery(
+      immunizationSavedQuery,
+      PATIENT_ID,
+      "default",
+      { endpointType: "immunization" },
+    ).getQuery("immunization");
+    expect(immunization.params.get("patient")).toBe(`Patient/${PATIENT_ID}`);
+    expect(immunization.params.get("patient.given")).toBeNull();
+
+    const epicImmunization = new CustomQuery(
+      immunizationSavedQuery,
+      PATIENT_ID,
+      "epic",
+      { endpointType: "immunization" },
+    ).getQuery("immunization");
+    expect(epicImmunization.params.get("patient")).toBe(PATIENT_ID);
+  });
+
+  it("ignores demographics on standard endpoints", () => {
+    const immunization = new CustomQuery(
+      immunizationSavedQuery,
+      PATIENT_ID,
+      "default",
+      { endpointType: "standard", patientDemographics: DEMOGRAPHICS },
+    ).getQuery("immunization");
+    expect(immunization.params.get("patient")).toBe(`Patient/${PATIENT_ID}`);
+    expect(immunization.params.get("patient.given")).toBeNull();
+  });
+});
+
+describe("extractChainedPatientDemographics", () => {
+  const basePatient: Patient = {
+    resourceType: "Patient",
+    id: "patient-123",
+    name: [{ given: ["Wayne", "Bruce"], family: "Waters" }],
+    birthDate: "2018-02-19",
+  };
+
+  it("uses the first given name, the family name, and the birth date", () => {
+    expect(extractChainedPatientDemographics(basePatient)).toEqual({
+      given: "Wayne",
+      family: "Waters",
+      birthDate: "2018-02-19",
+    });
+  });
+
+  it("prefers the official name over other name entries", () => {
+    const patient: Patient = {
+      ...basePatient,
+      name: [
+        { use: "nickname", given: ["Bats"], family: "Man" },
+        { use: "official", given: ["Wayne"], family: "Waters" },
+      ],
+    };
+    expect(extractChainedPatientDemographics(patient)).toEqual({
+      given: "Wayne",
+      family: "Waters",
+      birthDate: "2018-02-19",
+    });
+  });
+
+  it("falls back to the first usable name when none is official", () => {
+    const patient: Patient = {
+      ...basePatient,
+      name: [
+        { use: "official", family: "TextOnly" }, // no given name — not usable
+        { given: ["Wayne"], family: "Waters" },
+      ],
+    };
+    expect(extractChainedPatientDemographics(patient)).toEqual({
+      given: "Wayne",
+      family: "Waters",
+      birthDate: "2018-02-19",
+    });
+  });
+
+  it.each([
+    ["missing name", { ...basePatient, name: undefined }],
+    ["empty name list", { ...basePatient, name: [] }],
+    ["name without family", { ...basePatient, name: [{ given: ["Wayne"] }] }],
+    ["name without given", { ...basePatient, name: [{ family: "Waters" }] }],
+    ["missing birthDate", { ...basePatient, birthDate: undefined }],
+    ["year-only birthDate", { ...basePatient, birthDate: "2018" }],
+    ["year-month birthDate", { ...basePatient, birthDate: "2018-02" }],
+  ] as [string, Patient][])("returns undefined for %s", (_label, patient) => {
+    expect(extractChainedPatientDemographics(patient)).toBeUndefined();
   });
 });

--- a/src/app/backend/query-execution/custom-query.ts
+++ b/src/app/backend/query-execution/custom-query.ts
@@ -5,7 +5,8 @@ import {
   QueryTableTimebox,
   TimeWindow,
 } from "../../(pages)/queryBuilding/utils";
-import { QueryStrategy } from "../../(pages)/fhirServers/page";
+import { EndpointType, QueryStrategy } from "../../(pages)/fhirServers/page";
+import { HumanName, Patient } from "fhir/r4";
 
 // Epic-mode Condition and Encounter queries go out as GETs, so long code /
 // reference lists are chunked across multiple requests to keep URLs well under
@@ -34,6 +35,50 @@ export function chunkArray<T>(items: T[], chunkSize: number): T[][] {
   return chunks;
 }
 
+export type ChainedPatientDemographics = {
+  given: string;
+  family: string;
+  birthDate: string;
+};
+
+/**
+ * Extracts the demographics an Immunization Gateway's chained Immunization
+ * search (patient.given / patient.family / patient.birthdate) needs from a
+ * Patient resource. Prefers the "official" name; falls back to the first name
+ * entry with both a given and family name. Only the first given name is used
+ * (the gateway maps it to the HL7v2 PID-5 name).
+ * @param patient the discovered Patient resource
+ * @returns the demographics, or undefined when a usable name or a full
+ * YYYY-MM-DD birthDate is missing (partial FHIR dates can't be translated to
+ * a v2 DOB), in which case the caller falls back to a patient={id} search.
+ */
+export function extractChainedPatientDemographics(
+  patient: Patient,
+): ChainedPatientDemographics | undefined {
+  const names = patient.name ?? [];
+  const usable = (n: HumanName) => Boolean(n.given?.[0] && n.family);
+  const name =
+    names.find((n) => n.use === "official" && usable(n)) ?? names.find(usable);
+  const birthDate = patient.birthDate;
+  if (!name || !birthDate || !/^\d{4}-\d{2}-\d{2}$/.test(birthDate)) {
+    return undefined;
+  }
+  return { given: name.given![0], family: name.family!, birthDate };
+}
+
+export type CustomQueryOptions = {
+  /**
+   * The kind of endpoint being queried; Immunization Gateways get chained
+   * patient-demographic Immunization searches.
+   */
+  endpointType?: EndpointType;
+  /**
+   * Demographics from the discovered Patient, extracted with
+   * extractChainedPatientDemographics.
+   */
+  patientDemographics?: ChainedPatientDemographics;
+};
+
 function formatTimeFilter(timeWindow: TimeWindow | undefined) {
   if (!timeWindow) return undefined;
   const startString = timeWindow.timeWindowStart.substring(0, 10);
@@ -56,6 +101,8 @@ function formatTimeFilter(timeWindow: TimeWindow | undefined) {
 export class CustomQuery {
   patientId: string = "";
   queryStrategy: QueryStrategy = "default";
+  endpointType: EndpointType = "standard";
+  patientDemographics?: ChainedPatientDemographics;
   private timeboxInfo?: QueryTableTimebox;
 
   // Store four types of input codes
@@ -87,15 +134,21 @@ export class CustomQuery {
    * @param queryStrategy How the target server supports search: "default"
    * uses spec-standard POST _search queries; "epic" adapts to Epic's
    * supported search parameters (see QueryStrategy).
+   * @param options Endpoint-specific inputs: the server's endpointType and,
+   * for Immunization Gateways, the discovered patient's demographics used to
+   * build the chained Immunization search.
    */
   constructor(
     savedQuery: QueryTableResult,
     patientId: string,
     queryStrategy: QueryStrategy = "default",
+    options: CustomQueryOptions = {},
   ) {
     try {
       this.patientId = patientId;
       this.queryStrategy = queryStrategy;
+      this.endpointType = options.endpointType ?? "standard";
+      this.patientDemographics = options.patientDemographics;
       const queryData = savedQuery.queryData;
       const medicalRecordSection = savedQuery.medicalRecordSections;
       const timeboxInfo = savedQuery.timeboxWindows;
@@ -176,14 +229,31 @@ export class CustomQuery {
 
     if (medicalRecordSections && medicalRecordSections.immunizations) {
       const formattedParams = new URLSearchParams();
-      // FHIR R4 Immunization has no "subject" search param; the patient-scoping
-      // param is "patient". Using "subject" leaves the query unscoped and the IZ
-      // Gateway rejects it ("must contain patient.identifier or name+birthDate").
-      // Epic's search expects a bare patient id, not a Patient/ reference.
-      formattedParams.append(
-        "patient",
-        this.queryStrategy === "epic" ? patientId : `Patient/${patientId}`,
-      );
+      if (this.endpointType === "immunization" && this.patientDemographics) {
+        // Immunization Gateways (e.g. eHealth Exchange's fhirproxy) translate
+        // the FHIR search into an HL7v2 QBP Z34 query, which identifies the
+        // patient by demographics ("must contain patient.identifier or
+        // name+birthDate") — a patient={id} search returns nothing. Use
+        // chained demographic params from the discovered Patient instead.
+        formattedParams.append("patient.given", this.patientDemographics.given);
+        formattedParams.append(
+          "patient.family",
+          this.patientDemographics.family,
+        );
+        formattedParams.append(
+          "patient.birthdate",
+          this.patientDemographics.birthDate,
+        );
+      } else {
+        // FHIR R4 Immunization has no "subject" search param; the patient-scoping
+        // param is "patient". Using "subject" leaves the query unscoped and the IZ
+        // Gateway rejects it ("must contain patient.identifier or name+birthDate").
+        // Epic's search expects a bare patient id, not a Patient/ reference.
+        formattedParams.append(
+          "patient",
+          this.queryStrategy === "epic" ? patientId : `Patient/${patientId}`,
+        );
+      }
 
       this.fhirResourceQueries["immunization"] = {
         basePath: `/Immunization`,

--- a/src/app/backend/query-execution/iz-gateway.test.ts
+++ b/src/app/backend/query-execution/iz-gateway.test.ts
@@ -1,0 +1,224 @@
+import { Patient } from "fhir/r4";
+import { patientRecordsQuery } from "./service";
+import {
+  getFhirServerConfigs,
+  prepareFhirClient,
+} from "@/app/backend/fhir-servers/service";
+import { getSavedQueryByName } from "@/app/backend/query-building/service";
+import FHIRClient from "@/app/backend/fhir-servers/fhir-client";
+import {
+  EMPTY_MEDICAL_RECORD_SECTIONS,
+  QueryDataColumn,
+  QueryTableResult,
+} from "@/app/(pages)/queryBuilding/utils";
+import { DibbsValueSet } from "@/app/models/entities/valuesets";
+import { suppressConsoleLogs } from "@/app/tests/integration/fixtures";
+
+jest.mock("@/app/utils/auth", () => ({
+  superAdminAccessCheck: jest.fn().mockReturnValue(true),
+}));
+
+jest.mock("@/app/backend/fhir-servers/service", () => ({
+  prepareFhirClient: jest.fn(),
+  getFhirServerConfigs: jest.fn(),
+  getFhirServerNames: jest.fn(),
+}));
+
+jest.mock("@/app/backend/query-building/service", () => ({
+  getSavedQueryByName: jest.fn(),
+}));
+
+jest.mock("@/app/backend/audit-logs/decorator", () => ({
+  auditable: jest
+    .fn()
+    .mockImplementation(
+      () =>
+        (
+          _target: unknown,
+          _propertyName: string,
+          descriptor: PropertyDescriptor,
+        ) =>
+          descriptor,
+    ),
+}));
+
+const PATIENT_ID = "TlYwMDAwfDM5NzM1NjQ";
+const SNOMED_CODE = "14189004";
+
+const PATIENT: Patient = {
+  resourceType: "Patient",
+  id: PATIENT_ID,
+  name: [
+    { use: "official", given: ["WayneTWOIZG"], family: "WatersSNHDIZGTWO" },
+  ],
+  birthDate: "2018-02-19",
+};
+
+/**
+ * A saved query with an immunization section plus condition codes and other
+ * record sections, mirroring SNHD's MMR query — the gateway can only answer
+ * the immunization part.
+ * @returns the saved query table row
+ */
+function buildSavedQuery(): QueryTableResult {
+  const conditionsValueSet: DibbsValueSet = {
+    valueSetId: "vs-conditions",
+    valueSetVersion: "1",
+    valueSetName: "Test Conditions",
+    author: "test",
+    system: "http://snomed.info/sct",
+    dibbsConceptType: "conditions",
+    includeValueSet: true,
+    concepts: [{ code: SNOMED_CODE, display: "Measles", include: true }],
+    userCreated: false,
+  };
+
+  const queryData: QueryDataColumn = {
+    "condition-1": { "vs-conditions": conditionsValueSet },
+  };
+
+  return {
+    queryName: "MMR check",
+    queryId: "query-mmr",
+    queryData,
+    conditionsList: [],
+    medicalRecordSections: {
+      ...EMPTY_MEDICAL_RECORD_SECTIONS,
+      immunizations: true,
+      socialDeterminants: true,
+      serviceRequests: true,
+    },
+  };
+}
+
+/**
+ * Builds a mock 200 Response whose clone() re-reads the same bundle.
+ * @param path the request path, echoed into the mock URL
+ * @param bundle the bundle the response body resolves to
+ * @returns a mock Response
+ */
+function mockBundleResponse(path: string, bundle: object): Response {
+  const response = {
+    status: 200,
+    url: `https://example.com/fhir${path}`,
+    json: async () => bundle,
+    clone: () => ({ json: async () => bundle }),
+  };
+  return response as unknown as Response;
+}
+
+const EMPTY_BUNDLE = { resourceType: "Bundle", type: "searchset", entry: [] };
+
+describe("patientRecordsQuery against an Immunization Gateway", () => {
+  let mockFhirClient: jest.Mocked<FHIRClient>;
+
+  beforeEach(() => {
+    suppressConsoleLogs();
+    jest.clearAllMocks();
+
+    mockFhirClient = {
+      get: jest.fn(),
+      post: jest.fn(),
+      postJson: jest.fn(),
+      getBatch: jest.fn(),
+      getRequestLog: jest.fn().mockReturnValue([]),
+    } as unknown as jest.Mocked<FHIRClient>;
+
+    (prepareFhirClient as jest.Mock).mockResolvedValue(mockFhirClient);
+    (getFhirServerConfigs as jest.Mock).mockResolvedValue([
+      {
+        name: "IZ Gateway",
+        queryStrategy: "default",
+        endpointType: "immunization",
+      },
+      {
+        name: "Epic IZ Gateway",
+        queryStrategy: "epic",
+        endpointType: "immunization",
+      },
+    ]);
+    (getSavedQueryByName as jest.Mock).mockResolvedValue(buildSavedQuery());
+
+    mockFhirClient.get.mockImplementation(async (path: string) =>
+      mockBundleResponse(path, EMPTY_BUNDLE),
+    );
+    mockFhirClient.post.mockImplementation(async (path: string) =>
+      mockBundleResponse(path, EMPTY_BUNDLE),
+    );
+  });
+
+  async function runQuery(fhirServer = "IZ Gateway", patient?: Patient) {
+    return patientRecordsQuery({
+      patientId: PATIENT_ID,
+      fhirServer,
+      queryName: "MMR check",
+      patient,
+    });
+  }
+
+  it.each(["IZ Gateway", "Epic IZ Gateway"])(
+    "searches Immunization with chained patient demographics on %s",
+    async (server) => {
+      await runQuery(server, PATIENT);
+
+      const getPaths = mockFhirClient.get.mock.calls.map((c) => c[0] as string);
+      const immunizationPath = getPaths.find((p) =>
+        p.startsWith("/Immunization?"),
+      );
+      // The gateway translates the search into an HL7v2 QBP query, which
+      // identifies the patient by demographics — a patient={id} search
+      // returns nothing.
+      expect(immunizationPath).toBe(
+        "/Immunization?patient.given=WayneTWOIZG&patient.family=WatersSNHDIZGTWO&patient.birthdate=2018-02-19",
+      );
+    },
+  );
+
+  it("falls back to the patient param when no Patient resource is provided", async () => {
+    await runQuery("IZ Gateway");
+
+    let getPaths = mockFhirClient.get.mock.calls.map((c) => c[0] as string);
+    expect(getPaths.find((p) => p.startsWith("/Immunization?"))).toBe(
+      `/Immunization?patient=Patient%2F${PATIENT_ID}`,
+    );
+
+    jest.clearAllMocks();
+    (prepareFhirClient as jest.Mock).mockResolvedValue(mockFhirClient);
+    mockFhirClient.get.mockImplementation(async (path: string) =>
+      mockBundleResponse(path, EMPTY_BUNDLE),
+    );
+    mockFhirClient.getRequestLog.mockReturnValue([]);
+    await runQuery("Epic IZ Gateway");
+
+    getPaths = mockFhirClient.get.mock.calls.map((c) => c[0] as string);
+    expect(getPaths.find((p) => p.startsWith("/Immunization?"))).toBe(
+      `/Immunization?patient=${PATIENT_ID}`,
+    );
+  });
+
+  it("returns the gateway's Immunizations from the parsed response", async () => {
+    const gatewayBundle = {
+      resourceType: "Bundle",
+      type: "searchset",
+      entry: [
+        {
+          resource: { resourceType: "Immunization", id: "imm-1" },
+          search: { mode: "match" },
+        },
+        {
+          resource: { resourceType: "Immunization", id: "imm-2" },
+          search: { mode: "match" },
+        },
+      ],
+    };
+    mockFhirClient.get.mockImplementation(async (path: string) =>
+      path.startsWith("/Immunization?")
+        ? mockBundleResponse(path, gatewayBundle)
+        : mockBundleResponse(path, EMPTY_BUNDLE),
+    );
+
+    const result = await runQuery("IZ Gateway", PATIENT);
+
+    expect(result.Immunization?.map((i) => i.id)).toEqual(["imm-1", "imm-2"]);
+  });
+});

--- a/src/app/backend/query-execution/iz-gateway.test.ts
+++ b/src/app/backend/query-execution/iz-gateway.test.ts
@@ -174,6 +174,22 @@ describe("patientRecordsQuery against an Immunization Gateway", () => {
     },
   );
 
+  it.each(["IZ Gateway", "Epic IZ Gateway"])(
+    "sends only the Immunization search to %s, skipping other record sections",
+    async (server) => {
+      await runQuery(server, PATIENT);
+
+      // The gateway only serves immunization history, so the other sections
+      // in the saved query (social history, service requests, labs POST
+      // batch, and the epic medication/condition chains) never fire.
+      const getPaths = mockFhirClient.get.mock.calls.map((c) => c[0] as string);
+      expect(getPaths).toHaveLength(1);
+      expect(getPaths[0]).toMatch(/^\/Immunization\?/);
+      expect(mockFhirClient.post).not.toHaveBeenCalled();
+      expect(mockFhirClient.postJson).not.toHaveBeenCalled();
+    },
+  );
+
   it("falls back to the patient param when no Patient resource is provided", async () => {
     await runQuery("IZ Gateway");
 

--- a/src/app/backend/query-execution/iz-gateway.test.ts
+++ b/src/app/backend/query-execution/iz-gateway.test.ts
@@ -212,13 +212,39 @@ describe("patientRecordsQuery against an Immunization Gateway", () => {
     );
   });
 
-  it("returns the gateway's Immunizations from the parsed response", async () => {
+  it("returns the gateway's Immunizations and drops its search-outcome entries", async () => {
+    // Shape observed from the real gateway: id-bearing OperationOutcome
+    // entries with search.mode=outcome alongside the Immunization matches.
     const gatewayBundle = {
       resourceType: "Bundle",
       type: "searchset",
       entry: [
         {
-          resource: { resourceType: "Immunization", id: "imm-1" },
+          resource: {
+            resourceType: "OperationOutcome",
+            id: "outcome-1",
+            issue: [{ severity: "information", code: "informational" }],
+          },
+          search: { mode: "outcome" },
+        },
+        {
+          resource: { resourceType: "OperationOutcome", id: "outcome-2" },
+          search: { mode: "outcome" },
+        },
+        {
+          resource: {
+            resourceType: "Immunization",
+            id: "imm-1",
+            vaccineCode: {
+              coding: [
+                {
+                  system: "http://hl7.org/fhir/sid/cvx",
+                  code: "03",
+                  display: "MMR",
+                },
+              ],
+            },
+          },
           search: { mode: "match" },
         },
         {
@@ -236,5 +262,6 @@ describe("patientRecordsQuery against an Immunization Gateway", () => {
     const result = await runQuery("IZ Gateway", PATIENT);
 
     expect(result.Immunization?.map((i) => i.id)).toEqual(["imm-1", "imm-2"]);
+    expect(result.OperationOutcome).toBeUndefined();
   });
 });

--- a/src/app/backend/query-execution/service.ts
+++ b/src/app/backend/query-execution/service.ts
@@ -457,6 +457,17 @@ class QueryService {
       patientDemographics,
     });
 
+    // Immunization Gateways only serve immunization history — every other
+    // record-section search is a wasted round trip through the HL7v2
+    // translation layer that returns nothing, so skip them entirely.
+    const isImmunizationGateway = endpointType === "immunization";
+    if (isImmunizationGateway) {
+      console.log(
+        "Immunization Gateway server %s: skipping non-immunization record sections.",
+        fhirServer,
+      );
+    }
+
     const medicalRecordSectionResults: Response[] = [];
     // Each medical-record-section request is isolated in its own try/catch so a
     // network-level failure (e.g. an unsupported endpoint that resets the
@@ -474,7 +485,11 @@ class QueryService {
       }
     }
 
-    if (medicalRecordSections && medicalRecordSections.socialDeterminants) {
+    if (
+      !isImmunizationGateway &&
+      medicalRecordSections &&
+      medicalRecordSections.socialDeterminants
+    ) {
       try {
         const { basePath, params } = builtQuery.getQuery("socialHistory");
         medicalRecordSectionResults.push(
@@ -485,7 +500,11 @@ class QueryService {
       }
     }
 
-    if (medicalRecordSections && medicalRecordSections.serviceRequests) {
+    if (
+      !isImmunizationGateway &&
+      medicalRecordSections &&
+      medicalRecordSections.serviceRequests
+    ) {
       try {
         const { basePath, params } = builtQuery.getQuery("serviceRequest");
 
@@ -498,13 +517,13 @@ class QueryService {
       }
     }
 
-    const postPromises: Promise<Response | Response[]>[] = builtQuery
-      .compileAllPostRequests()
-      .map((req) => {
-        return fhirClient.post(req.path, req.params);
-      });
+    const postPromises: Promise<Response | Response[]>[] = isImmunizationGateway
+      ? []
+      : builtQuery.compileAllPostRequests().map((req) => {
+          return fhirClient.post(req.path, req.params);
+        });
 
-    if (queryStrategy === "epic") {
+    if (queryStrategy === "epic" && !isImmunizationGateway) {
       // Epic doesn't support POST _search (or server-side code filtering) for
       // MedicationRequest, so it goes out as a GET alongside the POST batch,
       // followed by reads of any referenced Medications the search didn't

--- a/src/app/backend/query-execution/service.ts
+++ b/src/app/backend/query-execution/service.ts
@@ -1,5 +1,12 @@
 "use server";
-import { Bundle, FhirResource, Medication, Patient, Task } from "fhir/r4";
+import {
+  Bundle,
+  FhirResource,
+  Medication,
+  OperationOutcome,
+  Patient,
+  Task,
+} from "fhir/r4";
 
 import { isFhirResource } from "../../constants";
 
@@ -1210,6 +1217,11 @@ class QueryService {
       const resources =
         response.entry
           ?.map((entry) => {
+            if (entry.resource?.resourceType === "OperationOutcome") {
+              // Search-infrastructure entries, not patient records — see
+              // processFhirResponse.
+              return null;
+            }
             if (entry.resource && isFhirResource(entry.resource)) {
               return entry.resource;
             } else {
@@ -1295,6 +1307,23 @@ class QueryService {
       // keeps the body.entry access from throwing on those values.
       if (body?.entry) {
         for (const entry of body.entry) {
+          if (
+            entry.search?.mode === "outcome" ||
+            entry.resource?.resourceType === "OperationOutcome"
+          ) {
+            // Search-infrastructure entries (e.g. the IZ Gateway returns
+            // per-query OperationOutcomes with ids and search.mode=outcome)
+            // aren't patient records; log their diagnostics and keep them out
+            // of the QueryResponse.
+            console.log(
+              "Skipping search-outcome entry from %s: %s",
+              response.url,
+              JSON.stringify(
+                (entry.resource as OperationOutcome | undefined)?.issue ?? [],
+              ),
+            );
+            continue;
+          }
           if (entry.resource && isFhirResource(entry.resource)) {
             // Add the resource only if the ID is unique to the resources being
             // returned for the query. Ids are type-qualified: FHIR ids are

--- a/src/app/backend/query-execution/service.ts
+++ b/src/app/backend/query-execution/service.ts
@@ -10,8 +10,10 @@ import {
 
 import { isFhirResource } from "../../constants";
 
+// ChainedPatientDemographics appears in a decorated method signature, which
+// requires a type-only import under emitDecoratorMetadata + isolatedModules.
+import type { ChainedPatientDemographics } from "./custom-query";
 import {
-  ChainedPatientDemographics,
   chunkArray,
   CustomQuery,
   extractChainedPatientDemographics,

--- a/src/app/backend/query-execution/service.ts
+++ b/src/app/backend/query-execution/service.ts
@@ -3,7 +3,12 @@ import { Bundle, FhirResource, Medication, Patient, Task } from "fhir/r4";
 
 import { isFhirResource } from "../../constants";
 
-import { chunkArray, CustomQuery } from "./custom-query";
+import {
+  ChainedPatientDemographics,
+  chunkArray,
+  CustomQuery,
+  extractChainedPatientDemographics,
+} from "./custom-query";
 import {
   filterMedicationResourcesByCode,
   referencedMedicationKey,
@@ -420,7 +425,8 @@ class QueryService {
    * @param savedQuery - Table row from the query database
    * @param patientId - ID of the referenced patient
    * @param fhirServer - name of the FHIR server
-   * @param  medicalRecordSections - whether to include medical record sections
+   * @param patientDemographics - demographics from the discovered Patient,
+   * used to build chained Immunization searches against Immunization Gateways
    * @returns a Response with FHIR information for further processing.
    */
   @auditable
@@ -428,6 +434,7 @@ class QueryService {
     savedQuery: QueryTableResult,
     patientId: string,
     fhirServer: string,
+    patientDemographics?: ChainedPatientDemographics,
   ) {
     const fhirClient = await prepareFhirClient(fhirServer);
     const serverConfigs = await getFhirServerConfigs();
@@ -435,8 +442,20 @@ class QueryService {
       (config) => config.name === fhirServer,
     );
     const queryStrategy = serverConfig?.queryStrategy ?? "default";
+    const endpointType = serverConfig?.endpointType ?? "standard";
+    if (endpointType === "immunization" && !patientDemographics) {
+      // The gateway can't resolve a FHIR patient id, so the fallback
+      // patient={id} search below will most likely return nothing.
+      console.warn(
+        "Immunization Gateway query for server %s has no patient demographics; falling back to a patient-id Immunization search.",
+        fhirServer,
+      );
+    }
     const medicalRecordSections = savedQuery.medicalRecordSections;
-    const builtQuery = new CustomQuery(savedQuery, patientId, queryStrategy);
+    const builtQuery = new CustomQuery(savedQuery, patientId, queryStrategy, {
+      endpointType,
+      patientDemographics,
+    });
 
     const medicalRecordSectionResults: Response[] = [];
     // Each medical-record-section request is isolated in its own try/catch so a
@@ -1035,11 +1054,19 @@ class QueryService {
       throw new Error(`Unable to query of name ${request?.queryName}`);
     }
 
+    // Only the slim demographics cross into the @auditable records request —
+    // the same PHI level makePatientDiscoveryRequest already audits — so the
+    // full Patient resource never lands in the audit log.
+    const patientDemographics = request.patient
+      ? extractChainedPatientDemographics(request.patient)
+      : undefined;
+
     const { responses, requests, medicationFilterCodes } =
       await QueryService.makePatientRecordsRequest(
         savedQuery,
         request.patientId,
         request.fhirServer,
+        patientDemographics,
       );
 
     let queryResponse = await QueryService.parseFhirSearch(responses);
@@ -1107,6 +1134,7 @@ class QueryService {
       await patientRecordsQuery({
         patientId: patient[0].id as string,
         ...queryRequest,
+        patient: patient[0],
       });
     return {
       Patient: patient,

--- a/src/app/models/entities/query.ts
+++ b/src/app/models/entities/query.ts
@@ -1,4 +1,4 @@
-import { Bundle, FhirResource } from "fhir/r4";
+import { Bundle, FhirResource, Patient } from "fhir/r4";
 import { UserGroupMembership } from "./users";
 import { DibbsValueSet } from "./valuesets";
 import { MedicalRecordSections } from "@/app/(pages)/queryBuilding/utils";
@@ -55,10 +55,17 @@ export type PatientRecordsRequest = {
   patientId: string;
   fhirServer: string;
   queryName: string;
+  /**
+   * The discovered Patient resource the records query is for. Immunization
+   * Gateway servers translate FHIR searches into HL7v2 QBP queries, which
+   * identify the patient by demographics rather than FHIR id, so the
+   * Immunization search is built from this resource's name and birthDate.
+   */
+  patient?: Patient;
 };
 
 export type FullPatientRequest = PatientDiscoveryRequest &
-  Omit<PatientRecordsRequest, "patientId">;
+  Omit<PatientRecordsRequest, "patientId" | "patient">;
 
 /**
  * Validates the patient search criteria for a discovery request.

--- a/src/app/tests/integration/mtls-api-query.test.ts
+++ b/src/app/tests/integration/mtls-api-query.test.ts
@@ -227,6 +227,9 @@ jest.mock("@/app/models/entities/query", () => ({
 }));
 
 jest.mock("@/app/backend/query-execution/custom-query", () => ({
+  // Keep the real module's helpers (extractChainedPatientDemographics,
+  // chunkArray) — patientRecordsQuery calls them outside CustomQuery.
+  ...jest.requireActual("@/app/backend/query-execution/custom-query"),
   CustomQuery: jest.fn().mockImplementation(() => ({
     getQuery: jest.fn().mockReturnValue({
       basePath: "/Observation",


### PR DESCRIPTION
> [!NOTE]
> Supersedes #1001 (auto-closed when its stacked base #998 merged and the branch was deleted); same commits, rebased onto `main`. All checks including e2e were green on the pre-rebase equivalent.

## Context

SNHD's testing against the eHealth Exchange IZ Gateway fhirproxy showed Query Connector returning no vaccination data while an equivalent Python request succeeded. The request/response logs SNHD shared pinpointed the difference: QC searched `Immunization?patient={id}`, but the gateway translates FHIR searches into HL7v2 QBP Z34 queries and can only identify patients by demographics — the working request is `Immunization?patient.given={given}&patient.family={family}&patient.birthdate={birthdate}`. A patient-reference search returns nothing.

The gateway's responses also include id-bearing `OperationOutcome` entries (`search.mode=outcome`) alongside the Immunization matches, which previously leaked into the Response-tab JSON as a phantom resource type.

## Changes

- **Chained-demographics Immunization search.** When a server's endpoint type is "immunization" (Immunization Gateway), the Immunization query is built from the discovered Patient's official name and birthDate (`patient.given`/`patient.family`/`patient.birthdate`) instead of a patient reference. The selected Patient resource rides along on `PatientRecordsRequest` from the UI (and from discovery on the API path); only the slim given/family/birthDate demographics cross into the auditable records request — the same PHI level patient discovery already audits. Missing or partial demographics (e.g. a YYYY-MM birthDate, which can't map to a v2 DOB) fall back to the existing `patient` param with a warning.
- **Immunization-only record queries for gateways.** The gateway can't answer condition/encounter/lab/medication/social-history searches, so those sections (including the Epic medication and condition→encounter chains, for servers configured with the Epic strategy) are skipped entirely — a records query against a gateway now sends exactly one Immunization search instead of a dozen doomed round trips.
- **Search-outcome entries dropped during parsing.** `OperationOutcome` / `search.mode=outcome` entries in searchset bundles are logged (their diagnostics often explain empty results) and excluded from the parsed response, so they no longer appear in the Response tab or `/api/query` bundles.

The chained params are deliberately unqualified (`patient.given`, not `patient:Patient.given`) to match the exact request shape verified working against the gateway; strict FHIR servers that require type-qualified chains aren't in scope for the immunization endpoint type.

## Testing

- New `iz-gateway.test.ts` suite: chained-demographics GET for both default- and Epic-strategy gateway servers, patient-param fallback without demographics, single-request behavior (no POST batch, no Epic chains), and outcome-entry filtering with a gateway-shaped bundle.
- `custom-query.test.ts`: chained-param compilation, fallbacks, demographics extraction rules (official-name preference, first given name, partial-date rejection).
- Full unit + integration suites pass.
- Verified end-to-end against the local dev stack: with a server set to the immunization endpoint type, the UI query flow emits `GET /Immunization?patient.given=Hyper&patient.family=Unlucky&patient.birthdate=1975-12-06` built from the discovered patient, skips all other section queries, and degrades gracefully on a non-200.

## Follow-ups

- SNHD retest: the IZ Gateway server config should set **Endpoint Type = Immunization Gateway** (query strategy no longer matters for that server).
- The July 8 `invalid onRequestStart method` / `fetch failed` errors SNHD saw on v1.1.0 were the pre-#995 undici dispatcher mismatch; #995 shipped in v1.1.1, so the next image they pull resolves those independently of this PR.