### PR TITLE
feat: race, ethnicity, and gender patient search parameters

### DIFF
--- a/src/app/(pages)/apiDocs/openapi.json
+++ b/src/app/(pages)/apiDocs/openapi.json
@@ -393,6 +393,50 @@
               "type": "string",
               "example": "48864"
             }
+          },
+          {
+            "name": "gender",
+            "in": "query",
+            "description": "Patient sex as a FHIR administrative-gender code. Optional search refinement; does not count toward required patient identifiers.",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "female",
+                "male",
+                "other",
+                "unknown"
+              ],
+              "example": "female"
+            }
+          },
+          {
+            "name": "race",
+            "in": "query",
+            "description": "Patient race as an OMB category code from the CDC Race & Ethnicity code system (urn:oid:2.16.840.1.113883.6.238). Uses the US Core race SearchParameter; servers without US Core support may ignore it. Optional search refinement.",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "1002-5",
+                "2028-9",
+                "2054-5",
+                "2076-8",
+                "2106-3"
+              ],
+              "example": "2106-3"
+            }
+          },
+          {
+            "name": "ethnicity",
+            "in": "query",
+            "description": "Patient ethnicity as an OMB category code from the CDC Race & Ethnicity code system (urn:oid:2.16.840.1.113883.6.238). Uses the US Core ethnicity SearchParameter; servers without US Core support may ignore it. Optional search refinement.",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "2135-2",
+                "2186-5"
+              ],
+              "example": "2135-2"
+            }
           }
         ],
         "responses": {

--- a/src/app/(pages)/apiDocs/openapi.yaml
+++ b/src/app/(pages)/apiDocs/openapi.yaml
@@ -230,6 +230,27 @@ paths:
           schema:
             type: string
             example: 517-425-1398
+        - name: gender
+          in: query
+          description: Patient sex as a FHIR administrative-gender code. Optional search refinement; does not count toward required patient identifiers
+          schema:
+            type: string
+            enum: [female, male, other, unknown]
+            example: female
+        - name: race
+          in: query
+          description: Patient race as an OMB category code from the CDC Race & Ethnicity code system (urn:oid:2.16.840.1.113883.6.238). Uses the US Core race SearchParameter; servers without US Core support may ignore it
+          schema:
+            type: string
+            enum: ["1002-5", "2028-9", "2054-5", "2076-8", "2106-3"]
+            example: "2106-3"
+        - name: ethnicity
+          in: query
+          description: Patient ethnicity as an OMB category code from the CDC Race & Ethnicity code system (urn:oid:2.16.840.1.113883.6.238). Uses the US Core ethnicity SearchParameter; servers without US Core support may ignore it
+          schema:
+            type: string
+            enum: ["2135-2", "2186-5"]
+            example: "2135-2"
       responses:
         200:
           description: The FHIR resources returned that match the information configured in the query referenced

--- a/src/app/(pages)/query/components/searchForm/SearchForm.tsx
+++ b/src/app/(pages)/query/components/searchForm/SearchForm.tsx
@@ -12,6 +12,9 @@ import {
 import { useSearchParams } from "next/navigation";
 import {
   stateOptions,
+  genderOptions,
+  raceOptions,
+  ethnicityOptions,
   Mode,
   hyperUnluckyPatient,
   AddressData,
@@ -78,6 +81,11 @@ const SearchForm: React.FC<SearchFormProps> = function SearchForm({
       zip: "",
     },
   );
+  const [gender, setGender] = useState<string>(initialValues?.gender ?? "");
+  const [race, setRace] = useState<string>(initialValues?.race ?? "");
+  const [ethnicity, setEthnicity] = useState<string>(
+    initialValues?.ethnicity ?? "",
+  );
 
   const [fhirServerConfig, setFhirServerConfig] =
     useState<FhirServerConfig | null>(null);
@@ -95,6 +103,20 @@ const SearchForm: React.FC<SearchFormProps> = function SearchForm({
     setPhone(params?.get("phone") || "");
     setDOB(params?.get("dob") || "");
     setMRN(params?.get("mrn") || "");
+
+    // Only accept demographic codes that match a known dropdown option
+    const genderParam = params?.get("gender") || "";
+    setGender(
+      genderOptions.some((o) => o.value === genderParam) ? genderParam : "",
+    );
+    const raceParam = params?.get("race") || "";
+    setRace(raceOptions.some((o) => o.value === raceParam) ? raceParam : "");
+    const ethnicityParam = params?.get("ethnicity") || "";
+    setEthnicity(
+      ethnicityOptions.some((o) => o.value === ethnicityParam)
+        ? ethnicityParam
+        : "",
+    );
 
     const zipAddr = params?.get("zip");
     const stateAddr = params?.get("state") || "";
@@ -159,6 +181,9 @@ const SearchForm: React.FC<SearchFormProps> = function SearchForm({
       fhirServer,
       phone: FormatPhoneAsDigits(phone),
       email,
+      gender,
+      race,
+      ethnicity,
       address: {
         street1: address.street1,
         street2: address.street2,
@@ -231,6 +256,9 @@ const SearchForm: React.FC<SearchFormProps> = function SearchForm({
       phone,
       email,
       address,
+      gender,
+      race,
+      ethnicity,
     });
 
     const patientDiscoveryRequest = getPatientDiscoveryRequest();
@@ -426,6 +454,71 @@ const SearchForm: React.FC<SearchFormProps> = function SearchForm({
                 />
               </div>
               {renderFieldError(dob)}
+            </div>
+          </div>
+          <div className="grid-row grid-gap margin-bottom-4">
+            <h3 className={`"font-sans-md" ${styles.searchFormSectionLabel}`}>
+              Demographics
+            </h3>
+            <div className="tablet:grid-col-4">
+              <Label htmlFor="gender" className="margin-top-0-important">
+                Sex
+              </Label>
+              <Select
+                id="gender"
+                name="gender"
+                value={gender}
+                onChange={(event) => {
+                  setGender(event.target.value);
+                }}
+              >
+                <option value="">- Select -</option>
+                {genderOptions.map((option) => (
+                  <option key={option.value} value={option.value}>
+                    {option.label}
+                  </option>
+                ))}
+              </Select>
+            </div>
+            <div className="tablet:grid-col-4">
+              <Label htmlFor="race" className="margin-top-0-important">
+                Race
+              </Label>
+              <Select
+                id="race"
+                name="race"
+                value={race}
+                onChange={(event) => {
+                  setRace(event.target.value);
+                }}
+              >
+                <option value="">- Select -</option>
+                {raceOptions.map((option) => (
+                  <option key={option.value} value={option.value}>
+                    {option.label}
+                  </option>
+                ))}
+              </Select>
+            </div>
+            <div className="tablet:grid-col-4">
+              <Label htmlFor="ethnicity" className="margin-top-0-important">
+                Ethnicity
+              </Label>
+              <Select
+                id="ethnicity"
+                name="ethnicity"
+                value={ethnicity}
+                onChange={(event) => {
+                  setEthnicity(event.target.value);
+                }}
+              >
+                <option value="">- Select -</option>
+                {ethnicityOptions.map((option) => (
+                  <option key={option.value} value={option.value}>
+                    {option.label}
+                  </option>
+                ))}
+              </Select>
             </div>
           </div>
           <div className="grid-row grid-gap margin-bottom-4">

--- a/src/app/(pages)/query/components/searchForm/SearchForm.tsx
+++ b/src/app/(pages)/query/components/searchForm/SearchForm.tsx
@@ -351,7 +351,7 @@ const SearchForm: React.FC<SearchFormProps> = function SearchForm({
         <Fieldset className={`${styles.searchFormContainer} bg-white`}>
           {showAdvanced && (
             <div className="grid-row grid-gap margin-bottom-4">
-              <h3 className={`"font-sans-md" ${styles.searchFormSectionLabel}`}>
+              <h3 className={`font-sans-md ${styles.searchFormSectionLabel}`}>
                 Advanced
               </h3>
               <Label
@@ -395,7 +395,7 @@ const SearchForm: React.FC<SearchFormProps> = function SearchForm({
           )}
 
           <div className="grid-row grid-gap margin-bottom-4">
-            <h3 className={`"font-sans-md" ${styles.searchFormSectionLabel}`}>
+            <h3 className={`font-sans-md ${styles.searchFormSectionLabel}`}>
               Name
             </h3>
             <div className="tablet:grid-col-6">
@@ -434,7 +434,7 @@ const SearchForm: React.FC<SearchFormProps> = function SearchForm({
             </div>
           </div>
           <div className="grid-row grid-gap margin-bottom-4">
-            <h3 className={`"font-sans-md" ${styles.searchFormSectionLabel}`}>
+            <h3 className={`font-sans-md ${styles.searchFormSectionLabel}`}>
               Date of Birth
             </h3>
             <div className="grid-col-6">
@@ -457,7 +457,7 @@ const SearchForm: React.FC<SearchFormProps> = function SearchForm({
             </div>
           </div>
           <div className="grid-row grid-gap margin-bottom-4">
-            <h3 className={`"font-sans-md" ${styles.searchFormSectionLabel}`}>
+            <h3 className={`font-sans-md ${styles.searchFormSectionLabel}`}>
               Demographics
             </h3>
             <div className="tablet:grid-col-4">
@@ -522,7 +522,7 @@ const SearchForm: React.FC<SearchFormProps> = function SearchForm({
             </div>
           </div>
           <div className="grid-row grid-gap margin-bottom-4">
-            <h3 className={`"font-sans-md" ${styles.searchFormSectionLabel}`}>
+            <h3 className={`font-sans-md ${styles.searchFormSectionLabel}`}>
               Phone number
             </h3>
             <div className="grid-col-6">
@@ -541,7 +541,7 @@ const SearchForm: React.FC<SearchFormProps> = function SearchForm({
             </div>
           </div>
           <div className="grid-row grid-gap margin-bottom-4">
-            <h3 className={`"font-sans-md" ${styles.searchFormSectionLabel}`}>
+            <h3 className={`font-sans-md ${styles.searchFormSectionLabel}`}>
               Email address
             </h3>
             <div className="grid-col-6">
@@ -560,7 +560,7 @@ const SearchForm: React.FC<SearchFormProps> = function SearchForm({
             </div>
           </div>
           <div className="grid-row grid-gap margin-bottom-4">
-            <h3 className={`"font-sans-md" ${styles.searchFormSectionLabel}`}>
+            <h3 className={`font-sans-md ${styles.searchFormSectionLabel}`}>
               Address
             </h3>
             <div className="grid-col">
@@ -655,7 +655,7 @@ const SearchForm: React.FC<SearchFormProps> = function SearchForm({
             </div>
           </div>
           <div className="grid-row grid-gap margin-bottom-4">
-            <h3 className={`"font-sans-md" ${styles.searchFormSectionLabel}`}>
+            <h3 className={`font-sans-md ${styles.searchFormSectionLabel}`}>
               Medical Record Number (MRN)
             </h3>
             <div className="grid-col-6">

--- a/src/app/(pages)/query/components/searchForm/__snapshots__/searchForm.test.tsx.snap
+++ b/src/app/(pages)/query/components/searchForm/__snapshots__/searchForm.test.tsx.snap
@@ -71,7 +71,7 @@ exports[`SearchForm does not prefill address with bad data 1`] = `
           class="grid-row grid-gap margin-bottom-4"
         >
           <h3
-            class=""font-sans-md" searchFormSectionLabel"
+            class="font-sans-md searchFormSectionLabel"
           >
             Name
           </h3>
@@ -122,7 +122,7 @@ exports[`SearchForm does not prefill address with bad data 1`] = `
           class="grid-row grid-gap margin-bottom-4"
         >
           <h3
-            class=""font-sans-md" searchFormSectionLabel"
+            class="font-sans-md searchFormSectionLabel"
           >
             Date of Birth
           </h3>
@@ -153,7 +153,7 @@ exports[`SearchForm does not prefill address with bad data 1`] = `
           class="grid-row grid-gap margin-bottom-4"
         >
           <h3
-            class=""font-sans-md" searchFormSectionLabel"
+            class="font-sans-md searchFormSectionLabel"
           >
             Demographics
           </h3>
@@ -286,7 +286,7 @@ exports[`SearchForm does not prefill address with bad data 1`] = `
           class="grid-row grid-gap margin-bottom-4"
         >
           <h3
-            class=""font-sans-md" searchFormSectionLabel"
+            class="font-sans-md searchFormSectionLabel"
           >
             Phone number
           </h3>
@@ -314,7 +314,7 @@ exports[`SearchForm does not prefill address with bad data 1`] = `
           class="grid-row grid-gap margin-bottom-4"
         >
           <h3
-            class=""font-sans-md" searchFormSectionLabel"
+            class="font-sans-md searchFormSectionLabel"
           >
             Email address
           </h3>
@@ -342,7 +342,7 @@ exports[`SearchForm does not prefill address with bad data 1`] = `
           class="grid-row grid-gap margin-bottom-4"
         >
           <h3
-            class=""font-sans-md" searchFormSectionLabel"
+            class="font-sans-md searchFormSectionLabel"
           >
             Address
           </h3>
@@ -775,7 +775,7 @@ exports[`SearchForm does not prefill address with bad data 1`] = `
           class="grid-row grid-gap margin-bottom-4"
         >
           <h3
-            class=""font-sans-md" searchFormSectionLabel"
+            class="font-sans-md searchFormSectionLabel"
           >
             Medical Record Number (MRN)
           </h3>
@@ -882,7 +882,7 @@ exports[`SearchForm does not prefill fhir server with bad data 1`] = `
           class="grid-row grid-gap margin-bottom-4"
         >
           <h3
-            class=""font-sans-md" searchFormSectionLabel"
+            class="font-sans-md searchFormSectionLabel"
           >
             Name
           </h3>
@@ -933,7 +933,7 @@ exports[`SearchForm does not prefill fhir server with bad data 1`] = `
           class="grid-row grid-gap margin-bottom-4"
         >
           <h3
-            class=""font-sans-md" searchFormSectionLabel"
+            class="font-sans-md searchFormSectionLabel"
           >
             Date of Birth
           </h3>
@@ -964,7 +964,7 @@ exports[`SearchForm does not prefill fhir server with bad data 1`] = `
           class="grid-row grid-gap margin-bottom-4"
         >
           <h3
-            class=""font-sans-md" searchFormSectionLabel"
+            class="font-sans-md searchFormSectionLabel"
           >
             Demographics
           </h3>
@@ -1097,7 +1097,7 @@ exports[`SearchForm does not prefill fhir server with bad data 1`] = `
           class="grid-row grid-gap margin-bottom-4"
         >
           <h3
-            class=""font-sans-md" searchFormSectionLabel"
+            class="font-sans-md searchFormSectionLabel"
           >
             Phone number
           </h3>
@@ -1125,7 +1125,7 @@ exports[`SearchForm does not prefill fhir server with bad data 1`] = `
           class="grid-row grid-gap margin-bottom-4"
         >
           <h3
-            class=""font-sans-md" searchFormSectionLabel"
+            class="font-sans-md searchFormSectionLabel"
           >
             Email address
           </h3>
@@ -1153,7 +1153,7 @@ exports[`SearchForm does not prefill fhir server with bad data 1`] = `
           class="grid-row grid-gap margin-bottom-4"
         >
           <h3
-            class=""font-sans-md" searchFormSectionLabel"
+            class="font-sans-md searchFormSectionLabel"
           >
             Address
           </h3>
@@ -1586,7 +1586,7 @@ exports[`SearchForm does not prefill fhir server with bad data 1`] = `
           class="grid-row grid-gap margin-bottom-4"
         >
           <h3
-            class=""font-sans-md" searchFormSectionLabel"
+            class="font-sans-md searchFormSectionLabel"
           >
             Medical Record Number (MRN)
           </h3>
@@ -1693,7 +1693,7 @@ exports[`SearchForm prefills form fields from query params 1`] = `
           class="grid-row grid-gap margin-bottom-4"
         >
           <h3
-            class=""font-sans-md" searchFormSectionLabel"
+            class="font-sans-md searchFormSectionLabel"
           >
             Name
           </h3>
@@ -1744,7 +1744,7 @@ exports[`SearchForm prefills form fields from query params 1`] = `
           class="grid-row grid-gap margin-bottom-4"
         >
           <h3
-            class=""font-sans-md" searchFormSectionLabel"
+            class="font-sans-md searchFormSectionLabel"
           >
             Date of Birth
           </h3>
@@ -1775,7 +1775,7 @@ exports[`SearchForm prefills form fields from query params 1`] = `
           class="grid-row grid-gap margin-bottom-4"
         >
           <h3
-            class=""font-sans-md" searchFormSectionLabel"
+            class="font-sans-md searchFormSectionLabel"
           >
             Demographics
           </h3>
@@ -1908,7 +1908,7 @@ exports[`SearchForm prefills form fields from query params 1`] = `
           class="grid-row grid-gap margin-bottom-4"
         >
           <h3
-            class=""font-sans-md" searchFormSectionLabel"
+            class="font-sans-md searchFormSectionLabel"
           >
             Phone number
           </h3>
@@ -1936,7 +1936,7 @@ exports[`SearchForm prefills form fields from query params 1`] = `
           class="grid-row grid-gap margin-bottom-4"
         >
           <h3
-            class=""font-sans-md" searchFormSectionLabel"
+            class="font-sans-md searchFormSectionLabel"
           >
             Email address
           </h3>
@@ -1964,7 +1964,7 @@ exports[`SearchForm prefills form fields from query params 1`] = `
           class="grid-row grid-gap margin-bottom-4"
         >
           <h3
-            class=""font-sans-md" searchFormSectionLabel"
+            class="font-sans-md searchFormSectionLabel"
           >
             Address
           </h3>
@@ -2397,7 +2397,7 @@ exports[`SearchForm prefills form fields from query params 1`] = `
           class="grid-row grid-gap margin-bottom-4"
         >
           <h3
-            class=""font-sans-md" searchFormSectionLabel"
+            class="font-sans-md searchFormSectionLabel"
           >
             Medical Record Number (MRN)
           </h3>
@@ -2504,7 +2504,7 @@ exports[`SearchForm renders fhir server form options on button click 1`] = `
           class="grid-row grid-gap margin-bottom-4"
         >
           <h3
-            class=""font-sans-md" searchFormSectionLabel"
+            class="font-sans-md searchFormSectionLabel"
           >
             Name
           </h3>
@@ -2555,7 +2555,7 @@ exports[`SearchForm renders fhir server form options on button click 1`] = `
           class="grid-row grid-gap margin-bottom-4"
         >
           <h3
-            class=""font-sans-md" searchFormSectionLabel"
+            class="font-sans-md searchFormSectionLabel"
           >
             Date of Birth
           </h3>
@@ -2586,7 +2586,7 @@ exports[`SearchForm renders fhir server form options on button click 1`] = `
           class="grid-row grid-gap margin-bottom-4"
         >
           <h3
-            class=""font-sans-md" searchFormSectionLabel"
+            class="font-sans-md searchFormSectionLabel"
           >
             Demographics
           </h3>
@@ -2719,7 +2719,7 @@ exports[`SearchForm renders fhir server form options on button click 1`] = `
           class="grid-row grid-gap margin-bottom-4"
         >
           <h3
-            class=""font-sans-md" searchFormSectionLabel"
+            class="font-sans-md searchFormSectionLabel"
           >
             Phone number
           </h3>
@@ -2747,7 +2747,7 @@ exports[`SearchForm renders fhir server form options on button click 1`] = `
           class="grid-row grid-gap margin-bottom-4"
         >
           <h3
-            class=""font-sans-md" searchFormSectionLabel"
+            class="font-sans-md searchFormSectionLabel"
           >
             Email address
           </h3>
@@ -2775,7 +2775,7 @@ exports[`SearchForm renders fhir server form options on button click 1`] = `
           class="grid-row grid-gap margin-bottom-4"
         >
           <h3
-            class=""font-sans-md" searchFormSectionLabel"
+            class="font-sans-md searchFormSectionLabel"
           >
             Address
           </h3>
@@ -3208,7 +3208,7 @@ exports[`SearchForm renders fhir server form options on button click 1`] = `
           class="grid-row grid-gap margin-bottom-4"
         >
           <h3
-            class=""font-sans-md" searchFormSectionLabel"
+            class="font-sans-md searchFormSectionLabel"
           >
             Medical Record Number (MRN)
           </h3>
@@ -3315,7 +3315,7 @@ exports[`SearchForm renders the patient search form 1`] = `
           class="grid-row grid-gap margin-bottom-4"
         >
           <h3
-            class=""font-sans-md" searchFormSectionLabel"
+            class="font-sans-md searchFormSectionLabel"
           >
             Name
           </h3>
@@ -3366,7 +3366,7 @@ exports[`SearchForm renders the patient search form 1`] = `
           class="grid-row grid-gap margin-bottom-4"
         >
           <h3
-            class=""font-sans-md" searchFormSectionLabel"
+            class="font-sans-md searchFormSectionLabel"
           >
             Date of Birth
           </h3>
@@ -3397,7 +3397,7 @@ exports[`SearchForm renders the patient search form 1`] = `
           class="grid-row grid-gap margin-bottom-4"
         >
           <h3
-            class=""font-sans-md" searchFormSectionLabel"
+            class="font-sans-md searchFormSectionLabel"
           >
             Demographics
           </h3>
@@ -3530,7 +3530,7 @@ exports[`SearchForm renders the patient search form 1`] = `
           class="grid-row grid-gap margin-bottom-4"
         >
           <h3
-            class=""font-sans-md" searchFormSectionLabel"
+            class="font-sans-md searchFormSectionLabel"
           >
             Phone number
           </h3>
@@ -3558,7 +3558,7 @@ exports[`SearchForm renders the patient search form 1`] = `
           class="grid-row grid-gap margin-bottom-4"
         >
           <h3
-            class=""font-sans-md" searchFormSectionLabel"
+            class="font-sans-md searchFormSectionLabel"
           >
             Email address
           </h3>
@@ -3586,7 +3586,7 @@ exports[`SearchForm renders the patient search form 1`] = `
           class="grid-row grid-gap margin-bottom-4"
         >
           <h3
-            class=""font-sans-md" searchFormSectionLabel"
+            class="font-sans-md searchFormSectionLabel"
           >
             Address
           </h3>
@@ -4019,7 +4019,7 @@ exports[`SearchForm renders the patient search form 1`] = `
           class="grid-row grid-gap margin-bottom-4"
         >
           <h3
-            class=""font-sans-md" searchFormSectionLabel"
+            class="font-sans-md searchFormSectionLabel"
           >
             Medical Record Number (MRN)
           </h3>

--- a/src/app/(pages)/query/components/searchForm/__snapshots__/searchForm.test.tsx.snap
+++ b/src/app/(pages)/query/components/searchForm/__snapshots__/searchForm.test.tsx.snap
@@ -155,6 +155,139 @@ exports[`SearchForm does not prefill address with bad data 1`] = `
           <h3
             class=""font-sans-md" searchFormSectionLabel"
           >
+            Demographics
+          </h3>
+          <div
+            class="tablet:grid-col-4"
+          >
+            <label
+              class="usa-label margin-top-0-important"
+              data-testid="label"
+              for="gender"
+            >
+              Sex
+            </label>
+            <select
+              class="usa-select"
+              data-testid="Select"
+              id="gender"
+              name="gender"
+            >
+              <option
+                value=""
+              >
+                - Select -
+              </option>
+              <option
+                value="female"
+              >
+                Female
+              </option>
+              <option
+                value="male"
+              >
+                Male
+              </option>
+              <option
+                value="other"
+              >
+                Other
+              </option>
+              <option
+                value="unknown"
+              >
+                Unknown
+              </option>
+            </select>
+          </div>
+          <div
+            class="tablet:grid-col-4"
+          >
+            <label
+              class="usa-label margin-top-0-important"
+              data-testid="label"
+              for="race"
+            >
+              Race
+            </label>
+            <select
+              class="usa-select"
+              data-testid="Select"
+              id="race"
+              name="race"
+            >
+              <option
+                value=""
+              >
+                - Select -
+              </option>
+              <option
+                value="1002-5"
+              >
+                American Indian or Alaska Native
+              </option>
+              <option
+                value="2028-9"
+              >
+                Asian
+              </option>
+              <option
+                value="2054-5"
+              >
+                Black or African American
+              </option>
+              <option
+                value="2076-8"
+              >
+                Native Hawaiian or Other Pacific Islander
+              </option>
+              <option
+                value="2106-3"
+              >
+                White
+              </option>
+            </select>
+          </div>
+          <div
+            class="tablet:grid-col-4"
+          >
+            <label
+              class="usa-label margin-top-0-important"
+              data-testid="label"
+              for="ethnicity"
+            >
+              Ethnicity
+            </label>
+            <select
+              class="usa-select"
+              data-testid="Select"
+              id="ethnicity"
+              name="ethnicity"
+            >
+              <option
+                value=""
+              >
+                - Select -
+              </option>
+              <option
+                value="2135-2"
+              >
+                Hispanic or Latino
+              </option>
+              <option
+                value="2186-5"
+              >
+                Not Hispanic or Latino
+              </option>
+            </select>
+          </div>
+        </div>
+        <div
+          class="grid-row grid-gap margin-bottom-4"
+        >
+          <h3
+            class=""font-sans-md" searchFormSectionLabel"
+          >
             Phone number
           </h3>
           <div
@@ -825,6 +958,139 @@ exports[`SearchForm does not prefill fhir server with bad data 1`] = `
                 value=""
               />
             </div>
+          </div>
+        </div>
+        <div
+          class="grid-row grid-gap margin-bottom-4"
+        >
+          <h3
+            class=""font-sans-md" searchFormSectionLabel"
+          >
+            Demographics
+          </h3>
+          <div
+            class="tablet:grid-col-4"
+          >
+            <label
+              class="usa-label margin-top-0-important"
+              data-testid="label"
+              for="gender"
+            >
+              Sex
+            </label>
+            <select
+              class="usa-select"
+              data-testid="Select"
+              id="gender"
+              name="gender"
+            >
+              <option
+                value=""
+              >
+                - Select -
+              </option>
+              <option
+                value="female"
+              >
+                Female
+              </option>
+              <option
+                value="male"
+              >
+                Male
+              </option>
+              <option
+                value="other"
+              >
+                Other
+              </option>
+              <option
+                value="unknown"
+              >
+                Unknown
+              </option>
+            </select>
+          </div>
+          <div
+            class="tablet:grid-col-4"
+          >
+            <label
+              class="usa-label margin-top-0-important"
+              data-testid="label"
+              for="race"
+            >
+              Race
+            </label>
+            <select
+              class="usa-select"
+              data-testid="Select"
+              id="race"
+              name="race"
+            >
+              <option
+                value=""
+              >
+                - Select -
+              </option>
+              <option
+                value="1002-5"
+              >
+                American Indian or Alaska Native
+              </option>
+              <option
+                value="2028-9"
+              >
+                Asian
+              </option>
+              <option
+                value="2054-5"
+              >
+                Black or African American
+              </option>
+              <option
+                value="2076-8"
+              >
+                Native Hawaiian or Other Pacific Islander
+              </option>
+              <option
+                value="2106-3"
+              >
+                White
+              </option>
+            </select>
+          </div>
+          <div
+            class="tablet:grid-col-4"
+          >
+            <label
+              class="usa-label margin-top-0-important"
+              data-testid="label"
+              for="ethnicity"
+            >
+              Ethnicity
+            </label>
+            <select
+              class="usa-select"
+              data-testid="Select"
+              id="ethnicity"
+              name="ethnicity"
+            >
+              <option
+                value=""
+              >
+                - Select -
+              </option>
+              <option
+                value="2135-2"
+              >
+                Hispanic or Latino
+              </option>
+              <option
+                value="2186-5"
+              >
+                Not Hispanic or Latino
+              </option>
+            </select>
           </div>
         </div>
         <div
@@ -1511,6 +1777,139 @@ exports[`SearchForm prefills form fields from query params 1`] = `
           <h3
             class=""font-sans-md" searchFormSectionLabel"
           >
+            Demographics
+          </h3>
+          <div
+            class="tablet:grid-col-4"
+          >
+            <label
+              class="usa-label margin-top-0-important"
+              data-testid="label"
+              for="gender"
+            >
+              Sex
+            </label>
+            <select
+              class="usa-select"
+              data-testid="Select"
+              id="gender"
+              name="gender"
+            >
+              <option
+                value=""
+              >
+                - Select -
+              </option>
+              <option
+                value="female"
+              >
+                Female
+              </option>
+              <option
+                value="male"
+              >
+                Male
+              </option>
+              <option
+                value="other"
+              >
+                Other
+              </option>
+              <option
+                value="unknown"
+              >
+                Unknown
+              </option>
+            </select>
+          </div>
+          <div
+            class="tablet:grid-col-4"
+          >
+            <label
+              class="usa-label margin-top-0-important"
+              data-testid="label"
+              for="race"
+            >
+              Race
+            </label>
+            <select
+              class="usa-select"
+              data-testid="Select"
+              id="race"
+              name="race"
+            >
+              <option
+                value=""
+              >
+                - Select -
+              </option>
+              <option
+                value="1002-5"
+              >
+                American Indian or Alaska Native
+              </option>
+              <option
+                value="2028-9"
+              >
+                Asian
+              </option>
+              <option
+                value="2054-5"
+              >
+                Black or African American
+              </option>
+              <option
+                value="2076-8"
+              >
+                Native Hawaiian or Other Pacific Islander
+              </option>
+              <option
+                value="2106-3"
+              >
+                White
+              </option>
+            </select>
+          </div>
+          <div
+            class="tablet:grid-col-4"
+          >
+            <label
+              class="usa-label margin-top-0-important"
+              data-testid="label"
+              for="ethnicity"
+            >
+              Ethnicity
+            </label>
+            <select
+              class="usa-select"
+              data-testid="Select"
+              id="ethnicity"
+              name="ethnicity"
+            >
+              <option
+                value=""
+              >
+                - Select -
+              </option>
+              <option
+                value="2135-2"
+              >
+                Hispanic or Latino
+              </option>
+              <option
+                value="2186-5"
+              >
+                Not Hispanic or Latino
+              </option>
+            </select>
+          </div>
+        </div>
+        <div
+          class="grid-row grid-gap margin-bottom-4"
+        >
+          <h3
+            class=""font-sans-md" searchFormSectionLabel"
+          >
             Phone number
           </h3>
           <div
@@ -2189,6 +2588,139 @@ exports[`SearchForm renders fhir server form options on button click 1`] = `
           <h3
             class=""font-sans-md" searchFormSectionLabel"
           >
+            Demographics
+          </h3>
+          <div
+            class="tablet:grid-col-4"
+          >
+            <label
+              class="usa-label margin-top-0-important"
+              data-testid="label"
+              for="gender"
+            >
+              Sex
+            </label>
+            <select
+              class="usa-select"
+              data-testid="Select"
+              id="gender"
+              name="gender"
+            >
+              <option
+                value=""
+              >
+                - Select -
+              </option>
+              <option
+                value="female"
+              >
+                Female
+              </option>
+              <option
+                value="male"
+              >
+                Male
+              </option>
+              <option
+                value="other"
+              >
+                Other
+              </option>
+              <option
+                value="unknown"
+              >
+                Unknown
+              </option>
+            </select>
+          </div>
+          <div
+            class="tablet:grid-col-4"
+          >
+            <label
+              class="usa-label margin-top-0-important"
+              data-testid="label"
+              for="race"
+            >
+              Race
+            </label>
+            <select
+              class="usa-select"
+              data-testid="Select"
+              id="race"
+              name="race"
+            >
+              <option
+                value=""
+              >
+                - Select -
+              </option>
+              <option
+                value="1002-5"
+              >
+                American Indian or Alaska Native
+              </option>
+              <option
+                value="2028-9"
+              >
+                Asian
+              </option>
+              <option
+                value="2054-5"
+              >
+                Black or African American
+              </option>
+              <option
+                value="2076-8"
+              >
+                Native Hawaiian or Other Pacific Islander
+              </option>
+              <option
+                value="2106-3"
+              >
+                White
+              </option>
+            </select>
+          </div>
+          <div
+            class="tablet:grid-col-4"
+          >
+            <label
+              class="usa-label margin-top-0-important"
+              data-testid="label"
+              for="ethnicity"
+            >
+              Ethnicity
+            </label>
+            <select
+              class="usa-select"
+              data-testid="Select"
+              id="ethnicity"
+              name="ethnicity"
+            >
+              <option
+                value=""
+              >
+                - Select -
+              </option>
+              <option
+                value="2135-2"
+              >
+                Hispanic or Latino
+              </option>
+              <option
+                value="2186-5"
+              >
+                Not Hispanic or Latino
+              </option>
+            </select>
+          </div>
+        </div>
+        <div
+          class="grid-row grid-gap margin-bottom-4"
+        >
+          <h3
+            class=""font-sans-md" searchFormSectionLabel"
+          >
             Phone number
           </h3>
           <div
@@ -2859,6 +3391,139 @@ exports[`SearchForm renders the patient search form 1`] = `
                 value=""
               />
             </div>
+          </div>
+        </div>
+        <div
+          class="grid-row grid-gap margin-bottom-4"
+        >
+          <h3
+            class=""font-sans-md" searchFormSectionLabel"
+          >
+            Demographics
+          </h3>
+          <div
+            class="tablet:grid-col-4"
+          >
+            <label
+              class="usa-label margin-top-0-important"
+              data-testid="label"
+              for="gender"
+            >
+              Sex
+            </label>
+            <select
+              class="usa-select"
+              data-testid="Select"
+              id="gender"
+              name="gender"
+            >
+              <option
+                value=""
+              >
+                - Select -
+              </option>
+              <option
+                value="female"
+              >
+                Female
+              </option>
+              <option
+                value="male"
+              >
+                Male
+              </option>
+              <option
+                value="other"
+              >
+                Other
+              </option>
+              <option
+                value="unknown"
+              >
+                Unknown
+              </option>
+            </select>
+          </div>
+          <div
+            class="tablet:grid-col-4"
+          >
+            <label
+              class="usa-label margin-top-0-important"
+              data-testid="label"
+              for="race"
+            >
+              Race
+            </label>
+            <select
+              class="usa-select"
+              data-testid="Select"
+              id="race"
+              name="race"
+            >
+              <option
+                value=""
+              >
+                - Select -
+              </option>
+              <option
+                value="1002-5"
+              >
+                American Indian or Alaska Native
+              </option>
+              <option
+                value="2028-9"
+              >
+                Asian
+              </option>
+              <option
+                value="2054-5"
+              >
+                Black or African American
+              </option>
+              <option
+                value="2076-8"
+              >
+                Native Hawaiian or Other Pacific Islander
+              </option>
+              <option
+                value="2106-3"
+              >
+                White
+              </option>
+            </select>
+          </div>
+          <div
+            class="tablet:grid-col-4"
+          >
+            <label
+              class="usa-label margin-top-0-important"
+              data-testid="label"
+              for="ethnicity"
+            >
+              Ethnicity
+            </label>
+            <select
+              class="usa-select"
+              data-testid="Select"
+              id="ethnicity"
+              name="ethnicity"
+            >
+              <option
+                value=""
+              >
+                - Select -
+              </option>
+              <option
+                value="2135-2"
+              >
+                Hispanic or Latino
+              </option>
+              <option
+                value="2186-5"
+              >
+                Not Hispanic or Latino
+              </option>
+            </select>
           </div>
         </div>
         <div

--- a/src/app/(pages)/query/components/searchForm/searchForm.test.tsx
+++ b/src/app/(pages)/query/components/searchForm/searchForm.test.tsx
@@ -97,7 +97,8 @@ describe("SearchForm", () => {
   });
 
   it("prefills form fields from query params", async () => {
-    const queryParams = "last=unlucky&mrn=1234";
+    const queryParams =
+      "last=unlucky&mrn=1234&gender=female&race=2106-3&ethnicity=not-a-code";
 
     const formattedParams = new URLSearchParams(queryParams);
     (useSearchParams as jest.Mock).mockReturnValue(formattedParams);
@@ -137,6 +138,13 @@ describe("SearchForm", () => {
     expect(lastName).toHaveValue("unlucky");
     expect(phone).toHaveValue("");
     expect(mrn).toHaveValue("1234");
+
+    // Known demographic codes prefill; unrecognized ones are rejected.
+    expect(screen.getByRole("combobox", { name: "Sex" })).toHaveValue("female");
+    expect(screen.getByRole("combobox", { name: "Race" })).toHaveValue(
+      "2106-3",
+    );
+    expect(screen.getByRole("combobox", { name: "Ethnicity" })).toHaveValue("");
   });
 
   it("repopulates fields from initialValues when revising a search", () => {
@@ -160,6 +168,9 @@ describe("SearchForm", () => {
         state: "MA",
         zip: "02101",
       },
+      gender: "female",
+      race: "2054-5",
+      ethnicity: "2186-5",
     };
 
     renderWithUser(
@@ -201,6 +212,13 @@ describe("SearchForm", () => {
     );
     expect(screen.getByRole("textbox", { name: "Zip code" })).toHaveValue(
       "02101",
+    );
+    expect(screen.getByRole("combobox", { name: "Sex" })).toHaveValue("female");
+    expect(screen.getByRole("combobox", { name: "Race" })).toHaveValue(
+      "2054-5",
+    );
+    expect(screen.getByRole("combobox", { name: "Ethnicity" })).toHaveValue(
+      "2186-5",
     );
   });
 
@@ -399,6 +417,64 @@ describe("SearchForm", () => {
     expect(setMode).toHaveBeenCalledWith("patient-results");
     expect(setUncertainMatchError).toHaveBeenCalledWith(false);
     expect(setLoading).toHaveBeenLastCalledWith(false);
+  });
+
+  it("includes selected demographics in the patient discovery request", async () => {
+    (useSearchParams as jest.Mock).mockReturnValue(new URLSearchParams(""));
+    (patientDiscoveryQuery as jest.Mock).mockClear();
+    (patientDiscoveryQuery as jest.Mock).mockResolvedValue([
+      { resourceType: "Patient", id: "p1" },
+    ]);
+
+    const setSearchFormValues = jest.fn();
+
+    const { user } = renderWithUser(
+      <RootProviderMock currentPage="/query">
+        <SearchForm
+          setMode={jest.fn()}
+          setLoading={jest.fn()}
+          setPatientDiscoveryQueryResponse={jest.fn()}
+          selectedFhirServer="Default server"
+          setFhirServer={jest.fn()}
+          fhirServers={["Default server"]}
+          setUncertainMatchError={jest.fn()}
+          setSearchFormValues={setSearchFormValues}
+        />
+      </RootProviderMock>,
+    );
+
+    await user.click(screen.getByRole("button", { name: "Fill fields" }));
+    await user.selectOptions(
+      screen.getByRole("combobox", { name: "Sex" }),
+      "female",
+    );
+    await user.selectOptions(
+      screen.getByRole("combobox", { name: "Race" }),
+      "2106-3",
+    );
+    await user.selectOptions(
+      screen.getByRole("combobox", { name: "Ethnicity" }),
+      "2135-2",
+    );
+
+    await user.click(
+      screen.getByRole("button", { name: "Search for patient" }),
+    );
+
+    expect(patientDiscoveryQuery).toHaveBeenCalledWith(
+      expect.objectContaining({
+        gender: "female",
+        race: "2106-3",
+        ethnicity: "2135-2",
+      }),
+    );
+    expect(setSearchFormValues).toHaveBeenCalledWith(
+      expect.objectContaining({
+        gender: "female",
+        race: "2106-3",
+        ethnicity: "2135-2",
+      }),
+    );
   });
 
   it("shows validation errors and does not query when required fields are missing", async () => {

--- a/src/app/api/query/parsers.test.ts
+++ b/src/app/api/query/parsers.test.ts
@@ -12,6 +12,9 @@ import {
   mapHL7SexToGender,
   mapHL7RaceToCode,
   mapHL7EthnicGroupToCode,
+  validateGenderCode,
+  validateRaceCode,
+  validateEthnicityCode,
 } from "./parsers";
 import { USE_CASE_DETAILS, USE_CASES } from "@/app/constants";
 
@@ -259,6 +262,58 @@ describe("parsePatientDemographics", () => {
       race: "2106-3",
       ethnicity: "2186-5",
     });
+  });
+
+  it("drops unrecognized gender and OMB category codes", () => {
+    const patient = makePatient({
+      gender: "nonbinary" as Patient["gender"],
+      extension: [
+        {
+          url: "http://hl7.org/fhir/us/core/StructureDefinition/us-core-race",
+          extension: [
+            {
+              url: "ombCategory",
+              valueCoding: {
+                system: "urn:oid:2.16.840.1.113883.6.238",
+                code: "not-a-code",
+              },
+            },
+          ],
+        },
+        {
+          url: "http://hl7.org/fhir/us/core/StructureDefinition/us-core-ethnicity",
+          extension: [
+            {
+              url: "ombCategory",
+              valueCoding: {
+                system: "urn:oid:2.16.840.1.113883.6.238",
+                code: "ASKU",
+              },
+            },
+          ],
+        },
+      ],
+    });
+
+    expect(parsePatientDemographics(patient)).toEqual({});
+  });
+});
+
+describe("demographic code validators", () => {
+  it("passes through supported codes", () => {
+    expect(validateGenderCode("female")).toBe("female");
+    expect(validateRaceCode("2106-3")).toBe("2106-3");
+    expect(validateEthnicityCode("2135-2")).toBe("2135-2");
+  });
+
+  it("returns empty string for unsupported codes", () => {
+    expect(validateGenderCode("Female")).toBe("");
+    expect(validateGenderCode("male&_revinclude=Provenance:target")).toBe("");
+    expect(validateRaceCode("W")).toBe("");
+    expect(validateEthnicityCode("H")).toBe("");
+    expect(validateGenderCode("")).toBe("");
+    expect(validateRaceCode("")).toBe("");
+    expect(validateEthnicityCode("")).toBe("");
   });
 });
 

--- a/src/app/api/query/parsers.test.ts
+++ b/src/app/api/query/parsers.test.ts
@@ -4,10 +4,14 @@ import {
   parseMRNs,
   parsePhoneNumbers,
   parseAddresses,
+  parseOmbCategoryCode,
   validEmail,
   parseEmails,
   parseHL7FromRequestBody,
   mapDeprecatedUseCaseToId,
+  mapHL7SexToGender,
+  mapHL7RaceToCode,
+  mapHL7EthnicGroupToCode,
 } from "./parsers";
 import { USE_CASE_DETAILS, USE_CASES } from "@/app/constants";
 
@@ -213,6 +217,108 @@ describe("parsePatientDemographics", () => {
 
   it("returns an empty object for a bare patient", () => {
     expect(parsePatientDemographics(makePatient())).toEqual({});
+  });
+
+  it("extracts gender and US Core race/ethnicity OMB category codes", () => {
+    const patient = makePatient({
+      gender: "female",
+      extension: [
+        {
+          url: "http://hl7.org/fhir/us/core/StructureDefinition/us-core-race",
+          extension: [
+            {
+              url: "ombCategory",
+              valueCoding: {
+                system: "urn:oid:2.16.840.1.113883.6.238",
+                code: "2106-3",
+                display: "White",
+              },
+            },
+            { url: "text", valueString: "White" },
+          ],
+        },
+        {
+          url: "http://hl7.org/fhir/us/core/StructureDefinition/us-core-ethnicity",
+          extension: [
+            {
+              url: "ombCategory",
+              valueCoding: {
+                system: "urn:oid:2.16.840.1.113883.6.238",
+                code: "2186-5",
+                display: "Not Hispanic or Latino",
+              },
+            },
+            { url: "text", valueString: "Not Hispanic or Latino" },
+          ],
+        },
+      ],
+    });
+
+    expect(parsePatientDemographics(patient)).toEqual({
+      gender: "female",
+      race: "2106-3",
+      ethnicity: "2186-5",
+    });
+  });
+});
+
+describe("parseOmbCategoryCode", () => {
+  const RACE_URL =
+    "http://hl7.org/fhir/us/core/StructureDefinition/us-core-race";
+
+  it("returns undefined when the patient has no extensions", () => {
+    expect(parseOmbCategoryCode(makePatient(), RACE_URL)).toBeUndefined();
+  });
+
+  it("returns undefined when the extension has no ombCategory", () => {
+    const patient = makePatient({
+      extension: [
+        {
+          url: RACE_URL,
+          extension: [{ url: "text", valueString: "White" }],
+        },
+      ],
+    });
+    expect(parseOmbCategoryCode(patient, RACE_URL)).toBeUndefined();
+  });
+});
+
+describe("mapHL7SexToGender", () => {
+  it.each([
+    ["M", "male"],
+    ["F", "female"],
+    ["f", "female"],
+    ["O", "other"],
+    ["A", "other"],
+    ["U", "unknown"],
+    ["", ""],
+    ["X", ""],
+  ])("maps %s to %s", (sex, expected) => {
+    expect(mapHL7SexToGender(sex)).toBe(expected);
+  });
+});
+
+describe("mapHL7RaceToCode", () => {
+  it("passes through supported OMB race category codes", () => {
+    expect(mapHL7RaceToCode("2106-3")).toBe("2106-3");
+    expect(mapHL7RaceToCode("1002-5")).toBe("1002-5");
+  });
+
+  it("returns empty string for unsupported codes", () => {
+    expect(mapHL7RaceToCode("W")).toBe("");
+    expect(mapHL7RaceToCode("")).toBe("");
+  });
+});
+
+describe("mapHL7EthnicGroupToCode", () => {
+  it.each([
+    ["H", "2135-2"],
+    ["N", "2186-5"],
+    ["2135-2", "2135-2"],
+    ["U", ""],
+    ["", ""],
+  ])("maps %s to %s", (ethnicGroup, expected) => {
+    expect(mapHL7EthnicGroupToCode(ethnicGroup)).toBe(expected);
   });
 });
 

--- a/src/app/api/query/parsers.ts
+++ b/src/app/api/query/parsers.ts
@@ -4,6 +4,7 @@ import {
   AddressData,
   USE_CASES,
   USE_CASE_DETAILS,
+  genderOptions,
   raceOptions,
   ethnicityOptions,
 } from "@/app/constants";
@@ -93,18 +94,20 @@ export function parsePatientDemographics(patient: Patient): PatientIdentifiers {
     }
   }
 
-  if (patient.gender) {
-    identifiers.gender = patient.gender;
+  const gender = validateGenderCode(patient.gender ?? "");
+  if (gender) {
+    identifiers.gender = gender;
   }
 
-  const race = parseOmbCategoryCode(patient, US_CORE_RACE_EXTENSION_URL);
+  const race = validateRaceCode(
+    parseOmbCategoryCode(patient, US_CORE_RACE_EXTENSION_URL) ?? "",
+  );
   if (race) {
     identifiers.race = race;
   }
 
-  const ethnicity = parseOmbCategoryCode(
-    patient,
-    US_CORE_ETHNICITY_EXTENSION_URL,
+  const ethnicity = validateEthnicityCode(
+    parseOmbCategoryCode(patient, US_CORE_ETHNICITY_EXTENSION_URL) ?? "",
   );
   if (ethnicity) {
     identifiers.ethnicity = ethnicity;
@@ -258,6 +261,39 @@ export function parseEmails(
 }
 
 /**
+ * Validates a FHIR administrative-gender code against the supported options.
+ * @param gender - The candidate gender code (e.g. female).
+ * @returns The code if it is a valid administrative-gender code, else empty
+ * string.
+ */
+export function validateGenderCode(gender: string): string {
+  return genderOptions.some((option) => option.value === gender) ? gender : "";
+}
+
+/**
+ * Validates a race code against the supported OMB race categories from the
+ * CDC Race & Ethnicity code system.
+ * @param race - The candidate race code (e.g. 2106-3).
+ * @returns The code if it is a supported OMB race category, else empty string.
+ */
+export function validateRaceCode(race: string): string {
+  return raceOptions.some((option) => option.value === race) ? race : "";
+}
+
+/**
+ * Validates an ethnicity code against the supported OMB ethnicity categories
+ * from the CDC Race & Ethnicity code system.
+ * @param ethnicity - The candidate ethnicity code (e.g. 2135-2).
+ * @returns The code if it is a supported OMB ethnicity category, else empty
+ * string.
+ */
+export function validateEthnicityCode(ethnicity: string): string {
+  return ethnicityOptions.some((option) => option.value === ethnicity)
+    ? ethnicity
+    : "";
+}
+
+/**
  * Maps an HL7v2 administrative sex code (PID.8, table 0001) to a FHIR
  * administrative-gender code.
  * @param sex - The HL7v2 administrative sex code (e.g. M, F, O, U).
@@ -286,7 +322,7 @@ export function mapHL7SexToGender(sex: string): string {
  * @returns The race code if it is a supported OMB category, else empty string.
  */
 export function mapHL7RaceToCode(race: string): string {
-  return raceOptions.some((option) => option.value === race) ? race : "";
+  return validateRaceCode(race);
 }
 
 /**
@@ -302,9 +338,7 @@ export function mapHL7EthnicGroupToCode(ethnicGroup: string): string {
     case "N":
       return "2186-5";
     default:
-      return ethnicityOptions.some((option) => option.value === ethnicGroup)
-        ? ethnicGroup
-        : "";
+      return validateEthnicityCode(ethnicGroup);
   }
 }
 

--- a/src/app/api/query/parsers.ts
+++ b/src/app/api/query/parsers.ts
@@ -1,6 +1,12 @@
 import { Patient } from "fhir/r4";
 import { FormatPhoneAsDigits } from "@/app/utils/format-service";
-import { AddressData, USE_CASES, USE_CASE_DETAILS } from "@/app/constants";
+import {
+  AddressData,
+  USE_CASES,
+  USE_CASE_DETAILS,
+  raceOptions,
+  ethnicityOptions,
+} from "@/app/constants";
 
 export type PatientIdentifiers = {
   first_name?: string;
@@ -14,7 +20,15 @@ export type PatientIdentifiers = {
   state?: string;
   zip?: string;
   email?: string;
+  gender?: string;
+  race?: string;
+  ethnicity?: string;
 };
+
+const US_CORE_RACE_EXTENSION_URL =
+  "http://hl7.org/fhir/us/core/StructureDefinition/us-core-race";
+const US_CORE_ETHNICITY_EXTENSION_URL =
+  "http://hl7.org/fhir/us/core/StructureDefinition/us-core-ethnicity";
 
 /**
  * Parses a patient resource to extract patient demographics.
@@ -79,7 +93,43 @@ export function parsePatientDemographics(patient: Patient): PatientIdentifiers {
     }
   }
 
+  if (patient.gender) {
+    identifiers.gender = patient.gender;
+  }
+
+  const race = parseOmbCategoryCode(patient, US_CORE_RACE_EXTENSION_URL);
+  if (race) {
+    identifiers.race = race;
+  }
+
+  const ethnicity = parseOmbCategoryCode(
+    patient,
+    US_CORE_ETHNICITY_EXTENSION_URL,
+  );
+  if (ethnicity) {
+    identifiers.ethnicity = ethnicity;
+  }
+
   return identifiers;
+}
+
+/**
+ * Extracts the OMB category code from a US Core race or ethnicity extension.
+ * @param patient - The patient resource to parse.
+ * @param extensionUrl - The US Core race or ethnicity StructureDefinition URL.
+ * @returns The OMB category code (e.g. 2106-3), or undefined if not present.
+ */
+export function parseOmbCategoryCode(
+  patient: Patient,
+  extensionUrl: string,
+): string | undefined {
+  const demographicExtension = patient.extension?.find(
+    (extension) => extension.url === extensionUrl,
+  );
+  const ombCategory = demographicExtension?.extension?.find(
+    (subExtension) => subExtension.url === "ombCategory",
+  );
+  return ombCategory?.valueCoding?.code;
 }
 
 /**
@@ -204,6 +254,57 @@ export function parseEmails(
       .map((contactPoint) => contactPoint.value)
       .filter((email) => validEmail(email));
     return emailAddresses.length > 0 ? emailAddresses : undefined;
+  }
+}
+
+/**
+ * Maps an HL7v2 administrative sex code (PID.8, table 0001) to a FHIR
+ * administrative-gender code.
+ * @param sex - The HL7v2 administrative sex code (e.g. M, F, O, U).
+ * @returns The FHIR administrative-gender code, or empty string if unmapped.
+ */
+export function mapHL7SexToGender(sex: string): string {
+  switch (sex.toUpperCase()) {
+    case "M":
+      return "male";
+    case "F":
+      return "female";
+    case "O":
+    case "A":
+      return "other";
+    case "U":
+      return "unknown";
+    default:
+      return "";
+  }
+}
+
+/**
+ * Validates an HL7v2 race code (PID.10, table 0005, which uses CDC Race &
+ * Ethnicity codes) against the supported OMB race categories.
+ * @param race - The HL7v2 race code (e.g. 2106-3).
+ * @returns The race code if it is a supported OMB category, else empty string.
+ */
+export function mapHL7RaceToCode(race: string): string {
+  return raceOptions.some((option) => option.value === race) ? race : "";
+}
+
+/**
+ * Maps an HL7v2 ethnic group code (PID.22, table 0189) to an OMB ethnicity
+ * category code. CDC Race & Ethnicity codes are passed through when supported.
+ * @param ethnicGroup - The HL7v2 ethnic group code (e.g. H, N, or 2135-2).
+ * @returns The OMB ethnicity category code, or empty string if unmapped.
+ */
+export function mapHL7EthnicGroupToCode(ethnicGroup: string): string {
+  switch (ethnicGroup.toUpperCase()) {
+    case "H":
+      return "2135-2";
+    case "N":
+      return "2186-5";
+    default:
+      return ethnicityOptions.some((option) => option.value === ethnicGroup)
+        ? ethnicGroup
+        : "";
   }
 }
 

--- a/src/app/api/query/route.ts
+++ b/src/app/api/query/route.ts
@@ -20,6 +20,9 @@ import {
   mapHL7SexToGender,
   parseHL7FromRequestBody,
   parsePatientDemographics,
+  validateEthnicityCode,
+  validateGenderCode,
+  validateRaceCode,
 } from "./parsers";
 import { Message } from "node-hl7-client";
 import { Bundle } from "fhir/r4";
@@ -91,9 +94,11 @@ export async function GET(request: NextRequest) {
   const zip = params.get("zip") ?? "";
 
   const email = params.get("email") ?? "";
-  const gender = params.get("gender") ?? "";
-  const race = params.get("race") ?? "";
-  const ethnicity = params.get("ethnicity") ?? "";
+  // Unrecognized demographic codes are dropped rather than forwarded to the
+  // FHIR server, matching the HL7v2 branch and the search form
+  const gender = validateGenderCode(params.get("gender") ?? "");
+  const race = validateRaceCode(params.get("race") ?? "");
+  const ethnicity = validateEthnicityCode(params.get("ethnicity") ?? "");
   const noParamsDefined = [
     given,
     family,

--- a/src/app/api/query/route.ts
+++ b/src/app/api/query/route.ts
@@ -15,6 +15,9 @@ import {
 } from "@/app/constants";
 import {
   mapDeprecatedUseCaseToId,
+  mapHL7EthnicGroupToCode,
+  mapHL7RaceToCode,
+  mapHL7SexToGender,
   parseHL7FromRequestBody,
   parsePatientDemographics,
 } from "./parsers";
@@ -88,6 +91,9 @@ export async function GET(request: NextRequest) {
   const zip = params.get("zip") ?? "";
 
   const email = params.get("email") ?? "";
+  const gender = params.get("gender") ?? "";
+  const race = params.get("race") ?? "";
+  const ethnicity = params.get("ethnicity") ?? "";
   const noParamsDefined = [
     given,
     family,
@@ -127,6 +133,9 @@ export async function GET(request: NextRequest) {
       zip,
     },
     email,
+    gender,
+    race,
+    ethnicity,
   };
 
   if (!validatedPatientSearch(QueryRequest)) {
@@ -211,6 +220,15 @@ export async function POST(request: NextRequest) {
       const zip = parsedMessage.get("PID.11.5").toString() ?? "";
       const phone = parsedMessage.get("NK1.5.1").toString() ?? "";
       const email = parsedMessage.get("PID.13.4").toString() ?? ""; //https://hl7-definition.caristix.com/v2/HL7v2.3/Fields/PID.13.4
+      const gender = mapHL7SexToGender(
+        parsedMessage.get("PID.8").toString() ?? "",
+      );
+      const race = mapHL7RaceToCode(
+        parsedMessage.get("PID.10.1").toString() ?? "",
+      );
+      const ethnicity = mapHL7EthnicGroupToCode(
+        parsedMessage.get("PID.22.1").toString() ?? "",
+      );
       const noPatientIdentifierDefined = [
         firstName,
         lastName,
@@ -239,6 +257,9 @@ export async function POST(request: NextRequest) {
         address: { street1, street2, city, state, zip },
         phone,
         email,
+        gender,
+        race,
+        ethnicity,
       };
     } catch (error: unknown) {
       return await handleAndReturnError(error);
@@ -281,6 +302,9 @@ export async function POST(request: NextRequest) {
         },
         phone: PatientIdentifiers?.phone,
         email: PatientIdentifiers?.email,
+        gender: PatientIdentifiers?.gender,
+        race: PatientIdentifiers?.race,
+        ethnicity: PatientIdentifiers?.ethnicity,
       };
     } catch (error: unknown) {
       return await handleAndReturnError(error);

--- a/src/app/backend/query-execution/service.ts
+++ b/src/app/backend/query-execution/service.ts
@@ -964,7 +964,7 @@ class QueryService {
     }
 
     if (dob) {
-      patientResource["birthdate"] = dob;
+      patientResource["birthDate"] = dob;
     }
 
     if (telecom.length > 0) {

--- a/src/app/backend/query-execution/service.ts
+++ b/src/app/backend/query-execution/service.ts
@@ -8,7 +8,12 @@ import {
   Task,
 } from "fhir/r4";
 
-import { isFhirResource } from "../../constants";
+import {
+  isFhirResource,
+  CDC_RACE_ETHNICITY_SYSTEM,
+  raceOptions,
+  ethnicityOptions,
+} from "../../constants";
 
 // ChainedPatientDemographics appears in a decorated method signature, which
 // requires a type-only import under emitDecoratorMetadata + isolatedModules.
@@ -58,6 +63,9 @@ interface PatientSearchParams {
     zip?: string;
   };
   email?: string;
+  gender?: string;
+  race?: string;
+  ethnicity?: string;
 }
 
 // Constants for configuration
@@ -108,13 +116,29 @@ class QueryService {
   private static async buildPatientSearchQuery(
     params: PatientSearchParams,
   ): Promise<string> {
-    const { firstName, lastName, dob, mrn, phone, address, email } = params;
+    const {
+      firstName,
+      lastName,
+      dob,
+      mrn,
+      phone,
+      address,
+      email,
+      gender,
+      race,
+      ethnicity,
+    } = params;
     let patientQuery = "Patient?";
 
     if (firstName) patientQuery += `given=${firstName}&`;
     if (lastName) patientQuery += `family=${lastName}&`;
     if (dob) patientQuery += `birthdate=${dob}&`;
     if (mrn) patientQuery += `identifier=${mrn}&`;
+    if (gender) patientQuery += `gender=${gender}&`;
+    // race/ethnicity are US Core SearchParameters (not base FHIR); servers
+    // without US Core support will ignore them under lenient search handling
+    if (race) patientQuery += `race=${race}&`;
+    if (ethnicity) patientQuery += `ethnicity=${ethnicity}&`;
 
     if (phone) {
       const phonesToSearch = phone.split(";");
@@ -893,6 +917,9 @@ class QueryService {
       phone,
       address,
       email,
+      gender,
+      race,
+      ethnicity,
       patientMatchConfiguration,
     } = request;
 
@@ -966,6 +993,52 @@ class QueryService {
           value: mrn,
         },
       ];
+    }
+
+    if (gender) {
+      patientResource["gender"] = gender;
+    }
+
+    const usCoreDemographicExtension = (
+      structureDefinitionUrl: string,
+      code: string,
+      display: string | undefined,
+    ) => ({
+      url: structureDefinitionUrl,
+      extension: [
+        {
+          url: "ombCategory",
+          valueCoding: {
+            system: CDC_RACE_ETHNICITY_SYSTEM,
+            code,
+            display,
+          },
+        },
+        { url: "text", valueString: display ?? code },
+      ],
+    });
+
+    const demographicExtensions = [];
+    if (race) {
+      demographicExtensions.push(
+        usCoreDemographicExtension(
+          "http://hl7.org/fhir/us/core/StructureDefinition/us-core-race",
+          race,
+          raceOptions.find((o) => o.value === race)?.label,
+        ),
+      );
+    }
+    if (ethnicity) {
+      demographicExtensions.push(
+        usCoreDemographicExtension(
+          "http://hl7.org/fhir/us/core/StructureDefinition/us-core-ethnicity",
+          ethnicity,
+          ethnicityOptions.find((o) => o.value === ethnicity)?.label,
+        ),
+      );
+    }
+    if (demographicExtensions.length > 0) {
+      patientResource["extension"] = demographicExtensions;
     }
 
     const hasIdentifiers = [

--- a/src/app/constants.ts
+++ b/src/app/constants.ts
@@ -201,12 +201,7 @@ export type BuildStep = "selection" | "condition" | "valueset";
 
 /* Mode that all pages can be in; used to set page data in context */
 export type PageType =
-  | "/"
-  | "queryBuilding"
-  | "fhir-servers"
-  | "userManagement"
-  | BuildStep
-  | Mode;
+  "/" | "queryBuilding" | "fhir-servers" | "userManagement" | BuildStep | Mode;
 
 export const metadata = {
   title: "Query Connector",
@@ -216,12 +211,7 @@ export const metadata = {
 export const DEFAULT_ERSD_VERSION = "3";
 
 export type ErsdConceptType =
-  | "ostc"
-  | "lotc"
-  | "lrtc"
-  | "mrtc"
-  | "dxtc"
-  | "sdtc";
+  "ostc" | "lotc" | "lrtc" | "mrtc" | "dxtc" | "sdtc";
 
 export const ersdToDibbsConceptMap: {
   [k in ErsdConceptType]: DibbsConceptType;

--- a/src/app/constants.ts
+++ b/src/app/constants.ts
@@ -57,7 +57,41 @@ export type PatientSearchFormValues = {
   phone: string;
   email: string;
   address: AddressData;
+  gender: string;
+  race: string;
+  ethnicity: string;
 };
+
+// CDC Race & Ethnicity code system used by the US Core race/ethnicity
+// extensions and search parameters.
+export const CDC_RACE_ETHNICITY_SYSTEM = "urn:oid:2.16.840.1.113883.6.238";
+
+/* Labels and FHIR administrative-gender codes for the sex dropdown on the
+ * query page. Labeled "Sex" in the UI to match the results display convention
+ * (see formatSex), but all administrative-gender codes are searchable. */
+export const genderOptions = [
+  { value: "female", label: "Female" },
+  { value: "male", label: "Male" },
+  { value: "other", label: "Other" },
+  { value: "unknown", label: "Unknown" },
+];
+
+/* Labels and OMB race category codes (CDC Race & Ethnicity code system) for
+ * the race dropdown on the query page */
+export const raceOptions = [
+  { value: "1002-5", label: "American Indian or Alaska Native" },
+  { value: "2028-9", label: "Asian" },
+  { value: "2054-5", label: "Black or African American" },
+  { value: "2076-8", label: "Native Hawaiian or Other Pacific Islander" },
+  { value: "2106-3", label: "White" },
+];
+
+/* Labels and OMB ethnicity category codes (CDC Race & Ethnicity code system)
+ * for the ethnicity dropdown on the query page */
+export const ethnicityOptions = [
+  { value: "2135-2", label: "Hispanic or Latino" },
+  { value: "2186-5", label: "Not Hispanic or Latino" },
+];
 
 //Create type to specify the demographic data fields for a patient
 export type DemoDataFields = {
@@ -167,7 +201,12 @@ export type BuildStep = "selection" | "condition" | "valueset";
 
 /* Mode that all pages can be in; used to set page data in context */
 export type PageType =
-  "/" | "queryBuilding" | "fhir-servers" | "userManagement" | BuildStep | Mode;
+  | "/"
+  | "queryBuilding"
+  | "fhir-servers"
+  | "userManagement"
+  | BuildStep
+  | Mode;
 
 export const metadata = {
   title: "Query Connector",
@@ -177,7 +216,12 @@ export const metadata = {
 export const DEFAULT_ERSD_VERSION = "3";
 
 export type ErsdConceptType =
-  "ostc" | "lotc" | "lrtc" | "mrtc" | "dxtc" | "sdtc";
+  | "ostc"
+  | "lotc"
+  | "lrtc"
+  | "mrtc"
+  | "dxtc"
+  | "sdtc";
 
 export const ersdToDibbsConceptMap: {
   [k in ErsdConceptType]: DibbsConceptType;

--- a/src/app/models/entities/query.ts
+++ b/src/app/models/entities/query.ts
@@ -40,6 +40,12 @@ export type PatientDiscoveryRequest = {
   phone?: string;
   address?: Address;
   email?: string;
+  /** FHIR administrative-gender code: male | female | other | unknown */
+  gender?: string;
+  /** OMB race category code from urn:oid:2.16.840.1.113883.6.238 (e.g. 2106-3) */
+  race?: string;
+  /** OMB ethnicity category code from urn:oid:2.16.840.1.113883.6.238 (e.g. 2135-2) */
+  ethnicity?: string;
   patientMatchConfiguration?: PatientMatchData;
 };
 

--- a/src/app/tests/integration/mtls-api-query.test.ts
+++ b/src/app/tests/integration/mtls-api-query.test.ts
@@ -206,6 +206,9 @@ jest.mock("@/app/backend/query-building/service", () => ({
 }));
 
 jest.mock("@/app/api/query/parsers", () => ({
+  // Pull in the real module so pure helpers (e.g. the HL7 code mappers) keep
+  // working when the route imports them; only the stubs below are overridden.
+  ...jest.requireActual("@/app/api/query/parsers"),
   parseHL7FromRequestBody: jest.fn().mockImplementation((body) => body),
   parsePatientDemographics: jest.fn().mockReturnValue({
     first_name: "John",

--- a/src/app/tests/integration/mtls-query-execution.test.ts
+++ b/src/app/tests/integration/mtls-query-execution.test.ts
@@ -425,5 +425,140 @@ describe("Query Execution with Mutual TLS", () => {
       expect(result).toHaveLength(1);
       expect(result[0]).toEqual(mockPatient);
     });
+
+    it("should include gender, race, and ethnicity search params when provided", async () => {
+      const nonMtlsServerConfig = {
+        ...mockServerConfig,
+        authType: "none",
+        endpointType: "standard",
+      };
+
+      const {
+        getFhirServerConfigs,
+        getFhirServerNames,
+      } = require("@/app/backend/fhir-servers/service");
+      (getFhirServerConfigs as jest.Mock).mockResolvedValue([
+        nonMtlsServerConfig,
+      ]);
+      (getFhirServerNames as jest.Mock).mockResolvedValue([
+        nonMtlsServerConfig.name,
+      ]);
+
+      const standardPatientResponse = {
+        status: 200,
+        headers: new Headers({ "content-type": "application/json" }),
+        json: async () => mockPatientBundle,
+        clone: () => standardPatientResponse,
+      } as Response;
+      mockFhirClient.get.mockResolvedValueOnce(standardPatientResponse);
+
+      const request = {
+        fhirServer: "Test mTLS Server",
+        firstName: "John",
+        lastName: "Doe",
+        dob: "1990-01-01",
+        gender: "male",
+        race: "2106-3",
+        ethnicity: "2186-5",
+      };
+
+      await patientDiscoveryQuery(request);
+
+      expect(mockFhirClient.get).toHaveBeenCalledWith(
+        "/Patient?given=John&family=Doe&birthdate=1990-01-01&gender=male&race=2106-3&ethnicity=2186-5",
+      );
+    });
+
+    it("should include gender and US Core race/ethnicity extensions in $match requests", async () => {
+      const matchServerConfig = {
+        ...mockServerConfig,
+        authType: "none",
+        endpointType: "standard",
+      };
+
+      const {
+        getFhirServerConfigs,
+        getFhirServerNames,
+      } = require("@/app/backend/fhir-servers/service");
+      (getFhirServerConfigs as jest.Mock).mockResolvedValue([
+        matchServerConfig,
+      ]);
+      (getFhirServerNames as jest.Mock).mockResolvedValue([
+        matchServerConfig.name,
+      ]);
+
+      const matchResponse = {
+        status: 200,
+        headers: new Headers({ "content-type": "application/json" }),
+        json: async () => mockPatientBundle,
+        clone: () => matchResponse,
+      } as Response;
+      mockFhirClient.postJson.mockResolvedValueOnce(matchResponse);
+
+      const request = {
+        fhirServer: "Test mTLS Server",
+        firstName: "John",
+        lastName: "Doe",
+        dob: "1990-01-01",
+        gender: "female",
+        race: "2054-5",
+        ethnicity: "2135-2",
+        patientMatchConfiguration: {
+          enabled: true,
+          supportsMatch: true,
+          onlyCertainMatches: false,
+          onlySingleMatch: false,
+          matchCount: 0,
+        },
+      };
+
+      await patientDiscoveryQuery(request);
+
+      expect(mockFhirClient.postJson).toHaveBeenCalledWith(
+        "/Patient/$match",
+        expect.objectContaining({
+          resourceType: "Parameters",
+        }),
+      );
+
+      const parameters = mockFhirClient.postJson.mock.calls[0][1] as {
+        parameter: { name: string; resource?: Record<string, unknown> }[];
+      };
+      const patientResource = parameters.parameter.find(
+        (p) => p.name === "resource",
+      )?.resource as Record<string, unknown>;
+
+      expect(patientResource["gender"]).toBe("female");
+      expect(patientResource["extension"]).toEqual([
+        {
+          url: "http://hl7.org/fhir/us/core/StructureDefinition/us-core-race",
+          extension: [
+            {
+              url: "ombCategory",
+              valueCoding: {
+                system: "urn:oid:2.16.840.1.113883.6.238",
+                code: "2054-5",
+                display: "Black or African American",
+              },
+            },
+            { url: "text", valueString: "Black or African American" },
+          ],
+        },
+        {
+          url: "http://hl7.org/fhir/us/core/StructureDefinition/us-core-ethnicity",
+          extension: [
+            {
+              url: "ombCategory",
+              valueCoding: {
+                system: "urn:oid:2.16.840.1.113883.6.238",
+                code: "2135-2",
+                display: "Hispanic or Latino",
+              },
+            },
+            { url: "text", valueString: "Hispanic or Latino" },
+          ],
+        },
+      ]);
+    });
   });
 });


### PR DESCRIPTION
# PULL REQUEST

## Summary

Adds sex, race, and ethnicity as optional patient search parameters for patient discovery, end to end:

- **Search form**: a new "Demographics" section (between Date of Birth and Phone number) with Sex, Race, and Ethnicity dropdowns. Dropdowns show display names and submit coded values — FHIR administrative-gender codes for sex, OMB category codes from the CDC Race & Ethnicity code system (`urn:oid:2.16.840.1.113883.6.238`) for race/ethnicity. Values persist when revising a search and prefill from URL params (`gender`, `race`, `ethnicity`), with unrecognized codes rejected the same way bad state/zip params are.
- **Standard search + TEFCA fanout**: `buildPatientSearchQuery` appends `gender=` plus the US Core `race=`/`ethnicity=` search parameters. The fanout Task embeds the same query string, so both paths are covered. Race/ethnicity are US Core SearchParameters rather than base FHIR — servers without US Core support ignore them under lenient search handling, so these two filters are best-effort.
- **$match**: the candidate Patient resource now carries `gender` and US Core race/ethnicity extensions (ombCategory + text sub-extensions).
- **Public API**: GET `/api/query` accepts the three new query params; the HL7v2 POST branch maps PID.8 (sex), PID.10 (race), and PID.22 (ethnic group) with unrecognized codes dropped; the FHIR POST branch extracts `Patient.gender` and the OMB codes from US Core extensions. OpenAPI docs (yaml + json) updated with enums and examples.

The new fields are search refinements only — they never count toward the minimum patient identifier requirements (first/last/DOB + one of MRN/address/phone/email).

**UX note for design review**: the sex field is labeled "Sex" to match the existing results-view convention, and the dropdowns use the standard USWDS Select styling in a three-column row.

## Related Issue

N/A

## Additional Information

Test coverage added at each layer: form rendering/prefill/submission payload (`searchForm.test.tsx` + updated snapshots), HL7/FHIR parsing and code mapping (`parsers.test.ts`), and query-string + $match Parameters body assertions (`mtls-query-execution.test.ts`).

## Checklist

- [x] Descriptive Pull Request title
- [ ] Link to relevant issues
- [x] Provide necessary context for design reviewers
- [x] Ensure test coverage is above agreed upon threshold
- [x] Update documentation