### PR TITLE
Release v1.1.2

### DIFF
--- a/app_version.yml
+++ b/app_version.yml
@@ -1,1 +1,1 @@
-version: 1.1.1
+version: 1.1.2

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "query-connector",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "query-connector",
-      "version": "1.1.1",
+      "version": "1.1.2",
       "dependencies": {
         "@aws-sdk/client-secrets-manager": "^3.1085.0",
         "@axe-core/playwright": "^4.12.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "query-connector",
   "description": "DIBBs Query Connector: a Next.js full-stack application for public health staff to query healthcare organizations for patient records via FHIR and TEFCA networks.",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "private": true,
   "scripts": {
     "dev": "docker compose -f docker-compose-dev.yaml up -d && next dev --turbopack; docker compose -f docker-compose-dev.yaml down --remove-orphans",


### PR DESCRIPTION
## Summary
Bumps the app version to **v1.1.2** to trigger a release.

Patch release containing:
- #998 — fix: Epic query strategy medication retrieval and display
- #1002 — fix: IZ Gateway immunization retrieval via chained patient demographics
- #999 — Bump keycloak/keycloak from 26.6 to 26.7
- #1000 — Bump the minor-and-patch group with 9 updates