### PR TITLE
feat: MDRO case investigation demo query and test patient results

### DIFF
--- a/e2e/query_execution.spec.ts
+++ b/e2e/query_execution.spec.ts
@@ -377,21 +377,25 @@ test.describe("alternate queries with the Query Connector", () => {
       page.getByRole("button", { name: "Encounters", expanded: true }),
     ).toBeVisible();
 
-    // Admission screening Observations: one positive row per headline organism
-    // plus the negative vancomycin-resistance gene result. These display texts
-    // are unique to a single Observation row across all result tables.
+    // Admission screening: one positive Observation per headline organism plus
+    // the negative vancomycin-resistance gene result. Each specimen's culture
+    // also gets its own DiagnosticReport carrying that culture's LOINC, so the
+    // culture display texts appear twice — once under Observations and once
+    // under Diagnostic Reports.
     await expect(
       page
         .getByRole("table")
         .getByRole("row")
         .filter({ hasText: "Candida auris" }),
-    ).toHaveCount(1);
+    ).toHaveCount(2);
     await expect(
       page
         .getByRole("table")
         .getByRole("row")
         .filter({ hasText: "Vancomycin resistant enterococcus" }),
-    ).toHaveCount(1);
+    ).toHaveCount(2);
+    // The molecular results are members of the nares report rather than reports
+    // in their own right, so they stay at one row each.
     await expect(
       page
         .getByRole("table")

--- a/e2e/query_execution.spec.ts
+++ b/e2e/query_execution.spec.ts
@@ -334,4 +334,89 @@ test.describe("alternate queries with the Query Connector", () => {
       page.getByRole("heading", { name: "Patient Record" }),
     ).toBeVisible();
   });
+
+  test("MDRO case investigation returns colonization and infection results", async ({
+    page,
+  }) => {
+    await page.getByRole("button", { name: "Fill fields" }).click();
+    // Select FHIR server from drop down
+    await page.getByRole("button", { name: "Advanced" }).click();
+    await page
+      .getByLabel("Healthcare Organization (HCO)")
+      .selectOption(DEFAULT_FHIR_SERVER);
+
+    await page.getByRole("button", { name: "Search for patient" }).click();
+    await expect(page.getByText("Loading")).toHaveCount(0, { timeout: 10000 });
+
+    await page.getByRole("button", { name: "Select patient" }).nth(0).click();
+    await expect(
+      page.getByRole("heading", { name: "Select a query" }),
+    ).toBeVisible();
+    await page.getByTestId("Select").selectOption("MDRO case investigation");
+    await page.getByRole("button", { name: "Submit" }).click();
+    await expect(page.getByText("Loading")).toHaveCount(0, { timeout: 10000 });
+
+    await expect(
+      page.getByRole("heading", { name: "Patient Record" }),
+    ).toBeVisible();
+    await expect(page.getByText(TEST_PATIENT_NAME)).toBeVisible();
+
+    // Every result-bearing section for this query renders as an expanded
+    // accordion: the admission screening Observations + DiagnosticReports and
+    // the June infection Conditions + LTCF Encounter.
+    await expect(
+      page.getByRole("button", { name: "Observations", expanded: true }),
+    ).toBeVisible();
+    await expect(
+      page.getByRole("button", { name: "Conditions", expanded: true }),
+    ).toBeVisible();
+    await expect(
+      page.getByRole("button", { name: "Diagnostic Reports", expanded: true }),
+    ).toBeVisible();
+    await expect(
+      page.getByRole("button", { name: "Encounters", expanded: true }),
+    ).toBeVisible();
+
+    // Admission screening Observations: one positive row per headline organism
+    // plus the negative vancomycin-resistance gene result. These display texts
+    // are unique to a single Observation row across all result tables.
+    await expect(
+      page
+        .getByRole("table")
+        .getByRole("row")
+        .filter({ hasText: "Candida auris" }),
+    ).toHaveCount(1);
+    await expect(
+      page
+        .getByRole("table")
+        .getByRole("row")
+        .filter({ hasText: "Vancomycin resistant enterococcus" }),
+    ).toHaveCount(1);
+    await expect(
+      page
+        .getByRole("table")
+        .getByRole("row")
+        .filter({ hasText: "Methicillin resistance mecA gene" }),
+    ).toHaveCount(1);
+    await expect(
+      page
+        .getByRole("table")
+        .getByRole("row")
+        .filter({ hasText: "Vancomycin resistance vanA gene" }),
+    ).toHaveCount(1);
+
+    // June infections: the MRSA sacral-wound Condition is a single row, while
+    // the carbapenem-resistant Enterobacteriaceae code drives both a Condition
+    // row and the LTCF Encounter's Visit Reason.
+    await expect(
+      page.getByRole("table").getByRole("row").filter({
+        hasText: "Skin infection caused by Methicillin resistant",
+      }),
+    ).toHaveCount(1);
+    await expect(
+      page.getByRole("table").getByRole("row").filter({
+        hasText: "Infection due to carbapenem resistant Enterobacteriaceae",
+      }),
+    ).toHaveCount(2);
+  });
 });

--- a/src/app/assets/dibbs_db_seed_query.json
+++ b/src/app/assets/dibbs_db_seed_query.json
@@ -5920,6 +5920,5922 @@
         }
       },
       "conditionsList": "{1}"
+    },
+    {
+      "author": "DIBBs",
+      "queryId": "b4c9d2e7-6a1f-4e83-9c25-7f0a3d8b1e46",
+      "dateCreated": "2024-12-10T15:45:30",
+      "dateLastModified": "2024-12-10T15:45:30",
+      "queryName": "MDRO case investigation",
+      "conditionsList": "{406602003,406575008,406604002,404681006,44591000087104,734350003,715174007,726492000,865929003}",
+      "queryData": {
+        "406602003": {
+          "2.16.840.1.113762.1.4.1146.1447_20230122": {
+            "valueSetId": "2.16.840.1.113762.1.4.1146.1447_20230122",
+            "valueSetVersion": "20230122",
+            "valueSetName": "MRSA (Disorders (SNOMED)",
+            "valueSetExternalId": "2.16.840.1.113762.1.4.1146.1447",
+            "author": "CSTE Steward",
+            "system": "http://snomed.info/sct",
+            "ersdConceptType": "conditions",
+            "dibbsConceptType": "conditions",
+            "includeValueSet": true,
+            "concepts": [
+              {
+                "code": "10625351000119105",
+                "display": "Bronchopneumonia caused by methicillin resistant Staphylococcus aureus (disorder)",
+                "include": true
+              },
+              {
+                "code": "1163107004",
+                "display": "Colitis caused by methicillin-resistant Staphylococcus aureus (disorder)",
+                "include": true
+              },
+              {
+                "code": "1176997000",
+                "display": "Skin infection caused by Methicillin resistant Staphylococcus aureus (disorder)",
+                "include": true
+              },
+              {
+                "code": "1193735000",
+                "display": "Inflammation of small intestine caused by methicillin-resistant Staphylococcus aureus (disorder)",
+                "include": true
+              },
+              {
+                "code": "1193736004",
+                "display": "Inflammation of intestine caused by methicillin-resistant Staphylococcus aureus (disorder)",
+                "include": true
+              },
+              {
+                "code": "124691000119101",
+                "display": "Pneumonia caused by methicillin resistant Staphylococcus aureus (disorder)",
+                "include": true
+              },
+              {
+                "code": "127321000119104",
+                "display": "Severe sepsis with acute organ dysfunction caused by methicillin resistant Staphylococcus aureus (disorder)",
+                "include": true
+              },
+              {
+                "code": "127421000119109",
+                "display": "Toxic shock syndrome caused by methicillin resistant Staphylococcus aureus infection (disorder)",
+                "include": true
+              },
+              {
+                "code": "128381000119104",
+                "display": "Septic shock co-occurrent with acute organ dysfunction caused by methicillin resistant Staphylococcus aureus (disorder)",
+                "include": true
+              },
+              {
+                "code": "13790001000004101",
+                "display": "Bacteremia caused by Methicillin resistant Staphylococcus aureus (finding)",
+                "include": true
+              },
+              {
+                "code": "266096002",
+                "display": "Methicillin resistant Staphylococcus aureus infection (disorder)",
+                "include": true
+              },
+              {
+                "code": "308155002",
+                "display": "Methicillin-resistant Staphylococcus aureus infection of postoperative wound (disorder)",
+                "include": true
+              },
+              {
+                "code": "423561003",
+                "display": "Community-acquired methicillin-resistant Staphylococcus aureus infection (disorder)",
+                "include": true
+              },
+              {
+                "code": "448812000",
+                "display": "Sepsis caused by methicillin resistant Staphylococcus aureus (disorder)",
+                "include": true
+              },
+              {
+                "code": "721749008",
+                "display": "Meningitis caused by methicillin resistant Staphylococcus aureus (disorder)",
+                "include": true
+              }
+            ]
+          },
+          "2.16.840.1.113762.1.4.1146.1449_20250218": {
+            "valueSetId": "2.16.840.1.113762.1.4.1146.1449_20250218",
+            "valueSetVersion": "20250218",
+            "valueSetName": "Staphylococcus aureus infection (Disorders) (SNOMED)",
+            "valueSetExternalId": "2.16.840.1.113762.1.4.1146.1449",
+            "author": "CSTE Steward",
+            "system": "http://snomed.info/sct",
+            "ersdConceptType": "conditions",
+            "dibbsConceptType": "conditions",
+            "includeValueSet": true,
+            "concepts": [
+              {
+                "code": "10625351000119105",
+                "display": "Bronchopneumonia caused by methicillin resistant Staphylococcus aureus (disorder)",
+                "include": true
+              },
+              {
+                "code": "10625391000119100",
+                "display": "Bronchopneumonia caused by methicillin susceptible Staphylococcus aureus (disorder)",
+                "include": true
+              },
+              {
+                "code": "10625631000119108",
+                "display": "Bronchopneumonia caused by Staphylococcus aureus (disorder)",
+                "include": true
+              },
+              {
+                "code": "1142039007",
+                "display": "Neonatal necrotizing fasciitis caused by Staphylococcus aureus (disorder)",
+                "include": true
+              },
+              {
+                "code": "1163107004",
+                "display": "Colitis caused by methicillin-resistant Staphylococcus aureus (disorder)",
+                "include": true
+              },
+              {
+                "code": "1172638007",
+                "display": "Inflammation of breast in neonate caused by Staphylococcus aureus (disorder)",
+                "include": true
+              },
+              {
+                "code": "1176997000",
+                "display": "Skin infection caused by Methicillin resistant Staphylococcus aureus (disorder)",
+                "include": true
+              },
+              {
+                "code": "1177033009",
+                "display": "Infection of skin caused by Panton-Valentine leukocidin producing Staphylococcus aureus (disorder)",
+                "include": true
+              },
+              {
+                "code": "1177075005",
+                "display": "Dacryoadenitis caused by Staphylococcus aureus (disorder)",
+                "include": true
+              },
+              {
+                "code": "1193735000",
+                "display": "Inflammation of small intestine caused by methicillin-resistant Staphylococcus aureus (disorder)",
+                "include": true
+              },
+              {
+                "code": "1193736004",
+                "display": "Inflammation of intestine caused by methicillin-resistant Staphylococcus aureus (disorder)",
+                "include": true
+              },
+              {
+                "code": "124691000119101",
+                "display": "Pneumonia caused by methicillin resistant Staphylococcus aureus (disorder)",
+                "include": true
+              },
+              {
+                "code": "1264225007",
+                "display": "Fetal infection caused by Staphylococcus aureus (disorder)",
+                "include": true
+              },
+              {
+                "code": "1264226008",
+                "display": "Early neonatal infection caused by Staphylococcus aureus (disorder)",
+                "include": true
+              },
+              {
+                "code": "127191000119104",
+                "display": "Septic shock co-occurrent with acute organ dysfunction caused by methicillin susceptible Staphylococcus aureus (disorder)",
+                "include": true
+              },
+              {
+                "code": "127331000119101",
+                "display": "Sepsis caused by methicillin susceptible Staphylococcus aureus (disorder)",
+                "include": true
+              },
+              {
+                "code": "127411000119102",
+                "display": "Toxic shock syndrome caused by methicillin susceptible Staphylococcus aureus (disorder)",
+                "include": true
+              },
+              {
+                "code": "127421000119109",
+                "display": "Toxic shock syndrome caused by methicillin resistant Staphylococcus aureus infection (disorder)",
+                "include": true
+              },
+              {
+                "code": "128381000119104",
+                "display": "Septic shock co-occurrent with acute organ dysfunction caused by methicillin resistant Staphylococcus aureus (disorder)",
+                "include": true
+              },
+              {
+                "code": "128711000119106",
+                "display": "Pneumonia caused by methicillin susceptible Staphylococcus aureus (disorder)",
+                "include": true
+              },
+              {
+                "code": "206378006",
+                "display": "Sepsis of newborn caused by Staphylococcus aureus (disorder)",
+                "include": true
+              },
+              {
+                "code": "22241000175107",
+                "display": "Sepsis due to infection by methicillin-sensitive Staphylococcus aureus (disorder)",
+                "include": true
+              },
+              {
+                "code": "230148000",
+                "display": "Staphylococcus aureus meningitis (disorder)",
+                "include": true
+              },
+              {
+                "code": "266096002",
+                "display": "Methicillin resistant Staphylococcus aureus infection (disorder)",
+                "include": true
+              },
+              {
+                "code": "282028001",
+                "display": "Multiple-resistant Staphylococcus aureus infection (disorder)",
+                "include": true
+              },
+              {
+                "code": "308155002",
+                "display": "Methicillin-resistant Staphylococcus aureus infection of postoperative wound (disorder)",
+                "include": true
+              },
+              {
+                "code": "359751003",
+                "display": "Impetigo caused by Staphylococcus aureus (disorder)",
+                "include": true
+              },
+              {
+                "code": "398384001",
+                "display": "Staphylococcus aureus food poisoning (disorder)",
+                "include": true
+              },
+              {
+                "code": "404678001",
+                "display": "Infection caused by glycopeptide resistant Staphylococcus aureus (disorder)",
+                "include": true
+              },
+              {
+                "code": "404681006",
+                "display": "Infection caused by vancomycin resistant Staphylococcus aureus (disorder)",
+                "include": true
+              },
+              {
+                "code": "406577000",
+                "display": "Infection caused by vancomycin intermediate/resistant Staphylococcus aureus (disorder)",
+                "include": true
+              },
+              {
+                "code": "406602003",
+                "display": "Infection caused by Staphylococcus aureus (disorder)",
+                "include": true
+              },
+              {
+                "code": "406603008",
+                "display": "Infection caused by glycopeptide intermediate Staphylococcus aureus (disorder)",
+                "include": true
+              },
+              {
+                "code": "406604002",
+                "display": "Infection caused by vancomycin intermediate Staphylococcus aureus (disorder)",
+                "include": true
+              },
+              {
+                "code": "406607009",
+                "display": "Infection caused by glycopeptide intermediate/resistant Staphylococcus aureus (disorder)",
+                "include": true
+              },
+              {
+                "code": "406615007",
+                "display": "Infection caused by vancomycin resistant Staphylococcus aureus, coagulase positive (disorder)",
+                "include": true
+              },
+              {
+                "code": "423561003",
+                "display": "Community-acquired methicillin-resistant Staphylococcus aureus infection (disorder)",
+                "include": true
+              },
+              {
+                "code": "426087004",
+                "display": "Right-sided Staphylococcus aureus endocarditis (disorder)",
+                "include": true
+              },
+              {
+                "code": "428763004",
+                "display": "Bacteremia caused by Staphylococcus aureus (finding)",
+                "include": true
+              },
+              {
+                "code": "428783003",
+                "display": "Osteomyelitis caused by Staphylococcus aureus (disorder)",
+                "include": true
+              },
+              {
+                "code": "441658007",
+                "display": "Pneumonia caused by Staphylococcus aureus (disorder)",
+                "include": true
+              },
+              {
+                "code": "442073005",
+                "display": "Infection caused by methicillin susceptible Staphylococcus aureus (disorder)",
+                "include": true
+              },
+              {
+                "code": "446413008",
+                "display": "Infection caused by Panton-Valentine leukocidin producing Staphylococcus aureus (disorder)",
+                "include": true
+              },
+              {
+                "code": "448417001",
+                "display": "Sepsis caused by Staphylococcus aureus (disorder)",
+                "include": true
+              },
+              {
+                "code": "448812000",
+                "display": "Sepsis caused by methicillin resistant Staphylococcus aureus (disorder)",
+                "include": true
+              },
+              {
+                "code": "721749008",
+                "display": "Meningitis caused by methicillin resistant Staphylococcus aureus (disorder)",
+                "include": true
+              },
+              {
+                "code": "721750008",
+                "display": "Fetus or newborn infection caused by Staphylococcus aureus (disorder)",
+                "include": true
+              },
+              {
+                "code": "762283002",
+                "display": "Ecthyma caused by Staphylococcus aureus (disorder)",
+                "include": true
+              },
+              {
+                "code": "762284008",
+                "display": "Cellulitis caused by Staphylococcus aureus (disorder)",
+                "include": true
+              },
+              {
+                "code": "763888005",
+                "display": "Necrotizing pneumonia caused by Panton-Valentine leukocidin producing Staphylococcus aureus (disorder)",
+                "include": true
+              }
+            ]
+          },
+          "2.16.840.1.113762.1.4.1146.1448_20220118": {
+            "valueSetId": "2.16.840.1.113762.1.4.1146.1448_20220118",
+            "valueSetVersion": "20220118",
+            "valueSetName": "MRSA (Disorders) (ICD10CM)",
+            "valueSetExternalId": "2.16.840.1.113762.1.4.1146.1448",
+            "author": "CSTE Steward",
+            "system": "http://hl7.org/fhir/sid/icd-10-cm",
+            "ersdConceptType": "conditions",
+            "dibbsConceptType": "conditions",
+            "includeValueSet": true,
+            "concepts": [
+              {
+                "code": "A41.02",
+                "display": "Sepsis due to Methicillin resistant Staphylococcus aureus",
+                "include": true
+              },
+              {
+                "code": "A49.02",
+                "display": "Methicillin resistant Staphylococcus aureus infection, unspecified site",
+                "include": true
+              },
+              {
+                "code": "B95.62",
+                "display": "Methicillin resistant Staphylococcus aureus infection as the cause of diseases classified elsewhere",
+                "include": true
+              },
+              {
+                "code": "J15.212",
+                "display": "Pneumonia due to Methicillin resistant Staphylococcus aureus",
+                "include": true
+              }
+            ]
+          },
+          "2.16.840.1.113762.1.4.1146.1450_20250218": {
+            "valueSetId": "2.16.840.1.113762.1.4.1146.1450_20250218",
+            "valueSetVersion": "20250218",
+            "valueSetName": "Staphylococcus aureus infection (Disorders) (ICD10CM)",
+            "valueSetExternalId": "2.16.840.1.113762.1.4.1146.1450",
+            "author": "CSTE Steward",
+            "system": "http://hl7.org/fhir/sid/icd-10-cm",
+            "ersdConceptType": "conditions",
+            "dibbsConceptType": "conditions",
+            "includeValueSet": true,
+            "concepts": [
+              {
+                "code": "A41.01",
+                "display": "Sepsis due to Methicillin susceptible Staphylococcus aureus",
+                "include": true
+              },
+              {
+                "code": "A41.02",
+                "display": "Sepsis due to Methicillin resistant Staphylococcus aureus",
+                "include": true
+              },
+              {
+                "code": "A49.01",
+                "display": "Methicillin susceptible Staphylococcus aureus infection, unspecified site",
+                "include": true
+              },
+              {
+                "code": "A49.02",
+                "display": "Methicillin resistant Staphylococcus aureus infection, unspecified site",
+                "include": true
+              },
+              {
+                "code": "B95.61",
+                "display": "Methicillin susceptible Staphylococcus aureus infection as the cause of diseases classified elsewhere",
+                "include": true
+              },
+              {
+                "code": "B95.62",
+                "display": "Methicillin resistant Staphylococcus aureus infection as the cause of diseases classified elsewhere",
+                "include": true
+              },
+              {
+                "code": "J15.211",
+                "display": "Pneumonia due to Methicillin susceptible Staphylococcus aureus",
+                "include": true
+              },
+              {
+                "code": "J15.212",
+                "display": "Pneumonia due to Methicillin resistant Staphylococcus aureus",
+                "include": true
+              },
+              {
+                "code": "P36.2",
+                "display": "Sepsis of newborn due to Staphylococcus aureus",
+                "include": true
+              }
+            ]
+          },
+          "2.16.840.1.113762.1.4.1146.1451_20220118": {
+            "valueSetId": "2.16.840.1.113762.1.4.1146.1451_20220118",
+            "valueSetVersion": "20220118",
+            "valueSetName": "MRSA (Organism or Substance in Lab Results)",
+            "valueSetExternalId": "2.16.840.1.113762.1.4.1146.1451",
+            "author": "CSTE Steward",
+            "system": "http://snomed.info/sct",
+            "ersdConceptType": "labs",
+            "dibbsConceptType": "labs",
+            "includeValueSet": true,
+            "concepts": [
+              {
+                "code": "115329001",
+                "display": "Methicillin resistant Staphylococcus aureus (organism)",
+                "include": true
+              },
+              {
+                "code": "312210001",
+                "display": "Methicillin resistant staphylococcus aureus positive (finding)",
+                "include": true
+              },
+              {
+                "code": "440608005",
+                "display": "Culture positive for methicillin resistant Staphylococcus aureus (finding)",
+                "include": true
+              },
+              {
+                "code": "448641000124101",
+                "display": "Methicillin resistant Staphylococcus aureus screen positive (finding)",
+                "include": true
+              },
+              {
+                "code": "716530009",
+                "display": "Non-multiple drug resistant methicillin resistant Staphylococcus aureus (organism)",
+                "include": true
+              },
+              {
+                "code": "716531008",
+                "display": "Multiple drug resistant methicillin resistant Staphylococcus aureus (organism)",
+                "include": true
+              },
+              {
+                "code": "720301008",
+                "display": "Deoxyribonucleic acid of methicillin resistant Staphylococcus aureus (substance)",
+                "include": true
+              }
+            ]
+          },
+          "2.16.840.1.113762.1.4.1146.1156_20250218": {
+            "valueSetId": "2.16.840.1.113762.1.4.1146.1156_20250218",
+            "valueSetVersion": "20250218",
+            "valueSetName": "Staphylococcus aureus (Organism or Substance in Lab Results)",
+            "valueSetExternalId": "2.16.840.1.113762.1.4.1146.1156",
+            "author": "CSTE Steward",
+            "system": "http://snomed.info/sct",
+            "ersdConceptType": "labs",
+            "dibbsConceptType": "labs",
+            "includeValueSet": true,
+            "concepts": [
+              {
+                "code": "1108501000112102",
+                "display": "Borderline oxacillin-resistant Staphylococcus aureus (organism)",
+                "include": true
+              },
+              {
+                "code": "113961008",
+                "display": "Staphylococcus aureus ss aureus (organism)",
+                "include": true
+              },
+              {
+                "code": "115329001",
+                "display": "Methicillin resistant Staphylococcus aureus (organism)",
+                "include": true
+              },
+              {
+                "code": "117269003",
+                "display": "Ribosomal ribonucleic acid of Staphylococcus aureus (substance)",
+                "include": true
+              },
+              {
+                "code": "3092008",
+                "display": "Staphylococcus aureus (organism)",
+                "include": true
+              },
+              {
+                "code": "404679009",
+                "display": "Glycopeptide resistant Staphylococcus aureus (organism)",
+                "include": true
+              },
+              {
+                "code": "404680007",
+                "display": "Vancomycin resistant Staphylococcus aureus (organism)",
+                "include": true
+              },
+              {
+                "code": "406576009",
+                "display": "Vancomycin intermediate/resistant Staphylococcus aureus (organism)",
+                "include": true
+              },
+              {
+                "code": "406605001",
+                "display": "Glycopeptide intermediate Staphylococcus aureus (organism)",
+                "include": true
+              },
+              {
+                "code": "406606000",
+                "display": "Glycopeptide intermediate/resistant Staphylococcus aureus (organism)",
+                "include": true
+              },
+              {
+                "code": "406962002",
+                "display": "Vancomycin intermediate Staphylococcus aureus (organism)",
+                "include": true
+              },
+              {
+                "code": "417943000",
+                "display": "Methicillin susceptible Staphylococcus aureus (organism)",
+                "include": true
+              },
+              {
+                "code": "418595000",
+                "display": "Staphylococcus aureus enterotoxin G (substance)",
+                "include": true
+              },
+              {
+                "code": "418864000",
+                "display": "Staphylococcus aureus enterotoxin C (substance)",
+                "include": true
+              },
+              {
+                "code": "418911003",
+                "display": "Staphylococcus aureus enterotoxin (substance)",
+                "include": true
+              },
+              {
+                "code": "418950004",
+                "display": "Staphylococcus aureus enterotoxin A (substance)",
+                "include": true
+              },
+              {
+                "code": "419175007",
+                "display": "Staphylococcus aureus enterotoxin D (substance)",
+                "include": true
+              },
+              {
+                "code": "419488004",
+                "display": "Staphylococcus aureus enterotoxin B (substance)",
+                "include": true
+              },
+              {
+                "code": "444684000",
+                "display": "Staphylococcus aureus enterotoxin E (substance)",
+                "include": true
+              },
+              {
+                "code": "44651000087108",
+                "display": "Staphylococcus aureus complex (organism)",
+                "include": true
+              },
+              {
+                "code": "50269000",
+                "display": "Staphylococcus aureus ss. anaerobius (organism)",
+                "include": true
+              },
+              {
+                "code": "698216001",
+                "display": "Vancomycin susceptible Staphylococcus aureus (organism)",
+                "include": true
+              },
+              {
+                "code": "708429000",
+                "display": "Deoxyribonucleic acid of Staphylococcus aureus (substance)",
+                "include": true
+              },
+              {
+                "code": "710564002",
+                "display": "Panton-Valentine leukocidin producing Staphylococcus aureus (organism)",
+                "include": true
+              },
+              {
+                "code": "711317006",
+                "display": "Staphylococcus aureus toxic shock syndrome toxin 1 (substance)",
+                "include": true
+              },
+              {
+                "code": "716530009",
+                "display": "Non-multiple drug resistant methicillin resistant Staphylococcus aureus (organism)",
+                "include": true
+              },
+              {
+                "code": "716531008",
+                "display": "Multiple drug resistant methicillin resistant Staphylococcus aureus (organism)",
+                "include": true
+              },
+              {
+                "code": "720301008",
+                "display": "Deoxyribonucleic acid of methicillin resistant Staphylococcus aureus (substance)",
+                "include": true
+              },
+              {
+                "code": "782499002",
+                "display": "Staphylococcus aureus toxin (substance)",
+                "include": true
+              }
+            ]
+          },
+          "2.16.840.1.113762.1.4.1146.1462_20250218": {
+            "valueSetId": "2.16.840.1.113762.1.4.1146.1462_20250218",
+            "valueSetVersion": "20250218",
+            "valueSetName": "Staphylococcus aureus (Tests for Staph aureus Nucleic Acid in Blood)",
+            "valueSetExternalId": "2.16.840.1.113762.1.4.1146.1462",
+            "author": "CSTE Steward",
+            "system": "http://loinc.org",
+            "ersdConceptType": "labs",
+            "dibbsConceptType": "labs",
+            "includeValueSet": true,
+            "concepts": [
+              {
+                "code": "105796-7",
+                "display": "Staphylococcus aureus DNA [Cycle Threshold #] in Positive blood culture by NAA with probe detection",
+                "include": true
+              },
+              {
+                "code": "73558-9",
+                "display": "Staphylococcus aureus and Staphylococcus sp.coagulase negative rRNA [Identifier] by FISH in Positive blood culture",
+                "include": true
+              },
+              {
+                "code": "85765-6",
+                "display": "Staphylococcus aureus DNA [Presence] by NAA with non-probe detection in Positive blood culture",
+                "include": true
+              },
+              {
+                "code": "88269-6",
+                "display": "Staphylococcus aureus gyrB gene [Presence] by Probe in Positive blood culture",
+                "include": true
+              },
+              {
+                "code": "92777-2",
+                "display": "Staphylococcus aureus DNA [Presence] by NAA with probe detection in Positive blood culture",
+                "include": true
+              }
+            ]
+          },
+          "2.16.840.1.113762.1.4.1146.1138_20250218": {
+            "valueSetId": "2.16.840.1.113762.1.4.1146.1138_20250218",
+            "valueSetVersion": "20250218",
+            "valueSetName": "Staphylococcus Aureus (Tests\u202fby Culture and Identification Method)",
+            "valueSetExternalId": "2.16.840.1.113762.1.4.1146.1138",
+            "author": "CSTE Steward",
+            "system": "http://loinc.org",
+            "ersdConceptType": "labs",
+            "dibbsConceptType": "labs",
+            "includeValueSet": true,
+            "concepts": [
+              {
+                "code": "100897-8",
+                "display": "Staphylococcus aureus [Presence] in Specimen by Organism specific culture",
+                "include": true
+              },
+              {
+                "code": "103141-8",
+                "display": "Staphylococcus aureus MLVA complex [Type] in Isolate or Specimen by Molecular genetics method",
+                "include": true
+              },
+              {
+                "code": "105796-7",
+                "display": "Staphylococcus aureus DNA [Cycle Threshold #] in Positive blood culture by NAA with probe detection",
+                "include": true
+              },
+              {
+                "code": "106044-1",
+                "display": "Methicillin resistant Staphylococcus aureus [Presence] in Skin by Organism specific culture",
+                "include": true
+              },
+              {
+                "code": "106046-6",
+                "display": "Methicillin resistant Staphylococcus aureus [Presence] in Axilla by Organism specific culture",
+                "include": true
+              },
+              {
+                "code": "13317-3",
+                "display": "Methicillin resistant Staphylococcus aureus [Presence] in Specimen by Organism specific culture",
+                "include": true
+              },
+              {
+                "code": "52969-3",
+                "display": "Methicillin resistant Staphylococcus aureus [Presence] in Nose by Organism specific culture",
+                "include": true
+              },
+              {
+                "code": "53572-4",
+                "display": "Methicillin resistant Staphylococcus aureus [Presence] in Genital specimen by Organism specific culture",
+                "include": true
+              },
+              {
+                "code": "73558-9",
+                "display": "Staphylococcus aureus and Staphylococcus sp.coagulase negative rRNA [Identifier] by FISH in Positive blood culture",
+                "include": true
+              },
+              {
+                "code": "76081-9",
+                "display": "Methicillin resistant Staphylococcus aureus [Presence] in Pharynx by Organism specific culture",
+                "include": true
+              },
+              {
+                "code": "85042-0",
+                "display": "Staphylococcus aureus glycopeptide resistant identified [Type] in Isolate",
+                "include": true
+              },
+              {
+                "code": "85045-3",
+                "display": "Staphylococcus aureus glycopeptide resistant based on vancomycin and teicoplanin IC [Identifier] by ARD gradient strip",
+                "include": true
+              },
+              {
+                "code": "85765-6",
+                "display": "Staphylococcus aureus DNA [Presence] by NAA with non-probe detection in Positive blood culture",
+                "include": true
+              },
+              {
+                "code": "88269-6",
+                "display": "Staphylococcus aureus gyrB gene [Presence] by Probe in Positive blood culture",
+                "include": true
+              },
+              {
+                "code": "92777-2",
+                "display": "Staphylococcus aureus DNA [Presence] by NAA with probe detection in Positive blood culture",
+                "include": true
+              },
+              {
+                "code": "97325-5",
+                "display": "Staphylococcus aureus VNTR pattern [Type] in Isolate or Specimen by Molecular genetics method",
+                "include": true
+              }
+            ]
+          },
+          "2.16.840.1.113762.1.4.1146.1454_20250218": {
+            "valueSetId": "2.16.840.1.113762.1.4.1146.1454_20250218",
+            "valueSetVersion": "20250218",
+            "valueSetName": "Staphylococcus aureus (Tests for Staph aureus Nucleic Acid)",
+            "valueSetExternalId": "2.16.840.1.113762.1.4.1146.1454",
+            "author": "CSTE Steward",
+            "system": "http://loinc.org",
+            "ersdConceptType": "labs",
+            "dibbsConceptType": "labs",
+            "includeValueSet": true,
+            "concepts": [
+              {
+                "code": "103141-8",
+                "display": "Staphylococcus aureus MLVA complex [Type] in Isolate or Specimen by Molecular genetics method",
+                "include": true
+              },
+              {
+                "code": "103163-2",
+                "display": "Staphylococcus aureus enterotoxin A + Staphylococcus aureus enterotoxin B DNA [Presence] in Wound by NAA with probe detection",
+                "include": true
+              },
+              {
+                "code": "103198-8",
+                "display": "Staphylococcus aureus DNA [Presence] in Respiratory system specimen by NAA with probe detection",
+                "include": true
+              },
+              {
+                "code": "103601-1",
+                "display": "Staphylococcus aureus MLVA type in Isolate or Specimen by Molecular genetics method",
+                "include": true
+              },
+              {
+                "code": "104757-0",
+                "display": "Staphylococcus aureus DNA [Presence] in Specimen by Molecular genetics method",
+                "include": true
+              },
+              {
+                "code": "35492-8",
+                "display": "Methicillin resistant Staphylococcus aureus (MRSA) DNA [Presence] in Specimen by NAA with probe detection",
+                "include": true
+              },
+              {
+                "code": "44878-7",
+                "display": "Staphylococcus aureus enterotoxin A sea gene [Presence] in Specimen by NAA with probe detection",
+                "include": true
+              },
+              {
+                "code": "44879-5",
+                "display": "Staphylococcus aureus enterotoxin E see gene [Presence] in Specimen by NAA with probe detection",
+                "include": true
+              },
+              {
+                "code": "44880-3",
+                "display": "Staphylococcus aureus enterotoxin B seb gene [Presence] in Specimen by NAA with probe detection",
+                "include": true
+              },
+              {
+                "code": "44881-1",
+                "display": "Staphylococcus aureus toxic shock syndrome toxin gene [Presence] in Specimen by NAA with probe detection",
+                "include": true
+              },
+              {
+                "code": "48816-3",
+                "display": "Staphylococcus aureus Panton-Valentine leukocidin gene [Presence] in Isolate or Specimen by Molecular genetics method",
+                "include": true
+              },
+              {
+                "code": "5033-6",
+                "display": "Staphylococcus aureus rRNA [Presence] in Specimen by Probe",
+                "include": true
+              },
+              {
+                "code": "61404-0",
+                "display": "Staphylococcus aureus DNA [Presence] in Specimen by NAA with probe detection",
+                "include": true
+              },
+              {
+                "code": "71786-8",
+                "display": "Staphylococcus aureus exfoliative toxin A eta gene [Presence] in Specimen by NAA with probe detection",
+                "include": true
+              },
+              {
+                "code": "71787-6",
+                "display": "Staphylococcus aureus exfoliative toxin B etb gene [Presence] in Specimen by NAA with probe detection",
+                "include": true
+              },
+              {
+                "code": "72822-0",
+                "display": "Staphylococcus aureus enterotoxin D sed gene [Presence] in Specimen by NAA with probe detection",
+                "include": true
+              },
+              {
+                "code": "72823-8",
+                "display": "Staphylococcus aureus enterotoxin C sec gene [Presence] in Specimen by NAA with probe detection",
+                "include": true
+              },
+              {
+                "code": "75755-9",
+                "display": "Methicillin susceptible Staphylococcus aureus DNA [Presence] in Specimen by NAA with probe detection",
+                "include": true
+              },
+              {
+                "code": "76577-6",
+                "display": "Staphylococcus aureus sau3AI gene [Presence] in Swab specimen by NAA with probe detection",
+                "include": true
+              },
+              {
+                "code": "76592-5",
+                "display": "Staphylococcus aureus sau3AI gene [#/mass] in XXX.tissue by NAA with probe detection",
+                "include": true
+              },
+              {
+                "code": "76605-5",
+                "display": "Staphylococcus aureus sau3AI gene [#/volume] in XXX.body fluid by NAA with probe detection",
+                "include": true
+              },
+              {
+                "code": "79447-9",
+                "display": "Staphylococcus aureus capsular polysaccharide enzyme cpe gene [Presence] in Nose by NAA with probe detection",
+                "include": true
+              },
+              {
+                "code": "90001-9",
+                "display": "Methicillin resistant Staphylococcus aureus (MRSA) DNA [Presence] in Nose by NAA with probe detection",
+                "include": true
+              },
+              {
+                "code": "92701-2",
+                "display": "Staphylococcus aureus DNA [Presence] in Nose by NAA with probe detection",
+                "include": true
+              },
+              {
+                "code": "92952-1",
+                "display": "Staphylococcus aureus DNA [NCncRange] in Sputum by NAA with non-probe detection",
+                "include": true
+              },
+              {
+                "code": "92953-9",
+                "display": "Staphylococcus aureus DNA [NCncRange] in Bronchoalveolar lavage by NAA with non-probe detection",
+                "include": true
+              },
+              {
+                "code": "94369-6",
+                "display": "Staphylococcus aureus DNA [Presence] in Lower respiratory specimen by NAA with probe detection",
+                "include": true
+              },
+              {
+                "code": "94512-1",
+                "display": "Staphylococcus aureus and Methicillin Resistant Staphylococcus aureus identified in Isolate or Specimen by Molecular genetics method",
+                "include": true
+              },
+              {
+                "code": "96328-0",
+                "display": "Staphylococcus aureus DNA [NCncRange] in Lower respiratory specimen by NAA with non-probe detection",
+                "include": true
+              },
+              {
+                "code": "97325-5",
+                "display": "Staphylococcus aureus VNTR pattern [Type] in Isolate or Specimen by Molecular genetics method",
+                "include": true
+              },
+              {
+                "code": "97634-0",
+                "display": "Staphylococcus aureus DNA [Presence] in Synovial fluid by NAA with non-probe detection",
+                "include": true
+              },
+              {
+                "code": "99029-1",
+                "display": "Staphylococcus aureus DNA [Presence] in Urine by NAA with probe detection",
+                "include": true
+              }
+            ]
+          },
+          "2.16.840.1.113762.1.4.1146.1453_20230122": {
+            "valueSetId": "2.16.840.1.113762.1.4.1146.1453_20230122",
+            "valueSetVersion": "20230122",
+            "valueSetName": "MRSA (Tests for Methicillin Resistance Gene)",
+            "valueSetExternalId": "2.16.840.1.113762.1.4.1146.1453",
+            "author": "CSTE Steward",
+            "system": "http://loinc.org",
+            "ersdConceptType": "labs",
+            "dibbsConceptType": "labs",
+            "includeValueSet": true,
+            "concepts": [
+              {
+                "code": "48813-0",
+                "display": "Methicillin resistance mecA gene [Presence] by Molecular method",
+                "include": true
+              },
+              {
+                "code": "72887-3",
+                "display": "Staphylococcus aureus methicillin resistance SCCmec [Presence] in Nose by NAA with probe detection",
+                "include": true
+              },
+              {
+                "code": "77666-6",
+                "display": "Methicillin resistance mecA mRNA [Presence] by FISH in Positive blood culture",
+                "include": true
+              },
+              {
+                "code": "77682-3",
+                "display": "Staphylococcus aureus methicillin resistance SCCmec+orfX junction [Presence] in Nose by NAA with probe detection",
+                "include": true
+              },
+              {
+                "code": "85786-2",
+                "display": "Methicillin resistance mecA gene [Presence] by NAA with non-probe detection in Positive blood culture",
+                "include": true
+              },
+              {
+                "code": "86620-2",
+                "display": "Methicillin resistance mecA+mecC genes [Presence] in Nose by NAA with probe detection",
+                "include": true
+              },
+              {
+                "code": "86621-0",
+                "display": "Methicillin resistance mecC gene [Presence] by Molecular method",
+                "include": true
+              },
+              {
+                "code": "88251-4",
+                "display": "Methicillin resistance mecA gene [Presence] by Probe in Positive blood culture",
+                "include": true
+              },
+              {
+                "code": "92968-7",
+                "display": "Methicillin resistance mecA+mecC genes [Presence] in Isolate or Specimen by Molecular genetics method",
+                "include": true
+              },
+              {
+                "code": "94424-9",
+                "display": "Staphylococcus aureus methicillin resistance SCCmec+orfX junction [Presence] by Molecular method",
+                "include": true
+              },
+              {
+                "code": "96309-0",
+                "display": "Methicillin resistance mecA+mecC genes+SCCmec+OrfX junction [Presence] by Molecular method",
+                "include": true
+              }
+            ]
+          },
+          "2.16.840.1.113762.1.4.1146.1455_20220118": {
+            "valueSetId": "2.16.840.1.113762.1.4.1146.1455_20220118",
+            "valueSetVersion": "20220118",
+            "valueSetName": "Staphylococcus aureus (Tests for Staph aureus Nucleic Acid in Specimen from Normally Sterile Site)",
+            "valueSetExternalId": "2.16.840.1.113762.1.4.1146.1455",
+            "author": "CSTE Steward",
+            "system": "http://loinc.org",
+            "ersdConceptType": "labs",
+            "dibbsConceptType": "labs",
+            "includeValueSet": true,
+            "concepts": [
+              {
+                "code": "76592-5",
+                "display": "Staphylococcus aureus sau3AI gene [#/mass] in XXX.tissue by NAA with probe detection",
+                "include": true
+              },
+              {
+                "code": "97634-0",
+                "display": "Staphylococcus aureus DNA [Presence] in Synovial fluid by NAA with non-probe detection",
+                "include": true
+              }
+            ]
+          },
+          "2.16.840.1.113762.1.4.1146.1452_20250218": {
+            "valueSetId": "2.16.840.1.113762.1.4.1146.1452_20250218",
+            "valueSetVersion": "20250218",
+            "valueSetName": "MRSA (Tests by Culture and Identification Method)",
+            "valueSetExternalId": "2.16.840.1.113762.1.4.1146.1452",
+            "author": "CSTE Steward",
+            "system": "http://loinc.org",
+            "ersdConceptType": "labs",
+            "dibbsConceptType": "labs",
+            "includeValueSet": true,
+            "concepts": [
+              {
+                "code": "106044-1",
+                "display": "Methicillin resistant Staphylococcus aureus [Presence] in Skin by Organism specific culture",
+                "include": true
+              },
+              {
+                "code": "106046-6",
+                "display": "Methicillin resistant Staphylococcus aureus [Presence] in Axilla by Organism specific culture",
+                "include": true
+              },
+              {
+                "code": "13317-3",
+                "display": "Methicillin resistant Staphylococcus aureus [Presence] in Specimen by Organism specific culture",
+                "include": true
+              },
+              {
+                "code": "52969-3",
+                "display": "Methicillin resistant Staphylococcus aureus [Presence] in Nose by Organism specific culture",
+                "include": true
+              },
+              {
+                "code": "53572-4",
+                "display": "Methicillin resistant Staphylococcus aureus [Presence] in Genital specimen by Organism specific culture",
+                "include": true
+              },
+              {
+                "code": "76081-9",
+                "display": "Methicillin resistant Staphylococcus aureus [Presence] in Pharynx by Organism specific culture",
+                "include": true
+              },
+              {
+                "code": "92049-6",
+                "display": "Staphylococcus species methicillin resistant identified in Isolate or Specimen by Molecular genetics method",
+                "include": true
+              },
+              {
+                "code": "94512-1",
+                "display": "Staphylococcus aureus and Methicillin Resistant Staphylococcus aureus identified in Isolate or Specimen by Molecular genetics method",
+                "include": true
+              }
+            ]
+          }
+        },
+        "406575008": {
+          "2.16.840.1.113762.1.4.1146.1463_20240123": {
+            "valueSetId": "2.16.840.1.113762.1.4.1146.1463_20240123",
+            "valueSetVersion": "20240123",
+            "valueSetName": "VRE (Disorders) (SNOMED)",
+            "valueSetExternalId": "2.16.840.1.113762.1.4.1146.1463",
+            "author": "CSTE Steward",
+            "system": "http://snomed.info/sct",
+            "ersdConceptType": "conditions",
+            "dibbsConceptType": "conditions",
+            "includeValueSet": true,
+            "concepts": [
+              {
+                "code": "1149093006",
+                "display": "Pneumonia caused by vancomycin resistant Enterococcus (disorder)",
+                "include": true
+              },
+              {
+                "code": "1153534006",
+                "display": "Sepsis caused by vancomycin resistant Enterococcus (disorder)",
+                "include": true
+              },
+              {
+                "code": "406575008",
+                "display": "Infection caused by vancomycin resistant enterococcus (disorder)",
+                "include": true
+              }
+            ]
+          },
+          "2.16.840.1.113762.1.4.1146.1469_20250218": {
+            "valueSetId": "2.16.840.1.113762.1.4.1146.1469_20250218",
+            "valueSetVersion": "20250218",
+            "valueSetName": "Enterococcus faecium or E. faecalis (Organism or Substance in Lab Results)",
+            "valueSetExternalId": "2.16.840.1.113762.1.4.1146.1469",
+            "author": "CSTE Steward",
+            "system": "http://snomed.info/sct",
+            "ersdConceptType": "labs",
+            "dibbsConceptType": "labs",
+            "includeValueSet": true,
+            "concepts": [
+              {
+                "code": "1187454003",
+                "display": "Enterococcus faecalis (substance)",
+                "include": true
+              },
+              {
+                "code": "416397000",
+                "display": "Enterococcus faecalis variant (organism)",
+                "include": true
+              },
+              {
+                "code": "661000112100",
+                "display": "Vancomycin resistant Enterococcus faecalis genotype vanB (organism)",
+                "include": true
+              },
+              {
+                "code": "707768008",
+                "display": "Enterococcus faecium genotype vanA (organism)",
+                "include": true
+              },
+              {
+                "code": "707769000",
+                "display": "Enterococcus faecium genotype vanB (organism)",
+                "include": true
+              },
+              {
+                "code": "708244002",
+                "display": "Deoxyribonucleic acid of Enterococcus faecalis (substance)",
+                "include": true
+              },
+              {
+                "code": "708245001",
+                "display": "Deoxyribonucleic acid of Enterococcus faecium (substance)",
+                "include": true
+              },
+              {
+                "code": "712663006",
+                "display": "Vancomycin resistant Enterococcus faecalis (organism)",
+                "include": true
+              },
+              {
+                "code": "712664000",
+                "display": "Vancomycin intermediate Enterococcus faecalis (organism)",
+                "include": true
+              },
+              {
+                "code": "712665004",
+                "display": "Vancomycin resistant Enterococcus faecium (organism)",
+                "include": true
+              },
+              {
+                "code": "712666003",
+                "display": "Vancomycin intermediate Enterococcus faecium (organism)",
+                "include": true
+              },
+              {
+                "code": "78065002",
+                "display": "Enterococcus faecalis (organism)",
+                "include": true
+              },
+              {
+                "code": "782956001",
+                "display": "Vancomycin susceptible Enterococcus faecium (organism)",
+                "include": true
+              },
+              {
+                "code": "782958000",
+                "display": "Vancomycin susceptible Enterococcus faecalis (organism)",
+                "include": true
+              },
+              {
+                "code": "90272000",
+                "display": "Enterococcus faecium (organism)",
+                "include": true
+              },
+              {
+                "code": "928051771000087103",
+                "display": "Enterococcus faecalis type 2 (organism)",
+                "include": true
+              }
+            ]
+          },
+          "2.16.840.1.113762.1.4.1146.1468_20240123": {
+            "valueSetId": "2.16.840.1.113762.1.4.1146.1468_20240123",
+            "valueSetVersion": "20240123",
+            "valueSetName": "Enterococcus gallinarum or E. casseliflavus/E. flavescens (Organism or Substance in Lab Results)",
+            "valueSetExternalId": "2.16.840.1.113762.1.4.1146.1468",
+            "author": "CSTE Steward",
+            "system": "http://snomed.info/sct",
+            "ersdConceptType": "labs",
+            "dibbsConceptType": "labs",
+            "includeValueSet": true,
+            "concepts": [
+              {
+                "code": "1117501000112104",
+                "display": "Vancomycin resistant Enterococcus casseliflavus (organism)",
+                "include": true
+              },
+              {
+                "code": "30949009",
+                "display": "Enterococcus casseliflavus (organism)",
+                "include": true
+              },
+              {
+                "code": "53233007",
+                "display": "Enterococcus gallinarum (organism)",
+                "include": true
+              },
+              {
+                "code": "703032005",
+                "display": "Enterococcus casseliflavus or Enterococcus gallinarum (finding)",
+                "include": true
+              }
+            ]
+          },
+          "2.16.840.1.113762.1.4.1146.1464_20250218": {
+            "valueSetId": "2.16.840.1.113762.1.4.1146.1464_20250218",
+            "valueSetVersion": "20250218",
+            "valueSetName": "VRE (Organism or Substance in Lab Results)",
+            "valueSetExternalId": "2.16.840.1.113762.1.4.1146.1464",
+            "author": "CSTE Steward",
+            "system": "http://snomed.info/sct",
+            "ersdConceptType": "labs",
+            "dibbsConceptType": "labs",
+            "includeValueSet": true,
+            "concepts": [
+              {
+                "code": "1117501000112104",
+                "display": "Vancomycin resistant Enterococcus casseliflavus (organism)",
+                "include": true
+              },
+              {
+                "code": "113727004",
+                "display": "Vancomycin resistant Enterococcus (organism)",
+                "include": true
+              },
+              {
+                "code": "661000112100",
+                "display": "Vancomycin resistant Enterococcus faecalis genotype vanB (organism)",
+                "include": true
+              },
+              {
+                "code": "707767003",
+                "display": "Vancomycin resistant vanB2 and vanB3 Enterococcus (organism)",
+                "include": true
+              },
+              {
+                "code": "707768008",
+                "display": "Enterococcus faecium genotype vanA (organism)",
+                "include": true
+              },
+              {
+                "code": "707769000",
+                "display": "Enterococcus faecium genotype vanB (organism)",
+                "include": true
+              },
+              {
+                "code": "710333000",
+                "display": "Vancomycin resistant enterococcus vanA strain (organism)",
+                "include": true
+              },
+              {
+                "code": "710334006",
+                "display": "Vancomycin resistant enterococcus vanB strain (organism)",
+                "include": true
+              },
+              {
+                "code": "712663006",
+                "display": "Vancomycin resistant Enterococcus faecalis (organism)",
+                "include": true
+              },
+              {
+                "code": "712665004",
+                "display": "Vancomycin resistant Enterococcus faecium (organism)",
+                "include": true
+              },
+              {
+                "code": "720234008",
+                "display": "Deoxyribonucleic acid of vancomycin resistant Enterococcus (substance)",
+                "include": true
+              },
+              {
+                "code": "782959008",
+                "display": "Vancomycin resistant Enterococcus raffinosus (organism)",
+                "include": true
+              },
+              {
+                "code": "838511009",
+                "display": "Linezolid and vancomycin resistant Enterococcus (organism)",
+                "include": true
+              }
+            ]
+          },
+          "2.16.840.1.113762.1.4.1146.1465_20230122": {
+            "valueSetId": "2.16.840.1.113762.1.4.1146.1465_20230122",
+            "valueSetVersion": "20230122",
+            "valueSetName": "VRE (Tests by Culture and Identification Method)",
+            "valueSetExternalId": "2.16.840.1.113762.1.4.1146.1465",
+            "author": "CSTE Steward",
+            "system": "http://loinc.org",
+            "ersdConceptType": "labs",
+            "dibbsConceptType": "labs",
+            "includeValueSet": true,
+            "concepts": [
+              {
+                "code": "100907-5",
+                "display": "Vancomycin resistant enterococcus [Identifier] in Specimen by Organism specific culture",
+                "include": true
+              },
+              {
+                "code": "13316-5",
+                "display": "Vancomycin resistant enterococcus [Presence] in Specimen by Organism specific culture",
+                "include": true
+              },
+              {
+                "code": "59150-3",
+                "display": "Vancomycin resistant enterococcus [Presence] in Anal by Organism specific culture",
+                "include": true
+              },
+              {
+                "code": "59151-1",
+                "display": "Vancomycin resistant enterococcus [Presence] in Urine by Organism specific culture",
+                "include": true
+              }
+            ]
+          },
+          "2.16.840.1.113762.1.4.1146.1467_20220118": {
+            "valueSetId": "2.16.840.1.113762.1.4.1146.1467_20220118",
+            "valueSetVersion": "20220118",
+            "valueSetName": "Enterococcus faecium or E. faecalis (Tests by Culture and Identification Method)",
+            "valueSetExternalId": "2.16.840.1.113762.1.4.1146.1467",
+            "author": "CSTE Steward",
+            "system": "http://loinc.org",
+            "ersdConceptType": "labs",
+            "dibbsConceptType": "labs",
+            "includeValueSet": true,
+            "concepts": [
+              {
+                "code": "73963-1",
+                "display": "Enterococcus faecalis and other enterococcus sp rRNA [Identifier] by FISH in Positive blood culture",
+                "include": true
+              },
+              {
+                "code": "88256-3",
+                "display": "Enterococcus faecalis hsp60 gene [Presence] by Probe in Positive blood culture",
+                "include": true
+              },
+              {
+                "code": "88257-1",
+                "display": "Enterococcus faecium hsp60 gene [Presence] by Probe in Positive blood culture",
+                "include": true
+              },
+              {
+                "code": "92782-2",
+                "display": "Enterococcus faecium DNA [Presence] by NAA with probe detection in Positive blood culture",
+                "include": true
+              },
+              {
+                "code": "92783-0",
+                "display": "Enterococcus faecalis DNA [Presence] by NAA with probe detection in Positive blood culture",
+                "include": true
+              },
+              {
+                "code": "96304-1",
+                "display": "Enterococcus faecalis DNA [Presence] by NAA with non-probe detection in Positive blood culture",
+                "include": true
+              },
+              {
+                "code": "96305-8",
+                "display": "Enterococcus faecium DNA [Presence] by NAA with non-probe detection in Positive blood culture",
+                "include": true
+              }
+            ]
+          },
+          "2.16.840.1.113762.1.4.1146.1466_20240123": {
+            "valueSetId": "2.16.840.1.113762.1.4.1146.1466_20240123",
+            "valueSetVersion": "20240123",
+            "valueSetName": "Enterococcus species (Tests\u00a0by Culture and Identification Method)",
+            "valueSetExternalId": "2.16.840.1.113762.1.4.1146.1466",
+            "author": "CSTE Steward",
+            "system": "http://loinc.org",
+            "ersdConceptType": "labs",
+            "dibbsConceptType": "labs",
+            "includeValueSet": true,
+            "concepts": [
+              {
+                "code": "100907-5",
+                "display": "Vancomycin resistant enterococcus [Identifier] in Specimen by Organism specific culture",
+                "include": true
+              },
+              {
+                "code": "13316-5",
+                "display": "Vancomycin resistant enterococcus [Presence] in Specimen by Organism specific culture",
+                "include": true
+              },
+              {
+                "code": "59150-3",
+                "display": "Vancomycin resistant enterococcus [Presence] in Anal by Organism specific culture",
+                "include": true
+              },
+              {
+                "code": "59151-1",
+                "display": "Vancomycin resistant enterococcus [Presence] in Urine by Organism specific culture",
+                "include": true
+              },
+              {
+                "code": "73963-1",
+                "display": "Enterococcus faecalis and other enterococcus sp rRNA [Identifier] by FISH in Positive blood culture",
+                "include": true
+              },
+              {
+                "code": "85775-5",
+                "display": "Enterococcus sp DNA [Presence] by NAA with non-probe detection in Positive blood culture",
+                "include": true
+              },
+              {
+                "code": "88256-3",
+                "display": "Enterococcus faecalis hsp60 gene [Presence] by Probe in Positive blood culture",
+                "include": true
+              },
+              {
+                "code": "88257-1",
+                "display": "Enterococcus faecium hsp60 gene [Presence] by Probe in Positive blood culture",
+                "include": true
+              },
+              {
+                "code": "92782-2",
+                "display": "Enterococcus faecium DNA [Presence] by NAA with probe detection in Positive blood culture",
+                "include": true
+              },
+              {
+                "code": "92783-0",
+                "display": "Enterococcus faecalis DNA [Presence] by NAA with probe detection in Positive blood culture",
+                "include": true
+              },
+              {
+                "code": "92784-8",
+                "display": "Enterococcus sp DNA [Presence] by NAA with probe detection in Positive blood culture",
+                "include": true
+              },
+              {
+                "code": "96304-1",
+                "display": "Enterococcus faecalis DNA [Presence] by NAA with non-probe detection in Positive blood culture",
+                "include": true
+              },
+              {
+                "code": "96305-8",
+                "display": "Enterococcus faecium DNA [Presence] by NAA with non-probe detection in Positive blood culture",
+                "include": true
+              }
+            ]
+          },
+          "2.16.840.1.113762.1.4.1146.1139_20250218": {
+            "valueSetId": "2.16.840.1.113762.1.4.1146.1139_20250218",
+            "valueSetVersion": "20250218",
+            "valueSetName": "VISA/VRSA\u00a0(Tests for\u00a0Vancomycin Resistance Gene)",
+            "valueSetExternalId": "2.16.840.1.113762.1.4.1146.1139",
+            "author": "CSTE Steward",
+            "system": "http://loinc.org",
+            "ersdConceptType": "labs",
+            "dibbsConceptType": "labs",
+            "includeValueSet": true,
+            "concepts": [
+              {
+                "code": "105816-3",
+                "display": "Vancomycin resistance vanA gene [Cycle Threshold #] in Positive blood culture by NAA with probe detection",
+                "include": true
+              },
+              {
+                "code": "105817-1",
+                "display": "Vancomycin resistance vanB gene [Cycle Threshold #] in Positive blood culture by NAA with probe detection",
+                "include": true
+              },
+              {
+                "code": "48814-8",
+                "display": "Vancomycin resistance vanA gene [Presence] by Molecular method",
+                "include": true
+              },
+              {
+                "code": "62261-3",
+                "display": "Vancomycin resistance vanA + vanB genes [Presence] by Molecular method",
+                "include": true
+              },
+              {
+                "code": "69379-6",
+                "display": "Vancomycin resistance vanA and vanB and vanC1 and vanC2 genes [Identifier] by Molecular method",
+                "include": true
+              },
+              {
+                "code": "72421-1",
+                "display": "Vancomycin resistance vanB gene [Presence] by Molecular method",
+                "include": true
+              },
+              {
+                "code": "72836-0",
+                "display": "Vancomycin resistance vanC2+vanC3 genes [Presence] by Molecular method",
+                "include": true
+              },
+              {
+                "code": "72837-8",
+                "display": "Vancomycin resistance vanC1 gene [Presence] by Molecular method",
+                "include": true
+              },
+              {
+                "code": "75753-4",
+                "display": "Vancomycin resistance vanD gene [Presence] by Molecular method",
+                "include": true
+              },
+              {
+                "code": "85787-0",
+                "display": "Vancomycin resistance vanA + vanB genes [Presence] by NAA with non-probe detection in Positive blood culture",
+                "include": true
+              },
+              {
+                "code": "88252-2",
+                "display": "Vancomycin resistance vanA gene [Presence] by Probe in Positive blood culture",
+                "include": true
+              },
+              {
+                "code": "88253-0",
+                "display": "Vancomycin resistance vanB gene [Presence] by Probe in Positive blood culture",
+                "include": true
+              },
+              {
+                "code": "92241-9",
+                "display": "Vancomycin [Susceptibility] by Genotype method",
+                "include": true
+              }
+            ]
+          }
+        },
+        "406604002": {
+          "2.16.840.1.113762.1.4.1146.1136_20200515": {
+            "valueSetId": "2.16.840.1.113762.1.4.1146.1136_20200515",
+            "valueSetVersion": "20200515",
+            "valueSetName": "VISA (Disorders) (SNOMED)",
+            "valueSetExternalId": "2.16.840.1.113762.1.4.1146.1136",
+            "author": "CSTE Steward",
+            "system": "http://snomed.info/sct",
+            "ersdConceptType": "conditions",
+            "dibbsConceptType": "conditions",
+            "includeValueSet": true,
+            "concepts": [
+              {
+                "code": "406577000",
+                "display": "Infection caused by vancomycin intermediate/resistant Staphylococcus aureus (disorder)",
+                "include": true
+              },
+              {
+                "code": "406603008",
+                "display": "Infection caused by glycopeptide intermediate Staphylococcus aureus (disorder)",
+                "include": true
+              },
+              {
+                "code": "406604002",
+                "display": "Infection caused by vancomycin intermediate Staphylococcus aureus (disorder)",
+                "include": true
+              },
+              {
+                "code": "406607009",
+                "display": "Infection caused by glycopeptide intermediate/resistant Staphylococcus aureus (disorder)",
+                "include": true
+              }
+            ]
+          },
+          "2.16.840.1.113762.1.4.1146.1137_20200515": {
+            "valueSetId": "2.16.840.1.113762.1.4.1146.1137_20200515",
+            "valueSetVersion": "20200515",
+            "valueSetName": "VISA\u00a0(Organism or Substance in Lab Results)",
+            "valueSetExternalId": "2.16.840.1.113762.1.4.1146.1137",
+            "author": "CSTE Steward",
+            "system": "http://snomed.info/sct",
+            "ersdConceptType": "labs",
+            "dibbsConceptType": "labs",
+            "includeValueSet": true,
+            "concepts": [
+              {
+                "code": "406576009",
+                "display": "Vancomycin intermediate/resistant Staphylococcus aureus (organism)",
+                "include": true
+              },
+              {
+                "code": "406605001",
+                "display": "Glycopeptide intermediate Staphylococcus aureus (organism)",
+                "include": true
+              },
+              {
+                "code": "406606000",
+                "display": "Glycopeptide intermediate/resistant Staphylococcus aureus (organism)",
+                "include": true
+              },
+              {
+                "code": "406962002",
+                "display": "Vancomycin intermediate Staphylococcus aureus (organism)",
+                "include": true
+              }
+            ]
+          }
+        },
+        "404681006": {
+          "2.16.840.1.113762.1.4.1146.1140_20200515": {
+            "valueSetId": "2.16.840.1.113762.1.4.1146.1140_20200515",
+            "valueSetVersion": "20200515",
+            "valueSetName": "VRSA\u00a0(Disorders) (SNOMED)",
+            "valueSetExternalId": "2.16.840.1.113762.1.4.1146.1140",
+            "author": "CSTE Steward",
+            "system": "http://snomed.info/sct",
+            "ersdConceptType": "conditions",
+            "dibbsConceptType": "conditions",
+            "includeValueSet": true,
+            "concepts": [
+              {
+                "code": "404678001",
+                "display": "Infection caused by glycopeptide resistant Staphylococcus aureus (disorder)",
+                "include": true
+              },
+              {
+                "code": "404681006",
+                "display": "Infection caused by vancomycin resistant Staphylococcus aureus (disorder)",
+                "include": true
+              },
+              {
+                "code": "406577000",
+                "display": "Infection caused by vancomycin intermediate/resistant Staphylococcus aureus (disorder)",
+                "include": true
+              },
+              {
+                "code": "406607009",
+                "display": "Infection caused by glycopeptide intermediate/resistant Staphylococcus aureus (disorder)",
+                "include": true
+              },
+              {
+                "code": "406615007",
+                "display": "Infection caused by vancomycin resistant Staphylococcus aureus, coagulase positive (disorder)",
+                "include": true
+              }
+            ]
+          },
+          "2.16.840.1.113762.1.4.1146.1141_20200515": {
+            "valueSetId": "2.16.840.1.113762.1.4.1146.1141_20200515",
+            "valueSetVersion": "20200515",
+            "valueSetName": "VRSA\u00a0(Organism or Substance in Lab Results)",
+            "valueSetExternalId": "2.16.840.1.113762.1.4.1146.1141",
+            "author": "CSTE Steward",
+            "system": "http://snomed.info/sct",
+            "ersdConceptType": "labs",
+            "dibbsConceptType": "labs",
+            "includeValueSet": true,
+            "concepts": [
+              {
+                "code": "404679009",
+                "display": "Glycopeptide resistant Staphylococcus aureus (organism)",
+                "include": true
+              },
+              {
+                "code": "404680007",
+                "display": "Vancomycin resistant Staphylococcus aureus (organism)",
+                "include": true
+              },
+              {
+                "code": "406576009",
+                "display": "Vancomycin intermediate/resistant Staphylococcus aureus (organism)",
+                "include": true
+              },
+              {
+                "code": "406606000",
+                "display": "Glycopeptide intermediate/resistant Staphylococcus aureus (organism)",
+                "include": true
+              }
+            ]
+          }
+        },
+        "44591000087104": {
+          "2.16.840.1.113762.1.4.1146.2463_20250219": {
+            "valueSetId": "2.16.840.1.113762.1.4.1146.2463_20250219",
+            "valueSetVersion": "20250219",
+            "valueSetName": "Carbapenem Resistant Enterobacterales (Disorders) (SNOMED)",
+            "valueSetExternalId": "2.16.840.1.113762.1.4.1146.2463",
+            "author": "CSTE Steward",
+            "system": "http://snomed.info/sct",
+            "ersdConceptType": "conditions",
+            "dibbsConceptType": "conditions",
+            "includeValueSet": true,
+            "concepts": [
+              {
+                "code": "712830002",
+                "display": "Infection due to carbapenem resistant Enterobacteriaceae (disorder)",
+                "include": true
+              }
+            ]
+          },
+          "2.16.840.1.113762.1.4.1146.2464_20250219": {
+            "valueSetId": "2.16.840.1.113762.1.4.1146.2464_20250219",
+            "valueSetVersion": "20250219",
+            "valueSetName": "CP_ Carbapenem Resistant Enterobacterales (Disorders) (SNOMED)",
+            "valueSetExternalId": "2.16.840.1.113762.1.4.1146.2464",
+            "author": "CSTE Steward",
+            "system": "http://snomed.info/sct",
+            "ersdConceptType": "conditions",
+            "dibbsConceptType": "conditions",
+            "includeValueSet": true,
+            "concepts": [
+              {
+                "code": "34521000087103",
+                "display": "Infection caused by carbapenemase-producing Enterobacteriaceae (disorder)",
+                "include": true
+              }
+            ]
+          },
+          "2.16.840.1.113762.1.4.1146.2255_20240123": {
+            "valueSetId": "2.16.840.1.113762.1.4.1146.2255_20240123",
+            "valueSetVersion": "20240123",
+            "valueSetName": "Carbapenem Resistant Bacterial Infection [Carbapenemase Producing] (SNOMED)",
+            "valueSetExternalId": "2.16.840.1.113762.1.4.1146.2255",
+            "author": "CSTE Steward",
+            "system": "http://snomed.info/sct",
+            "ersdConceptType": "conditions",
+            "dibbsConceptType": "conditions",
+            "includeValueSet": true,
+            "concepts": [
+              {
+                "code": "34521000087103",
+                "display": "Infection caused by carbapenemase-producing Enterobacteriaceae (disorder)",
+                "include": true
+              }
+            ]
+          },
+          "2.16.840.1.113762.1.4.1146.1672_20220602": {
+            "valueSetId": "2.16.840.1.113762.1.4.1146.1672_20220602",
+            "valueSetVersion": "20220602",
+            "valueSetName": "Carbapenem Resistant Bacterial Infection (SNOMED)",
+            "valueSetExternalId": "2.16.840.1.113762.1.4.1146.1672",
+            "author": "CSTE Steward",
+            "system": "http://snomed.info/sct",
+            "ersdConceptType": "conditions",
+            "dibbsConceptType": "conditions",
+            "includeValueSet": true,
+            "concepts": [
+              {
+                "code": "445780006",
+                "display": "Infection caused by carbapenem resistant Acinetobacter (disorder)",
+                "include": true
+              },
+              {
+                "code": "707274007",
+                "display": "Infection caused by carbapenem resistant bacteria (disorder)",
+                "include": true
+              },
+              {
+                "code": "712830002",
+                "display": "Infection due to carbapenem resistant Enterobacteriaceae (disorder)",
+                "include": true
+              }
+            ]
+          },
+          "2.16.840.1.113762.1.4.1146.1882_20250219": {
+            "valueSetId": "2.16.840.1.113762.1.4.1146.1882_20250219",
+            "valueSetVersion": "20250219",
+            "valueSetName": "Carbapenemase production (Organism or Substance in Lab Results)",
+            "valueSetExternalId": "2.16.840.1.113762.1.4.1146.1882",
+            "author": "CSTE Steward",
+            "system": "http://snomed.info/sct",
+            "ersdConceptType": "labs",
+            "dibbsConceptType": "labs",
+            "includeValueSet": true,
+            "concepts": [
+              {
+                "code": "1085301000112105",
+                "display": "Carbapenemase-producing Acinetobacter calcoaceticus (organism)",
+                "include": true
+              },
+              {
+                "code": "1085401000112103",
+                "display": "Carbapenemase-producing Acinetobacter baumannii-Acinetobacter calcoaceticus complex (organism)",
+                "include": true
+              },
+              {
+                "code": "1085501000112104",
+                "display": "Carbapenemase-producing Acinetobacter (organism)",
+                "include": true
+              },
+              {
+                "code": "1085701000112109",
+                "display": "Carbapenemase-producing Acinetobacter johnsonii (organism)",
+                "include": true
+              },
+              {
+                "code": "1085801000112101",
+                "display": "Carbapenemase-producing Acinetobacter junii (organism)",
+                "include": true
+              },
+              {
+                "code": "1085901000112106",
+                "display": "Carbapenemase-producing Acinetobacter lwoffii (organism)",
+                "include": true
+              },
+              {
+                "code": "1086001000112103",
+                "display": "Carbapenemase-producing Acinetobacter nosocomialis (organism)",
+                "include": true
+              },
+              {
+                "code": "1086101000112102",
+                "display": "Carbapenemase-producing Acinetobacter radioresistens (organism)",
+                "include": true
+              },
+              {
+                "code": "1086201000112108",
+                "display": "Carbapenemase-producing Acinetobacter ursingii (organism)",
+                "include": true
+              },
+              {
+                "code": "1089101000112105",
+                "display": "Carbapenemase-producing Citrobacter amalonaticus (organism)",
+                "include": true
+              },
+              {
+                "code": "1089301000112107",
+                "display": "Carbapenemase-producing Citrobacter braakii (organism)",
+                "include": true
+              },
+              {
+                "code": "1089501000112101",
+                "display": "Carbapenemase-producing Citrobacter (organism)",
+                "include": true
+              },
+              {
+                "code": "1089701000112106",
+                "display": "Carbapenemase-producing Citrobacter farmeri (organism)",
+                "include": true
+              },
+              {
+                "code": "1089901000112108",
+                "display": "Carbapenemase-producing Citrobacter freundii (organism)",
+                "include": true
+              },
+              {
+                "code": "1090401000112109",
+                "display": "Carbapenemase-producing Citrobacter koseri (organism)",
+                "include": true
+              },
+              {
+                "code": "1091201000112104",
+                "display": "Carbapenemase-producing Citrobacter werkmanii (organism)",
+                "include": true
+              },
+              {
+                "code": "1091401000112100",
+                "display": "Carbapenemase-producing Citrobacter youngae (organism)",
+                "include": true
+              },
+              {
+                "code": "1092401000112105",
+                "display": "Carbapenemase-producing Cronobacter sakazakii (organism)",
+                "include": true
+              },
+              {
+                "code": "1093401000112101",
+                "display": "Carbapenemase-producing Enterobacter (organism)",
+                "include": true
+              },
+              {
+                "code": "1093601000112103",
+                "display": "Carbapenemase-producing Enterobacter asburiae (organism)",
+                "include": true
+              },
+              {
+                "code": "1094301000112105",
+                "display": "Carbapenemase-producing Enterobacter hormaechei (organism)",
+                "include": true
+              },
+              {
+                "code": "1096801000112108",
+                "display": "Carbapenemase-producing Klebsiella (organism)",
+                "include": true
+              },
+              {
+                "code": "1098201000112108",
+                "display": "Carbapenemase-producing Klebsiella pneumoniae (organism)",
+                "include": true
+              },
+              {
+                "code": "1099001000112108",
+                "display": "Carbapenemase-producing Kluyvera (organism)",
+                "include": true
+              },
+              {
+                "code": "1099201000112103",
+                "display": "Carbapenemase-producing Kluyvera ascorbata (organism)",
+                "include": true
+              },
+              {
+                "code": "1099401000112104",
+                "display": "Carbapenemase-producing Kluyvera cryocrescens (organism)",
+                "include": true
+              },
+              {
+                "code": "1099601000112101",
+                "display": "Carbapenemase-producing Kluyvera georgiana (organism)",
+                "include": true
+              },
+              {
+                "code": "1099801000112102",
+                "display": "Carbapenemase-producing Kluyvera intermedia (organism)",
+                "include": true
+              },
+              {
+                "code": "1100001000112108",
+                "display": "Carbapenemase-producing Leclercia (organism)",
+                "include": true
+              },
+              {
+                "code": "1100201000112103",
+                "display": "Carbapenemase-producing Leclercia adecarboxylata (organism)",
+                "include": true
+              },
+              {
+                "code": "1101601000112106",
+                "display": "Carbapenemase-producing Morganella morganii (organism)",
+                "include": true
+              },
+              {
+                "code": "1102601000112100",
+                "display": "Carbapenemase-producing Proteus (organism)",
+                "include": true
+              },
+              {
+                "code": "1103001000112103",
+                "display": "Carbapenemase-producing Proteus mirabilis (organism)",
+                "include": true
+              },
+              {
+                "code": "1103601000112105",
+                "display": "Carbapenemase-producing Providencia (organism)",
+                "include": true
+              },
+              {
+                "code": "1104001000112101",
+                "display": "Carbapenemase-producing Providencia rettgeri (organism)",
+                "include": true
+              },
+              {
+                "code": "1105401000112106",
+                "display": "Carbapenemase-producing Raoultella ornithinolytica (organism)",
+                "include": true
+              },
+              {
+                "code": "1105601000112109",
+                "display": "Carbapenemase-producing Raoultella planticola (organism)",
+                "include": true
+              },
+              {
+                "code": "1106001000112106",
+                "display": "Carbapenemase-producing Salmonella (organism)",
+                "include": true
+              },
+              {
+                "code": "1106601000112104",
+                "display": "Carbapenemase-producing Serratia fonticola (organism)",
+                "include": true
+              },
+              {
+                "code": "1107201000112104",
+                "display": "Carbapenemase-producing Serratia marcescens (organism)",
+                "include": true
+              },
+              {
+                "code": "1112101000112106",
+                "display": "Carbapenemase-producing Lelliottia amnigena (organism)",
+                "include": true
+              },
+              {
+                "code": "30731000112102",
+                "display": "Carbapenemase-producing Acinetobacter seifertii (organism)",
+                "include": true
+              },
+              {
+                "code": "33691000087101",
+                "display": "Carbapenemase-producing Klebsiella variicola (organism)",
+                "include": true
+              },
+              {
+                "code": "44601000087107",
+                "display": "Carbapenemase-producing Citrobacter freundii complex (organism)",
+                "include": true
+              },
+              {
+                "code": "51271000087100",
+                "display": "Carbapenemase-producing Klebsiella oxytoca (organism)",
+                "include": true
+              },
+              {
+                "code": "51281000087103",
+                "display": "Carbapenemase-producing Enterobacterales (organism)",
+                "include": true
+              },
+              {
+                "code": "713171002",
+                "display": "Klebsiella pneumoniae carbapenemase 2 producing Klebsiella pneumoniae (organism)",
+                "include": true
+              },
+              {
+                "code": "734350003",
+                "display": "Carbapenemase-producing bacteria (organism)",
+                "include": true
+              },
+              {
+                "code": "734351004",
+                "display": "Carbapenemase-producing Enterobacteriaceae (organism)",
+                "include": true
+              },
+              {
+                "code": "734352006",
+                "display": "Carbapenemase-producing Klebsiella aerogenes (organism)",
+                "include": true
+              },
+              {
+                "code": "734353001",
+                "display": "Carbapenemase-producing Enterobacter cloacae complex (organism)",
+                "include": true
+              },
+              {
+                "code": "737526007",
+                "display": "Carbapenemase-producing Acinetobacter baumannii (organism)",
+                "include": true
+              },
+              {
+                "code": "737527003",
+                "display": "Carbapenemase-producing Pseudomonas aeruginosa (organism)",
+                "include": true
+              },
+              {
+                "code": "737528008",
+                "display": "Carbapenemase-producing Escherichia coli (organism)",
+                "include": true
+              },
+              {
+                "code": "737529000",
+                "display": "Carbapenemase-producing Enterobacter cloacae (organism)",
+                "include": true
+              },
+              {
+                "code": "762987008",
+                "display": "Extended spectrum beta-lactamase and carbapenemase producing bacteria (organism)",
+                "include": true
+              },
+              {
+                "code": "770392005",
+                "display": "Carbapenemase-producing Raoultella (organism)",
+                "include": true
+              },
+              {
+                "code": "773734006",
+                "display": "OXA-48 carbapenemase-producing bacteria (organism)",
+                "include": true
+              }
+            ]
+          },
+          "2.16.840.1.113762.1.4.1146.1209_20220118": {
+            "valueSetId": "2.16.840.1.113762.1.4.1146.1209_20220118",
+            "valueSetVersion": "20220118",
+            "valueSetName": "Enterobacter spp., E. coli, or Klebsiella spp. [Carbapenemase Producing] (Organism or Substance in Lab Results)",
+            "valueSetExternalId": "2.16.840.1.113762.1.4.1146.1209",
+            "author": "CSTE Steward",
+            "system": "http://snomed.info/sct",
+            "ersdConceptType": "labs",
+            "dibbsConceptType": "labs",
+            "includeValueSet": true,
+            "concepts": [
+              {
+                "code": "1093401000112101",
+                "display": "Carbapenemase-producing Enterobacter (organism)",
+                "include": true
+              },
+              {
+                "code": "1093601000112103",
+                "display": "Carbapenemase-producing Enterobacter asburiae (organism)",
+                "include": true
+              },
+              {
+                "code": "1094301000112105",
+                "display": "Carbapenemase-producing Enterobacter hormaechei (organism)",
+                "include": true
+              },
+              {
+                "code": "1096801000112108",
+                "display": "Carbapenemase-producing Klebsiella (organism)",
+                "include": true
+              },
+              {
+                "code": "1098201000112108",
+                "display": "Carbapenemase-producing Klebsiella pneumoniae (organism)",
+                "include": true
+              },
+              {
+                "code": "713171002",
+                "display": "Klebsiella pneumoniae carbapenemase 2 producing Klebsiella pneumoniae (organism)",
+                "include": true
+              },
+              {
+                "code": "734352006",
+                "display": "Carbapenemase-producing Klebsiella aerogenes (organism)",
+                "include": true
+              },
+              {
+                "code": "734353001",
+                "display": "Carbapenemase-producing Enterobacter cloacae complex (organism)",
+                "include": true
+              },
+              {
+                "code": "737528008",
+                "display": "Carbapenemase-producing Escherichia coli (organism)",
+                "include": true
+              },
+              {
+                "code": "737529000",
+                "display": "Carbapenemase-producing Enterobacter cloacae (organism)",
+                "include": true
+              }
+            ]
+          },
+          "2.16.840.1.113762.1.4.1146.1208_20200515": {
+            "valueSetId": "2.16.840.1.113762.1.4.1146.1208_20200515",
+            "valueSetVersion": "20200515",
+            "valueSetName": "Enterobacter spp., E. coli, or Klebsiella spp. [Carbapenem Resistant] (Organism or Substance in Lab Results)",
+            "valueSetExternalId": "2.16.840.1.113762.1.4.1146.1208",
+            "author": "CSTE Steward",
+            "system": "http://snomed.info/sct",
+            "ersdConceptType": "labs",
+            "dibbsConceptType": "labs",
+            "includeValueSet": true,
+            "concepts": [
+              {
+                "code": "446870005",
+                "display": "Carbapenem resistant Klebsiella pneumoniae (organism)",
+                "include": true
+              },
+              {
+                "code": "714007005",
+                "display": "Carbapenem resistant Enterobacter cloacae (organism)",
+                "include": true
+              },
+              {
+                "code": "715307006",
+                "display": "Carbapenem resistant Escherichia coli (organism)",
+                "include": true
+              },
+              {
+                "code": "719792001",
+                "display": "Carbapenem resistant Klebsiella oxytoca (organism)",
+                "include": true
+              },
+              {
+                "code": "734200008",
+                "display": "Carbapenem resistant Klebsiella aerogenes (organism)",
+                "include": true
+              },
+              {
+                "code": "734201007",
+                "display": "Carbapenem resistant Enterobacter cloacae complex (organism)",
+                "include": true
+              }
+            ]
+          },
+          "2.16.840.1.113762.1.4.1146.1214_20230122": {
+            "valueSetId": "2.16.840.1.113762.1.4.1146.1214_20230122",
+            "valueSetVersion": "20230122",
+            "valueSetName": "Carbapenemase resistance mechanism (Organism or Substance in Lab Results)",
+            "valueSetExternalId": "2.16.840.1.113762.1.4.1146.1214",
+            "author": "CSTE Steward",
+            "system": "http://snomed.info/sct",
+            "ersdConceptType": "labs",
+            "dibbsConceptType": "labs",
+            "includeValueSet": true,
+            "concepts": [
+              {
+                "code": "1104601000112108",
+                "display": "Metallo-beta-lactamase producing Pseudomonas aeruginosa (organism)",
+                "include": true
+              },
+              {
+                "code": "713171002",
+                "display": "Klebsiella pneumoniae carbapenemase 2 producing Klebsiella pneumoniae (organism)",
+                "include": true
+              },
+              {
+                "code": "762987008",
+                "display": "Extended spectrum beta-lactamase and carbapenemase producing bacteria (organism)",
+                "include": true
+              },
+              {
+                "code": "773734006",
+                "display": "OXA-48 carbapenemase-producing bacteria (organism)",
+                "include": true
+              },
+              {
+                "code": "870562001",
+                "display": "Metallo-beta-lactamase producing bacteria (organism)",
+                "include": true
+              }
+            ]
+          },
+          "2.16.840.1.113762.1.4.1146.2471_20250219": {
+            "valueSetId": "2.16.840.1.113762.1.4.1146.2471_20250219",
+            "valueSetVersion": "20250219",
+            "valueSetName": "Proteus spp., Providencia spp., and Morganella spp. (Organism or Substance in Lab Results)",
+            "valueSetExternalId": "2.16.840.1.113762.1.4.1146.2471",
+            "author": "CSTE Steward",
+            "system": "http://snomed.info/sct",
+            "ersdConceptType": "labs",
+            "dibbsConceptType": "labs",
+            "includeValueSet": true,
+            "concepts": [
+              {
+                "code": "1101501000112107",
+                "display": "Extended spectrum beta-lactamase producing Morganella (organism)",
+                "include": true
+              },
+              {
+                "code": "1101601000112106",
+                "display": "Carbapenemase-producing Morganella morganii (organism)",
+                "include": true
+              },
+              {
+                "code": "1101701000112102",
+                "display": "Extended spectrum beta-lactamase producing Morganella morganii (organism)",
+                "include": true
+              },
+              {
+                "code": "1102601000112100",
+                "display": "Carbapenemase-producing Proteus (organism)",
+                "include": true
+              },
+              {
+                "code": "1103001000112103",
+                "display": "Carbapenemase-producing Proteus mirabilis (organism)",
+                "include": true
+              },
+              {
+                "code": "1103101000112102",
+                "display": "AmpC beta-lactamase producing Proteus mirabilis (organism)",
+                "include": true
+              },
+              {
+                "code": "1103301000112100",
+                "display": "Extended spectrum beta-lactamase producing Proteus penneri (organism)",
+                "include": true
+              },
+              {
+                "code": "1103501000112106",
+                "display": "Extended spectrum beta-lactamase producing Proteus vulgaris (organism)",
+                "include": true
+              },
+              {
+                "code": "1103601000112105",
+                "display": "Carbapenemase-producing Providencia (organism)",
+                "include": true
+              },
+              {
+                "code": "1104001000112101",
+                "display": "Carbapenemase-producing Providencia rettgeri (organism)",
+                "include": true
+              },
+              {
+                "code": "1104501000112109",
+                "display": "Extended spectrum beta-lactamase producing Providencia stuartii (organism)",
+                "include": true
+              },
+              {
+                "code": "112284001",
+                "display": "Genus Providencia (organism)",
+                "include": true
+              },
+              {
+                "code": "114460006",
+                "display": "Morganella morganii, biogroup 1 (organism)",
+                "include": true
+              },
+              {
+                "code": "114461005",
+                "display": "Proteus inconstans (organism)",
+                "include": true
+              },
+              {
+                "code": "1279979005",
+                "display": "Extended spectrum beta-lactamase producing Morganellaceae (organism)",
+                "include": true
+              },
+              {
+                "code": "1284965007",
+                "display": "AmpC beta-lactamase producing Morganellaceae (organism)",
+                "include": true
+              },
+              {
+                "code": "14196002",
+                "display": "Providencia rettgeri (organism)",
+                "include": true
+              },
+              {
+                "code": "1445008",
+                "display": "Providencia stuartii (organism)",
+                "include": true
+              },
+              {
+                "code": "19196004",
+                "display": "Providencia rustigianii (organism)",
+                "include": true
+              },
+              {
+                "code": "243301005",
+                "display": "Morganella morganii (organism)",
+                "include": true
+              },
+              {
+                "code": "243302003",
+                "display": "Morganella morganii subspecies morganii (organism)",
+                "include": true
+              },
+              {
+                "code": "243303008",
+                "display": "Morganella morganii subsp sibonii (organism)",
+                "include": true
+              },
+              {
+                "code": "243304002",
+                "display": "Proteus vulgaris biogroup 2 (organism)",
+                "include": true
+              },
+              {
+                "code": "416146002",
+                "display": "Proteus genomospecies 6 (organism)",
+                "include": true
+              },
+              {
+                "code": "416370007",
+                "display": "Proteus genomospecies 5 (organism)",
+                "include": true
+              },
+              {
+                "code": "417388005",
+                "display": "Proteus genomospecies 4 (organism)",
+                "include": true
+              },
+              {
+                "code": "417592004",
+                "display": "Proteus hauseri (organism)",
+                "include": true
+              },
+              {
+                "code": "438388000",
+                "display": "Genus Thermoproteus (organism)",
+                "include": true
+              },
+              {
+                "code": "45298005",
+                "display": "Proteus penneri (organism)",
+                "include": true
+              },
+              {
+                "code": "45834001",
+                "display": "Proteus vulgaris (organism)",
+                "include": true
+              },
+              {
+                "code": "46349009",
+                "display": "Providencia alcalifaciens (organism)",
+                "include": true
+              },
+              {
+                "code": "47300009",
+                "display": "Providencia heimbachae (organism)",
+                "include": true
+              },
+              {
+                "code": "50517009",
+                "display": "Genus Proteus (organism)",
+                "include": true
+              },
+              {
+                "code": "50713005",
+                "display": "Genus Morganella (organism)",
+                "include": true
+              },
+              {
+                "code": "541051000124105",
+                "display": "Carbapenem resistant Providencia (organism)",
+                "include": true
+              },
+              {
+                "code": "541071000124100",
+                "display": "Carbapenem resistant Proteus vulgaris (organism)",
+                "include": true
+              },
+              {
+                "code": "541091000124104",
+                "display": "Extended spectrum beta-lactamase producing Providencia (organism)",
+                "include": true
+              },
+              {
+                "code": "541111000124108",
+                "display": "Carbapenem resistant Morganella morganii (organism)",
+                "include": true
+              },
+              {
+                "code": "6031000146109",
+                "display": "Providencia vermicola (organism)",
+                "include": true
+              },
+              {
+                "code": "707293009",
+                "display": "Multidrug-resistant Morganella morganii (organism)",
+                "include": true
+              },
+              {
+                "code": "708408009",
+                "display": "Deoxyribonucleic acid of Proteus mirabilis (substance)",
+                "include": true
+              },
+              {
+                "code": "713929002",
+                "display": "Extended spectrum beta-lactamase producing Proteus mirabilis (organism)",
+                "include": true
+              },
+              {
+                "code": "714314003",
+                "display": "Multiple drug-resistant Proteus mirabilis (organism)",
+                "include": true
+              },
+              {
+                "code": "719793006",
+                "display": "Carbapenem resistant Proteus mirabilis (organism)",
+                "include": true
+              },
+              {
+                "code": "73457008",
+                "display": "Proteus mirabilis (organism)",
+                "include": true
+              },
+              {
+                "code": "830220000",
+                "display": "Deoxyribonucleic acid of Proteus (substance)",
+                "include": true
+              },
+              {
+                "code": "860983002",
+                "display": "Family Morganellaceae (organism)",
+                "include": true
+              }
+            ]
+          },
+          "2.16.840.1.113762.1.4.1146.2474_20250219": {
+            "valueSetId": "2.16.840.1.113762.1.4.1146.2474_20250219",
+            "valueSetVersion": "20250219",
+            "valueSetName": "Enterobacterales species [Carbapenemase Producing] (Organism or Substance in Lab Results)",
+            "valueSetExternalId": "2.16.840.1.113762.1.4.1146.2474",
+            "author": "CSTE Steward",
+            "system": "http://snomed.info/sct",
+            "ersdConceptType": "labs",
+            "dibbsConceptType": "labs",
+            "includeValueSet": true,
+            "concepts": [
+              {
+                "code": "1089101000112105",
+                "display": "Carbapenemase-producing Citrobacter amalonaticus (organism)",
+                "include": true
+              },
+              {
+                "code": "1089301000112107",
+                "display": "Carbapenemase-producing Citrobacter braakii (organism)",
+                "include": true
+              },
+              {
+                "code": "1089501000112101",
+                "display": "Carbapenemase-producing Citrobacter (organism)",
+                "include": true
+              },
+              {
+                "code": "1089701000112106",
+                "display": "Carbapenemase-producing Citrobacter farmeri (organism)",
+                "include": true
+              },
+              {
+                "code": "1089901000112108",
+                "display": "Carbapenemase-producing Citrobacter freundii (organism)",
+                "include": true
+              },
+              {
+                "code": "1090401000112109",
+                "display": "Carbapenemase-producing Citrobacter koseri (organism)",
+                "include": true
+              },
+              {
+                "code": "1091201000112104",
+                "display": "Carbapenemase-producing Citrobacter werkmanii (organism)",
+                "include": true
+              },
+              {
+                "code": "1091401000112100",
+                "display": "Carbapenemase-producing Citrobacter youngae (organism)",
+                "include": true
+              },
+              {
+                "code": "1092401000112105",
+                "display": "Carbapenemase-producing Cronobacter sakazakii (organism)",
+                "include": true
+              },
+              {
+                "code": "1093401000112101",
+                "display": "Carbapenemase-producing Enterobacter (organism)",
+                "include": true
+              },
+              {
+                "code": "1093601000112103",
+                "display": "Carbapenemase-producing Enterobacter asburiae (organism)",
+                "include": true
+              },
+              {
+                "code": "1094301000112105",
+                "display": "Carbapenemase-producing Enterobacter hormaechei (organism)",
+                "include": true
+              },
+              {
+                "code": "1096801000112108",
+                "display": "Carbapenemase-producing Klebsiella (organism)",
+                "include": true
+              },
+              {
+                "code": "1098201000112108",
+                "display": "Carbapenemase-producing Klebsiella pneumoniae (organism)",
+                "include": true
+              },
+              {
+                "code": "1099001000112108",
+                "display": "Carbapenemase-producing Kluyvera (organism)",
+                "include": true
+              },
+              {
+                "code": "1099201000112103",
+                "display": "Carbapenemase-producing Kluyvera ascorbata (organism)",
+                "include": true
+              },
+              {
+                "code": "1099401000112104",
+                "display": "Carbapenemase-producing Kluyvera cryocrescens (organism)",
+                "include": true
+              },
+              {
+                "code": "1099601000112101",
+                "display": "Carbapenemase-producing Kluyvera georgiana (organism)",
+                "include": true
+              },
+              {
+                "code": "1099801000112102",
+                "display": "Carbapenemase-producing Kluyvera intermedia (organism)",
+                "include": true
+              },
+              {
+                "code": "1100001000112108",
+                "display": "Carbapenemase-producing Leclercia (organism)",
+                "include": true
+              },
+              {
+                "code": "1100201000112103",
+                "display": "Carbapenemase-producing Leclercia adecarboxylata (organism)",
+                "include": true
+              },
+              {
+                "code": "1101601000112106",
+                "display": "Carbapenemase-producing Morganella morganii (organism)",
+                "include": true
+              },
+              {
+                "code": "1102601000112100",
+                "display": "Carbapenemase-producing Proteus (organism)",
+                "include": true
+              },
+              {
+                "code": "1103001000112103",
+                "display": "Carbapenemase-producing Proteus mirabilis (organism)",
+                "include": true
+              },
+              {
+                "code": "1103601000112105",
+                "display": "Carbapenemase-producing Providencia (organism)",
+                "include": true
+              },
+              {
+                "code": "1104001000112101",
+                "display": "Carbapenemase-producing Providencia rettgeri (organism)",
+                "include": true
+              },
+              {
+                "code": "1105401000112106",
+                "display": "Carbapenemase-producing Raoultella ornithinolytica (organism)",
+                "include": true
+              },
+              {
+                "code": "1105601000112109",
+                "display": "Carbapenemase-producing Raoultella planticola (organism)",
+                "include": true
+              },
+              {
+                "code": "1106001000112106",
+                "display": "Carbapenemase-producing Salmonella (organism)",
+                "include": true
+              },
+              {
+                "code": "1106601000112104",
+                "display": "Carbapenemase-producing Serratia fonticola (organism)",
+                "include": true
+              },
+              {
+                "code": "1107201000112104",
+                "display": "Carbapenemase-producing Serratia marcescens (organism)",
+                "include": true
+              },
+              {
+                "code": "33691000087101",
+                "display": "Carbapenemase-producing Klebsiella variicola (organism)",
+                "include": true
+              },
+              {
+                "code": "44601000087107",
+                "display": "Carbapenemase-producing Citrobacter freundii complex (organism)",
+                "include": true
+              },
+              {
+                "code": "51271000087100",
+                "display": "Carbapenemase-producing Klebsiella oxytoca (organism)",
+                "include": true
+              },
+              {
+                "code": "51281000087103",
+                "display": "Carbapenemase-producing Enterobacterales (organism)",
+                "include": true
+              },
+              {
+                "code": "713171002",
+                "display": "Klebsiella pneumoniae carbapenemase 2 producing Klebsiella pneumoniae (organism)",
+                "include": true
+              },
+              {
+                "code": "734351004",
+                "display": "Carbapenemase-producing Enterobacteriaceae (organism)",
+                "include": true
+              },
+              {
+                "code": "734352006",
+                "display": "Carbapenemase-producing Klebsiella aerogenes (organism)",
+                "include": true
+              },
+              {
+                "code": "734353001",
+                "display": "Carbapenemase-producing Enterobacter cloacae complex (organism)",
+                "include": true
+              },
+              {
+                "code": "737528008",
+                "display": "Carbapenemase-producing Escherichia coli (organism)",
+                "include": true
+              },
+              {
+                "code": "737529000",
+                "display": "Carbapenemase-producing Enterobacter cloacae (organism)",
+                "include": true
+              },
+              {
+                "code": "770392005",
+                "display": "Carbapenemase-producing Raoultella (organism)",
+                "include": true
+              }
+            ]
+          },
+          "2.16.840.1.113762.1.4.1146.2473_20250219": {
+            "valueSetId": "2.16.840.1.113762.1.4.1146.2473_20250219",
+            "valueSetVersion": "20250219",
+            "valueSetName": "Enterobacterales species [Carbapenem Resistant] (Organism or Substance in Lab Results)",
+            "valueSetExternalId": "2.16.840.1.113762.1.4.1146.2473",
+            "author": "CSTE Steward",
+            "system": "http://snomed.info/sct",
+            "ersdConceptType": "labs",
+            "dibbsConceptType": "labs",
+            "includeValueSet": true,
+            "concepts": [
+              {
+                "code": "44591000087104",
+                "display": "Carbapenem resistant Enterobacterales (organism)",
+                "include": true
+              },
+              {
+                "code": "446870005",
+                "display": "Carbapenem resistant Klebsiella pneumoniae (organism)",
+                "include": true
+              },
+              {
+                "code": "541051000124105",
+                "display": "Carbapenem resistant Providencia (organism)",
+                "include": true
+              },
+              {
+                "code": "541071000124100",
+                "display": "Carbapenem resistant Proteus vulgaris (organism)",
+                "include": true
+              },
+              {
+                "code": "541111000124108",
+                "display": "Carbapenem resistant Morganella morganii (organism)",
+                "include": true
+              },
+              {
+                "code": "712662001",
+                "display": "Carbapenem resistant Enterobacteriaceae (organism)",
+                "include": true
+              },
+              {
+                "code": "714007005",
+                "display": "Carbapenem resistant Enterobacter cloacae (organism)",
+                "include": true
+              },
+              {
+                "code": "715307006",
+                "display": "Carbapenem resistant Escherichia coli (organism)",
+                "include": true
+              },
+              {
+                "code": "719792001",
+                "display": "Carbapenem resistant Klebsiella oxytoca (organism)",
+                "include": true
+              },
+              {
+                "code": "719793006",
+                "display": "Carbapenem resistant Proteus mirabilis (organism)",
+                "include": true
+              },
+              {
+                "code": "734200008",
+                "display": "Carbapenem resistant Klebsiella aerogenes (organism)",
+                "include": true
+              },
+              {
+                "code": "734201007",
+                "display": "Carbapenem resistant Enterobacter cloacae complex (organism)",
+                "include": true
+              },
+              {
+                "code": "816049003",
+                "display": "Carbapenem-resistant Serratia marcescens (organism)",
+                "include": true
+              }
+            ]
+          },
+          "2.16.840.1.113762.1.4.1146.2467_20250219": {
+            "valueSetId": "2.16.840.1.113762.1.4.1146.2467_20250219",
+            "valueSetVersion": "20250219",
+            "valueSetName": "CRE (Tests for Enterobacterales species Nucleic Acid)",
+            "valueSetExternalId": "2.16.840.1.113762.1.4.1146.2467",
+            "author": "CSTE Steward",
+            "system": "http://loinc.org",
+            "ersdConceptType": "labs",
+            "dibbsConceptType": "labs",
+            "includeValueSet": true,
+            "concepts": [
+              {
+                "code": "101363-0",
+                "display": "Yersinia pestis DNA [Presence] in Blood by NAA with non-probe detection",
+                "include": true
+              },
+              {
+                "code": "101372-1",
+                "display": "Yersinia pestis DNA [Presence] in Sputum by NAA with non-probe detection",
+                "include": true
+              },
+              {
+                "code": "101427-3",
+                "display": "Shigella sp DNA [Presence] in Stool by NAA with probe detection",
+                "include": true
+              },
+              {
+                "code": "101511-4",
+                "display": "Salmonella enterica serotype 1,4,[5],12:i:- [Cycle Threshold #] in Specimen by NAA with probe detection",
+                "include": true
+              },
+              {
+                "code": "101512-2",
+                "display": "Salmonella typhimurium DNA [Cycle Threshold #] in Specimen by NAA with probe detection",
+                "include": true
+              },
+              {
+                "code": "101558-5",
+                "display": "Escherichia coli enteroinvasive DNA [Presence] in Stool by NAA with probe detection",
+                "include": true
+              },
+              {
+                "code": "103162-4",
+                "display": "Escherichia coli enteropathogenic DNA [Presence] in Wound by NAA with probe detection",
+                "include": true
+              },
+              {
+                "code": "103169-9",
+                "display": "Citrobacter freundii DNA [Presence] in Wound by NAA with probe detection",
+                "include": true
+              },
+              {
+                "code": "103173-1",
+                "display": "Enterobacter aerogenes+Enterobacter cloacae DNA [Presence] in Specimen by NAA with probe detection",
+                "include": true
+              },
+              {
+                "code": "103174-9",
+                "display": "Enterobacter spp DNA [Presence] in Wound by NAA with probe detection",
+                "include": true
+              },
+              {
+                "code": "103176-4",
+                "display": "Escherichia coli enteroinvasive DNA [Presence] in Wound by NAA with probe detection",
+                "include": true
+              },
+              {
+                "code": "103177-2",
+                "display": "Escherichia coli enterotoxigenic DNA [Presence] in Wound by NAA with probe detection",
+                "include": true
+              },
+              {
+                "code": "103186-3",
+                "display": "Klebsiella pneumoniae and Klebsiella oxytoca DNA [Presence] in Wound by NAA with probe detection",
+                "include": true
+              },
+              {
+                "code": "103187-1",
+                "display": "Klebsiella pneumoniae DNA [Presence] in Respiratory system specimen by NAA with probe detection",
+                "include": true
+              },
+              {
+                "code": "103188-9",
+                "display": "Morganella morganii DNA [Presence] in Wound by NAA with probe detection",
+                "include": true
+              },
+              {
+                "code": "103194-7",
+                "display": "Proteus mirabilis DNA [Presence] in Urine by NAA with probe detection",
+                "include": true
+              },
+              {
+                "code": "103195-4",
+                "display": "Proteus vulgaris DNA [Presence] in Specimen by NAA with probe detection",
+                "include": true
+              },
+              {
+                "code": "103196-2",
+                "display": "Proteus vulgaris DNA [Presence] in Urine by NAA with probe detection",
+                "include": true
+              },
+              {
+                "code": "103201-0",
+                "display": "Yersinia enterocolitica DNA [Presence] in Wound by NAA with probe detection",
+                "include": true
+              },
+              {
+                "code": "103555-9",
+                "display": "Escherichia coli O157:H7 DNA [Presence] in Wound by NAA with probe detection",
+                "include": true
+              },
+              {
+                "code": "103622-7",
+                "display": "Enterobacter spp DNA [Presence] in Specimen by NAA with probe detection",
+                "include": true
+              },
+              {
+                "code": "103624-3",
+                "display": "Klebsiella pneumoniae and Klebsiella oxytoca DNA [Presence] in Specimen by NAA with probe detection",
+                "include": true
+              },
+              {
+                "code": "104449-4",
+                "display": "Salmonella paratyphi DNA [Presence] in Blood by NAA with probe detection",
+                "include": true
+              },
+              {
+                "code": "105642-3",
+                "display": "Citrobacter freundii complex DNA [Presence] in Specimen by NAA with probe detection",
+                "include": true
+              },
+              {
+                "code": "105643-1",
+                "display": "Citrobacter koseri DNA [Presence] in Specimen by NAA with probe detection",
+                "include": true
+              },
+              {
+                "code": "105650-6",
+                "display": "Enterobacter cloacae DNA [Presence] in Specimen by NAA with probe detection",
+                "include": true
+              },
+              {
+                "code": "105651-4",
+                "display": "Enterobacter cloacae complex DNA [Presence] in Specimen by NAA with probe detection",
+                "include": true
+              },
+              {
+                "code": "105652-2",
+                "display": "Enterobacter hormaechei DNA [Presence] in Specimen by NAA with probe detection",
+                "include": true
+              },
+              {
+                "code": "105653-0",
+                "display": "Enterobacter roggenkampii DNA [Presence] in Specimen by NAA with probe detection",
+                "include": true
+              },
+              {
+                "code": "105662-1",
+                "display": "Klebsiella oxytoca DNA [Presence] in Specimen by NAA with probe detection",
+                "include": true
+              },
+              {
+                "code": "105663-9",
+                "display": "Klebsiella variicola subspecies. tropica DNA [Presence] in Specimen by NAA with probe detection",
+                "include": true
+              },
+              {
+                "code": "105667-0",
+                "display": "Morganella morganii DNA [Presence] in Specimen by NAA with probe detection",
+                "include": true
+              },
+              {
+                "code": "105674-6",
+                "display": "Proteus sp DNA [Presence] in Specimen by NAA with probe detection",
+                "include": true
+              },
+              {
+                "code": "105675-3",
+                "display": "Providencia stuartii DNA [Presence] in Specimen by NAA with probe detection",
+                "include": true
+              },
+              {
+                "code": "105683-7",
+                "display": "Yersinia enterocolitica DNA [Presence] in Specimen by NAA with probe detection",
+                "include": true
+              },
+              {
+                "code": "105684-5",
+                "display": "Yersinia pseudotuberculosis complex DNA [Presence] in Specimen by NAA with probe detection",
+                "include": true
+              },
+              {
+                "code": "23431-0",
+                "display": "Salmonella gallinarum DNA [Presence] in Specimen by NAA with probe detection",
+                "include": true
+              },
+              {
+                "code": "23432-8",
+                "display": "Salmonella gallinarum rRNA [Presence] in Specimen by Probe",
+                "include": true
+              },
+              {
+                "code": "23435-1",
+                "display": "Salmonella pullorum DNA [Presence] in Specimen by NAA with probe detection",
+                "include": true
+              },
+              {
+                "code": "23436-9",
+                "display": "Salmonella pullorum rRNA [Presence] in Specimen by Probe",
+                "include": true
+              },
+              {
+                "code": "33691-7",
+                "display": "Yersinia pestis DNA [Presence] in Specimen by NAA with probe detection",
+                "include": true
+              },
+              {
+                "code": "38990-8",
+                "display": "Escherichia coli O157:H7 DNA [Presence] in Specimen by NAA with probe detection",
+                "include": true
+              },
+              {
+                "code": "44088-3",
+                "display": "Escherichia coli O157:H7 DNA [Identifier] in Specimen by NAA with probe detection",
+                "include": true
+              },
+              {
+                "code": "46455-2",
+                "display": "Shigella sp DNA [Presence] in Specimen by NAA with probe detection",
+                "include": true
+              },
+              {
+                "code": "48646-4",
+                "display": "Yersinia sp DNA [Identifier] in Specimen by NAA with probe detection",
+                "include": true
+              },
+              {
+                "code": "49612-5",
+                "display": "Salmonella sp DNA [Presence] in Specimen by NAA with probe detection",
+                "include": true
+              },
+              {
+                "code": "53947-8",
+                "display": "Escherichia coli Stx1 and Stx2 toxin stx1 and stx2 and H7 flagellar fliC genes [Identifier] in Specimen by NAA with probe detection",
+                "include": true
+              },
+              {
+                "code": "61361-2",
+                "display": "Klebsiella aerogenes DNA [Presence] in Specimen by NAA with probe detection",
+                "include": true
+              },
+              {
+                "code": "61370-3",
+                "display": "Salmonella enterica DNA [Presence] in Specimen by NAA with probe detection",
+                "include": true
+              },
+              {
+                "code": "61398-4",
+                "display": "Escherichia coli DNA [Presence] in Specimen by NAA with probe detection",
+                "include": true
+              },
+              {
+                "code": "61399-2",
+                "display": "Klebsiella pneumoniae DNA [Presence] in Specimen by NAA with probe detection",
+                "include": true
+              },
+              {
+                "code": "61400-8",
+                "display": "Proteus mirabilis DNA [Presence] in Specimen by NAA with probe detection",
+                "include": true
+              },
+              {
+                "code": "61402-4",
+                "display": "Serratia marcescens DNA [Presence] in Specimen by NAA with probe detection",
+                "include": true
+              },
+              {
+                "code": "63423-8",
+                "display": "Escherichia coli eaeA gene [Presence] in Specimen by NAA with probe detection",
+                "include": true
+              },
+              {
+                "code": "63427-9",
+                "display": "Escherichia coli Stx1 toxin stx1 gene [Presence] in Specimen by NAA with probe detection",
+                "include": true
+              },
+              {
+                "code": "63428-7",
+                "display": "Escherichia coli Stx2 toxin stx2 gene [Presence] in Specimen by NAA with probe detection",
+                "include": true
+              },
+              {
+                "code": "70019-5",
+                "display": "Klebsiella oxytoca DNA [Presence] in Blood by NAA with probe detection",
+                "include": true
+              },
+              {
+                "code": "70021-1",
+                "display": "Salmonella typhi DNA [Presence] in Blood by NAA with probe detection",
+                "include": true
+              },
+              {
+                "code": "70242-3",
+                "display": "Shigella species+EIEC invasion plasmid antigen H ipaH gene [Presence] in Stool by NAA with probe detection",
+                "include": true
+              },
+              {
+                "code": "70296-9",
+                "display": "Plesiomonas shigelloides DNA [Presence] in Stool by NAA with probe detection",
+                "include": true
+              },
+              {
+                "code": "76576-8",
+                "display": "Serratia marcescens gyrB gene [Presence] in Swab specimen by NAA with probe detection",
+                "include": true
+              },
+              {
+                "code": "76583-4",
+                "display": "Klebsiella pneumoniae phoE gene [Presence] in Swab specimen by NAA with probe detection",
+                "include": true
+              },
+              {
+                "code": "76591-7",
+                "display": "Serratia marcescens gyrB gene [#/mass] in XXX.tissue by NAA with probe detection",
+                "include": true
+              },
+              {
+                "code": "76598-2",
+                "display": "Klebsiella pneumoniae phoE gene [#/mass] in XXX.tissue by NAA with probe detection",
+                "include": true
+              },
+              {
+                "code": "76604-8",
+                "display": "Serratia marcescens gyrB gene [#/volume] in XXX.body fluid by NAA with probe detection",
+                "include": true
+              },
+              {
+                "code": "76611-3",
+                "display": "Klebsiella pneumoniae phoE gene [#/volume] in XXX.body fluid by NAA with probe detection",
+                "include": true
+              },
+              {
+                "code": "79383-6",
+                "display": "Salmonella sp rpoD gene [Presence] in Stool by NAA with probe detection",
+                "include": true
+              },
+              {
+                "code": "79385-1",
+                "display": "Yersinia enterocolitica recN gene [Presence] in Stool by NAA with probe detection",
+                "include": true
+              },
+              {
+                "code": "79386-9",
+                "display": "Escherichia coli Stx1 toxin stx1 gene [Presence] in Stool by NAA with probe detection",
+                "include": true
+              },
+              {
+                "code": "79387-7",
+                "display": "Escherichia coli Stx2 toxin stx2 gene [Presence] in Stool by NAA with probe detection",
+                "include": true
+              },
+              {
+                "code": "80348-6",
+                "display": "Escherichia coli enteropathogenic eae gene [Presence] in Stool by NAA with non-probe detection",
+                "include": true
+              },
+              {
+                "code": "80349-4",
+                "display": "Escherichia coli enteroaggregative pAA plasmid aggR+aatA genes [Presence] in Stool by NAA with non-probe detection",
+                "include": true
+              },
+              {
+                "code": "80350-2",
+                "display": "Shigella species+EIEC invasion plasmid antigen H ipaH gene [Presence] in Stool by NAA with non-probe detection",
+                "include": true
+              },
+              {
+                "code": "80351-0",
+                "display": "Escherichia coli enterotoxigenic ltA+st1a+st1b genes [Presence] in Stool by NAA with non-probe detection",
+                "include": true
+              },
+              {
+                "code": "80676-0",
+                "display": "Escherichia coli O157 rfbE gene [Presence] in Stool by NAA with probe detection",
+                "include": true
+              },
+              {
+                "code": "80677-8",
+                "display": "Escherichia coli enterotoxigenic eltA+estB genes [Presence] in Stool by NAA with probe detection",
+                "include": true
+              },
+              {
+                "code": "80678-6",
+                "display": "Salmonella sp invA+fliC genes [Presence] in Stool by NAA with probe detection",
+                "include": true
+              },
+              {
+                "code": "80679-4",
+                "display": "Escherichia coli Stx1 and Stx2 toxin stx1+stx2 genes [Presence] in Stool by NAA with probe detection",
+                "include": true
+              },
+              {
+                "code": "81285-9",
+                "display": "Escherichia coli Stx1 and Stx2 toxin stx1 and stx2 genes [Identifier] in Stool by NAA with probe detection",
+                "include": true
+              },
+              {
+                "code": "81657-9",
+                "display": "Salmonella sp spaO gene [Presence] in Stool by NAA with probe detection",
+                "include": true
+              },
+              {
+                "code": "82182-7",
+                "display": "Escherichia coli K1 DNA [Presence] in Cerebral spinal fluid by NAA with non-probe detection",
+                "include": true
+              },
+              {
+                "code": "82198-3",
+                "display": "Plesiomonas shigelloides DNA [Presence] in Stool by NAA with non-probe detection",
+                "include": true
+              },
+              {
+                "code": "82199-1",
+                "display": "Salmonella enterica+bongori DNA [Presence] in Stool by NAA with non-probe detection",
+                "include": true
+              },
+              {
+                "code": "82202-3",
+                "display": "Yersinia enterocolitica DNA [Presence] in Stool by NAA with non-probe detection",
+                "include": true
+              },
+              {
+                "code": "82203-1",
+                "display": "Escherichia coli Stx1 and Stx2 toxin stx1+stx2 genes [Presence] in Stool by NAA with non-probe detection",
+                "include": true
+              },
+              {
+                "code": "82204-9",
+                "display": "Escherichia coli O157 DNA [Presence] in Stool by NAA with non-probe detection",
+                "include": true
+              },
+              {
+                "code": "87394-3",
+                "display": "Salmonella sp DNA [Cycle Threshold #] in Specimen by NAA with probe detection",
+                "include": true
+              },
+              {
+                "code": "87951-0",
+                "display": "Escherichia coli eaeA gene [Presence] in Stool by NAA with probe detection",
+                "include": true
+              },
+              {
+                "code": "92723-6",
+                "display": "Yersinia enterocolitica DNA [Presence] in Stool by NAA with probe detection",
+                "include": true
+              },
+              {
+                "code": "92954-7",
+                "display": "Serratia marcescens DNA [NCncRange] in Sputum by NAA with non-probe detection",
+                "include": true
+              },
+              {
+                "code": "92955-4",
+                "display": "Serratia marcescens DNA [NCncRange] in Bronchoalveolar lavage by NAA with non-probe detection",
+                "include": true
+              },
+              {
+                "code": "92961-2",
+                "display": "Proteus sp DNA [NCncRange] in Sputum by NAA with non-probe detection",
+                "include": true
+              },
+              {
+                "code": "92962-0",
+                "display": "Proteus sp DNA [NCncRange] in Bronchoalveolar lavage by NAA with non-probe detection",
+                "include": true
+              },
+              {
+                "code": "92970-3",
+                "display": "Klebsiella pneumoniae+Klebsiella variicola+Klebsiella quasipneumoniae DNA [NCncRange] in Sputum by NAA with non-probe detection",
+                "include": true
+              },
+              {
+                "code": "92971-1",
+                "display": "Klebsiella pneumoniae+Klebsiella variicola+Klebsiella quasipneumoniae DNA [NCncRange] in Bronchoalveolar lavage by NAA with non-probe detection",
+                "include": true
+              },
+              {
+                "code": "92972-9",
+                "display": "Klebsiella oxytoca DNA [NCncRange] in Sputum by NAA with non-probe detection",
+                "include": true
+              },
+              {
+                "code": "92973-7",
+                "display": "Klebsiella oxytoca DNA [NCncRange] in Bronchoalveolar lavage by NAA with non-probe detection",
+                "include": true
+              },
+              {
+                "code": "92974-5",
+                "display": "Klebsiella aerogenes DNA [NCncRange] in Sputum by NAA with non-probe detection",
+                "include": true
+              },
+              {
+                "code": "92975-2",
+                "display": "Klebsiella aerogenes DNA [NCncRange] in Bronchoalveolar lavage by NAA with non-probe detection",
+                "include": true
+              },
+              {
+                "code": "92982-8",
+                "display": "Escherichia coli DNA [NCncRange] in Sputum by NAA with non-probe detection",
+                "include": true
+              },
+              {
+                "code": "92983-6",
+                "display": "Escherichia coli DNA [NCncRange] in Bronchoalveolar lavage by NAA with non-probe detection",
+                "include": true
+              },
+              {
+                "code": "92984-4",
+                "display": "Enterobacter cloacae complex DNA [NCncRange] in Sputum by NAA with non-probe detection",
+                "include": true
+              },
+              {
+                "code": "92985-1",
+                "display": "Enterobacter cloacae complex DNA [NCncRange] in Bronchoalveolar lavage by NAA with non-probe detection",
+                "include": true
+              },
+              {
+                "code": "94370-4",
+                "display": "Serratia marcescens DNA [Presence] in Lower respiratory specimen by NAA with probe detection",
+                "include": true
+              },
+              {
+                "code": "94372-0",
+                "display": "Proteus sp DNA [Presence] in Lower respiratory specimen by NAA with probe detection",
+                "include": true
+              },
+              {
+                "code": "94374-6",
+                "display": "Klebsiella pneumoniae DNA [Presence] in Lower respiratory specimen by NAA with probe detection",
+                "include": true
+              },
+              {
+                "code": "94375-3",
+                "display": "Klebsiella oxytoca DNA [Presence] in Lower respiratory specimen by NAA with probe detection",
+                "include": true
+              },
+              {
+                "code": "94376-1",
+                "display": "Klebsiella aerogenes DNA [Presence] in Lower respiratory specimen by NAA with probe detection",
+                "include": true
+              },
+              {
+                "code": "94378-7",
+                "display": "Escherichia coli DNA [Presence] in Lower respiratory specimen by NAA with probe detection",
+                "include": true
+              },
+              {
+                "code": "94379-5",
+                "display": "Enterobacter cloacae complex DNA [Presence] in Lower respiratory specimen by NAA with probe detection",
+                "include": true
+              },
+              {
+                "code": "94632-7",
+                "display": "Escherichia coli K99 DNA [Cycle Threshold #] in Specimen by NAA with probe detection",
+                "include": true
+              },
+              {
+                "code": "96318-1",
+                "display": "Enterobacter cloacae complex DNA [NCncRange] in Lower respiratory specimen by NAA with non-probe detection",
+                "include": true
+              },
+              {
+                "code": "96319-9",
+                "display": "Escherichia coli DNA [NCncRange] in Lower respiratory specimen by NAA with non-probe detection",
+                "include": true
+              },
+              {
+                "code": "96322-3",
+                "display": "Klebsiella oxytoca DNA [NCncRange] in Lower respiratory specimen by NAA with non-probe detection",
+                "include": true
+              },
+              {
+                "code": "96323-1",
+                "display": "Klebsiella aerogenes DNA [NCncRange] in Lower respiratory specimen by NAA with non-probe detection",
+                "include": true
+              },
+              {
+                "code": "96324-9",
+                "display": "Klebsiella pneumoniae+Klebsiella variicola+Klebsiella quasipneumoniae DNA [NCncRange] in Lower respiratory specimen by NAA with non-probe detection",
+                "include": true
+              },
+              {
+                "code": "96327-2",
+                "display": "Proteus sp DNA [NCncRange] in Lower respiratory specimen by NAA with non-probe detection",
+                "include": true
+              },
+              {
+                "code": "96329-8",
+                "display": "Serratia marcescens DNA [NCncRange] in Lower respiratory specimen by NAA with non-probe detection",
+                "include": true
+              },
+              {
+                "code": "97313-1",
+                "display": "Salmonella sp DNA [Presence] in Stool by NAA with probe detection",
+                "include": true
+              },
+              {
+                "code": "97317-2",
+                "display": "Escherichia coli enteroaggregative DNA [Presence] in Stool by NAA with probe detection",
+                "include": true
+              },
+              {
+                "code": "97318-0",
+                "display": "Escherichia coli enteropathogenic DNA [Presence] in Stool by NAA with probe detection",
+                "include": true
+              },
+              {
+                "code": "97319-8",
+                "display": "Escherichia coli enterotoxigenic DNA [Presence] in Stool by NAA with probe detection",
+                "include": true
+              },
+              {
+                "code": "97320-6",
+                "display": "Escherichia coli O157 DNA [Presence] in Stool by NAA with probe detection",
+                "include": true
+              },
+              {
+                "code": "97613-4",
+                "display": "Citrobacter sp DNA [Presence] in Synovial fluid by NAA with non-probe detection",
+                "include": true
+              },
+              {
+                "code": "97616-7",
+                "display": "Enterobacter cloacae complex DNA [Presence] in Synovial fluid by NAA with non-probe detection",
+                "include": true
+              },
+              {
+                "code": "97619-1",
+                "display": "Escherichia coli DNA [Presence] in Synovial fluid by NAA with non-probe detection",
+                "include": true
+              },
+              {
+                "code": "97623-3",
+                "display": "Klebsiella aerogenes DNA [Presence] in Synovial fluid by NAA with non-probe detection",
+                "include": true
+              },
+              {
+                "code": "97624-1",
+                "display": "Klebsiella pneumoniae+Klebsiella variicola+Klebsiella quasipneumoniae DNA [Presence] in Synovial fluid by NAA with non-probe detection",
+                "include": true
+              },
+              {
+                "code": "97625-8",
+                "display": "Morganella morganii DNA [Presence] in Synovial fluid by NAA with non-probe detection",
+                "include": true
+              },
+              {
+                "code": "97630-8",
+                "display": "Proteus sp DNA [Presence] in Synovial fluid by NAA with non-probe detection",
+                "include": true
+              },
+              {
+                "code": "97632-4",
+                "display": "Salmonella sp DNA [Presence] in Synovial fluid by NAA with non-probe detection",
+                "include": true
+              },
+              {
+                "code": "97633-2",
+                "display": "Serratia marcescens DNA [Presence] in Synovial fluid by NAA with non-probe detection",
+                "include": true
+              },
+              {
+                "code": "99014-3",
+                "display": "Citrobacter freundii DNA [Presence] in Urine by NAA with probe detection",
+                "include": true
+              },
+              {
+                "code": "99015-0",
+                "display": "Citrobacter koseri DNA [Presence] in Urine by NAA with probe detection",
+                "include": true
+              },
+              {
+                "code": "99016-8",
+                "display": "Enterobacter cloacae complex DNA [Presence] in Urine by NAA with probe detection",
+                "include": true
+              },
+              {
+                "code": "99019-2",
+                "display": "Escherichia coli DNA [Presence] in Urine by NAA with probe detection",
+                "include": true
+              },
+              {
+                "code": "99020-0",
+                "display": "Klebsiella aerogenes DNA [Presence] in Urine by NAA with probe detection",
+                "include": true
+              },
+              {
+                "code": "99021-8",
+                "display": "Klebsiella oxytoca DNA [Presence] in Urine by NAA with probe detection",
+                "include": true
+              },
+              {
+                "code": "99022-6",
+                "display": "Klebsiella pneumoniae DNA [Presence] in Urine by NAA with probe detection",
+                "include": true
+              },
+              {
+                "code": "99023-4",
+                "display": "Morganella morganii DNA [Presence] in Urine by NAA with probe detection",
+                "include": true
+              },
+              {
+                "code": "99024-2",
+                "display": "Proteus sp DNA [Presence] in Urine by NAA with probe detection",
+                "include": true
+              },
+              {
+                "code": "99025-9",
+                "display": "Providencia rettgeri DNA [Presence] in Urine by NAA with probe detection",
+                "include": true
+              },
+              {
+                "code": "99026-7",
+                "display": "Providencia stuartii DNA [Presence] in Urine by NAA with probe detection",
+                "include": true
+              },
+              {
+                "code": "99028-3",
+                "display": "Serratia marcescens DNA [Presence] in Urine by NAA with probe detection",
+                "include": true
+              },
+              {
+                "code": "99089-5",
+                "display": "Escherichia coli K1 DNA [Presence] in Cerebral spinal fluid by NAA with probe detection",
+                "include": true
+              }
+            ]
+          },
+          "2.16.840.1.113762.1.4.1146.2468_20250219": {
+            "valueSetId": "2.16.840.1.113762.1.4.1146.2468_20250219",
+            "valueSetVersion": "20250219",
+            "valueSetName": "CRE (Combination Tests that include Enterobacterales by Culture and Identification)",
+            "valueSetExternalId": "2.16.840.1.113762.1.4.1146.2468",
+            "author": "CSTE Steward",
+            "system": "http://loinc.org",
+            "ersdConceptType": "labs",
+            "dibbsConceptType": "labs",
+            "includeValueSet": true,
+            "concepts": [
+              {
+                "code": "103661-5",
+                "display": "Campylobacter and Salmonella and Shigella sp identified in Stool by Organism specific culture",
+                "include": true
+              },
+              {
+                "code": "103662-3",
+                "display": "Campylobacter and Salmonella and Shigella and Yersinia sp identified in Stool by Organism specific culture",
+                "include": true
+              },
+              {
+                "code": "103663-1",
+                "display": "Salmonella and Shigella and Campylobacter and E. coli sp identified in Stool by Organism specific culture",
+                "include": true
+              },
+              {
+                "code": "105620-9",
+                "display": "Campylobacter and Salmonella and Shigella sp # 2 identified in Stool by Organism specific culture",
+                "include": true
+              },
+              {
+                "code": "105621-7",
+                "display": "Campylobacter and Salmonella and Shigella sp # 3 identified in Stool by Organism specific culture",
+                "include": true
+              },
+              {
+                "code": "73961-5",
+                "display": "Escherichia coli and Klebsiella pneumoniae and Pseudomonas aeruginosa rRNA [Identifier] by FISH in Positive blood culture",
+                "include": true
+              }
+            ]
+          },
+          "2.16.840.1.113762.1.4.1146.2465_20250219": {
+            "valueSetId": "2.16.840.1.113762.1.4.1146.2465_20250219",
+            "valueSetVersion": "20250219",
+            "valueSetName": "CRE (Tests for Enterobacterales species [excluding Proteus spp., Providencia spp., and Morganella spp.] by Culture and Identification Method)",
+            "valueSetExternalId": "2.16.840.1.113762.1.4.1146.2465",
+            "author": "CSTE Steward",
+            "system": "http://loinc.org",
+            "ersdConceptType": "labs",
+            "dibbsConceptType": "labs",
+            "includeValueSet": true,
+            "concepts": [
+              {
+                "code": "100899-4",
+                "display": "Enterobacteriaceae.extended spectrum beta lactamase resistance phenotype [Identifier] in Specimen by Organism specific culture",
+                "include": true
+              },
+              {
+                "code": "100901-8",
+                "display": "Enterobacteriaceae.carbapenemase resistance phenotype [Identifier] in Anal by Organism specific culture",
+                "include": true
+              },
+              {
+                "code": "100902-6",
+                "display": "Enterobacteriaceae.carbapenemase resistance phenotype.OXA-48 [Identifier] in Anal by Organism specific culture",
+                "include": true
+              },
+              {
+                "code": "100909-1",
+                "display": "Cronobacter sakazakii [Presence] by Organism specific culture",
+                "include": true
+              },
+              {
+                "code": "101371-3",
+                "display": "Yersinia pestis DNA [Presence] by NAA with non-probe detection in Positive blood culture",
+                "include": true
+              },
+              {
+                "code": "101536-1",
+                "display": "Salmonella sp whole genome [Nucleotide sequence] in Isolate by Sequencing",
+                "include": true
+              },
+              {
+                "code": "103789-4",
+                "display": "Aeromonas and plesiomonas sp identified in Stool by Organism specific culture",
+                "include": true
+              },
+              {
+                "code": "104447-8",
+                "display": "Salmonella paratyphi DNA [Presence] in Isolate by NAA with probe detection",
+                "include": true
+              },
+              {
+                "code": "104448-6",
+                "display": "Salmonella paratyphi [Identifier] in Isolate by Agglutination",
+                "include": true
+              },
+              {
+                "code": "104450-2",
+                "display": "Salmonella typhi DNA [Presence] in Isolate by NAA with probe detection",
+                "include": true
+              },
+              {
+                "code": "104767-9",
+                "display": "Salmonella sp [Identifier] in Isolate by Sequencing",
+                "include": true
+              },
+              {
+                "code": "104772-9",
+                "display": "Salmonella sp serotype [Identifier] in Isolate by Sequencing",
+                "include": true
+              },
+              {
+                "code": "104774-5",
+                "display": "Salmonella sp antigenic formula [Identifier] in Isolate by Sequencing",
+                "include": true
+              },
+              {
+                "code": "105764-5",
+                "display": "Enterobacter spp DNA [Cycle Threshold #] in Positive blood culture by NAA with probe detection",
+                "include": true
+              },
+              {
+                "code": "105765-2",
+                "display": "Escherichia coli DNA [Cycle Threshold #] in Positive blood culture by NAA with probe detection",
+                "include": true
+              },
+              {
+                "code": "105766-0",
+                "display": "Klebsiella spp DNA [Cycle Threshold #] in Positive blood culture by NAA with probe detection",
+                "include": true
+              },
+              {
+                "code": "105768-6",
+                "display": "Salmonella spp DNA [Cycle Threshold #] in Positive blood culture by NAA with probe detection",
+                "include": true
+              },
+              {
+                "code": "105769-4",
+                "display": "Serratia spp DNA [Cycle Threshold #] in Positive blood culture by NAA with probe detection",
+                "include": true
+              },
+              {
+                "code": "105776-9",
+                "display": "Enterobacterales DNA [Cycle Threshold #] in Positive blood culture by NAA with probe detection",
+                "include": true
+              },
+              {
+                "code": "10851-4",
+                "display": "Escherichia coli O157:H7 [Presence] in Stool by Organism specific culture",
+                "include": true
+              },
+              {
+                "code": "13318-1",
+                "display": "Escherichia coli enteroinvasive identified in Stool by Organism specific culture",
+                "include": true
+              },
+              {
+                "code": "16832-8",
+                "display": "Escherichia coli enterotoxic identified in Stool by Organism specific culture",
+                "include": true
+              },
+              {
+                "code": "16835-1",
+                "display": "Escherichia coli shiga-like toxin identified in Stool by Organism specific culture",
+                "include": true
+              },
+              {
+                "code": "16836-9",
+                "display": "Escherichia coli verotoxic identified in Stool by Organism specific culture",
+                "include": true
+              },
+              {
+                "code": "17563-8",
+                "display": "Salmonella sp identified in Specimen by Organism specific culture",
+                "include": true
+              },
+              {
+                "code": "17576-0",
+                "display": "Shigella sp identified in Specimen by Organism specific culture",
+                "include": true
+              },
+              {
+                "code": "20789-4",
+                "display": "Escherichia coli serotype [Identifier] in Isolate",
+                "include": true
+              },
+              {
+                "code": "20811-6",
+                "display": "Escherichia coli [Presence] in Specimen by Culture FDA method",
+                "include": true
+              },
+              {
+                "code": "20813-2",
+                "display": "Escherichia coli F41 [Presence] in Isolate by Agglutination",
+                "include": true
+              },
+              {
+                "code": "20816-5",
+                "display": "Escherichia coli K88 [Presence] in Isolate by Agglutination",
+                "include": true
+              },
+              {
+                "code": "20819-9",
+                "display": "Escherichia coli K99 [Presence] in Isolate by Agglutination",
+                "include": true
+              },
+              {
+                "code": "20823-1",
+                "display": "Escherichia coli O157:H7 [Presence] in Raw milk by Organism specific culture",
+                "include": true
+              },
+              {
+                "code": "20951-0",
+                "display": "Salmonella sp serotype [Identifier] in Isolate by Agglutination",
+                "include": true
+              },
+              {
+                "code": "20953-6",
+                "display": "Salmonella sp identified in Tissue by Organism specific culture",
+                "include": true
+              },
+              {
+                "code": "20955-1",
+                "display": "Salmonella sp identified in Stool by Organism specific culture",
+                "include": true
+              },
+              {
+                "code": "20964-3",
+                "display": "Shigella sp identified in Feed by Organism specific culture",
+                "include": true
+              },
+              {
+                "code": "23602-6",
+                "display": "Salmonella enteritidis [Presence] in Stool by Organism specific culture",
+                "include": true
+              },
+              {
+                "code": "28549-4",
+                "display": "Yersinia sp identified in Stool by Organism specific culture",
+                "include": true
+              },
+              {
+                "code": "33685-9",
+                "display": "Yersinia pestis [Presence] in Specimen by Organism specific culture",
+                "include": true
+              },
+              {
+                "code": "33686-7",
+                "display": "Yersinia pestis [Presence] in Isolate by Organism specific culture",
+                "include": true
+              },
+              {
+                "code": "33688-3",
+                "display": "Yersinia pestis Ag [Presence] in Isolate by Immunofluorescence",
+                "include": true
+              },
+              {
+                "code": "33692-5",
+                "display": "Yersinia pestis DNA [Presence] in Isolate by NAA with probe detection",
+                "include": true
+              },
+              {
+                "code": "33693-3",
+                "display": "Yersinia pestis [Presence] in Isolate by Phage lysis",
+                "include": true
+              },
+              {
+                "code": "34891-2",
+                "display": "Salmonella enteritidis [Presence] in Specimen by Organism specific culture",
+                "include": true
+              },
+              {
+                "code": "42255-0",
+                "display": "Salmonella and Shigella sp identified in Specimen by Organism specific culture",
+                "include": true
+              },
+              {
+                "code": "42256-8",
+                "display": "Shigella boydii Ag [Presence] in Isolate",
+                "include": true
+              },
+              {
+                "code": "42257-6",
+                "display": "Shigella dysenteriae Ag [Presence] in Isolate",
+                "include": true
+              },
+              {
+                "code": "42258-4",
+                "display": "Shigella flexneri Ag [Presence] in Isolate",
+                "include": true
+              },
+              {
+                "code": "42259-2",
+                "display": "Shigella sonnei Ag [Presence] in Isolate",
+                "include": true
+              },
+              {
+                "code": "43371-4",
+                "display": "Salmonella and Shigella sp identified in Stool by Organism specific culture",
+                "include": true
+              },
+              {
+                "code": "44089-1",
+                "display": "Escherichia coli O157:H7 [Identifier] in Specimen by Organism specific culture",
+                "include": true
+              },
+              {
+                "code": "44090-9",
+                "display": "Escherichia coli O157:H7 [Presence] in Isolate by Organism specific culture",
+                "include": true
+              },
+              {
+                "code": "45162-5",
+                "display": "Escherichia coli O157 Ag [Presence] in Isolate by Latex agglutination",
+                "include": true
+              },
+              {
+                "code": "46454-5",
+                "display": "Shigella sp [Presence] in Specimen by Organism specific culture",
+                "include": true
+              },
+              {
+                "code": "48806-4",
+                "display": "Salmonella sp+Shigella sp+Escherichia coli enterotoxic identified in Stool by Organism specific culture",
+                "include": true
+              },
+              {
+                "code": "49056-5",
+                "display": "Shigella sp serotype [Identifier] in Isolate by Agglutination",
+                "include": true
+              },
+              {
+                "code": "53944-5",
+                "display": "Escherichia coli enteroinvasive [Presence] in Isolate",
+                "include": true
+              },
+              {
+                "code": "53945-2",
+                "display": "Escherichia coli adherence pattern [Identifier] in Isolate by Hep2 substrate",
+                "include": true
+              },
+              {
+                "code": "53955-1",
+                "display": "Escherichia coli O157 identified in Isolate by Organism specific culture",
+                "include": true
+              },
+              {
+                "code": "53956-9",
+                "display": "Salmonella typhi [Identifier] in Isolate by Agglutination",
+                "include": true
+              },
+              {
+                "code": "56475-7",
+                "display": "Salmonella sp antigenic formula [Identifier] in Isolate by Agglutination",
+                "include": true
+              },
+              {
+                "code": "59846-6",
+                "display": "Salmonella sp identified [Type] in Isolate",
+                "include": true
+              },
+              {
+                "code": "65756-9",
+                "display": "Salmonella sp serovar [Type] in Isolate",
+                "include": true
+              },
+              {
+                "code": "6595-3",
+                "display": "Klebsiella granulomatis [Presence] in Isolate by Organism specific culture",
+                "include": true
+              },
+              {
+                "code": "701-3",
+                "display": "Yersinia sp identified in Specimen by Organism specific culture",
+                "include": true
+              },
+              {
+                "code": "73664-5",
+                "display": "Yersinia adhesion protein YadA [Presence] in Isolate",
+                "include": true
+              },
+              {
+                "code": "73673-6",
+                "display": "Yersinia enterocolitica serotype [Type] in Isolate by Agglutination",
+                "include": true
+              },
+              {
+                "code": "77924-9",
+                "display": "Enterobacteriaceae.carbapenem resistant [Presence] in Anorectal or stool specimen by Organism specific culture",
+                "include": true
+              },
+              {
+                "code": "82298-1",
+                "display": "Yersinia enterocolitica [Presence] in Specimen by Culture",
+                "include": true
+              },
+              {
+                "code": "82300-5",
+                "display": "Shigella sp [Presence] in Stool by Culture",
+                "include": true
+              },
+              {
+                "code": "82301-3",
+                "display": "Salmonella sp [Presence] in Stool by Culture",
+                "include": true
+              },
+              {
+                "code": "82303-9",
+                "display": "Escherichia coli O157 [Presence] in Stool by Culture",
+                "include": true
+              },
+              {
+                "code": "82304-7",
+                "display": "Plesiomonas shigelloides [Presence] in Stool by Culture",
+                "include": true
+              },
+              {
+                "code": "85761-5",
+                "display": "Klebsiella pneumoniae DNA [Presence] by NAA with non-probe detection in Positive blood culture",
+                "include": true
+              },
+              {
+                "code": "85771-4",
+                "display": "Enterobacteriaceae DNA [Presence] by NAA with non-probe detection in Positive blood culture",
+                "include": true
+              },
+              {
+                "code": "85772-2",
+                "display": "Enterobacter cloacae complex DNA [Presence] by NAA with non-probe detection in Positive blood culture",
+                "include": true
+              },
+              {
+                "code": "85773-0",
+                "display": "Escherichia coli DNA [Presence] by NAA with non-probe detection in Positive blood culture",
+                "include": true
+              },
+              {
+                "code": "85774-8",
+                "display": "Klebsiella oxytoca DNA [Presence] by NAA with non-probe detection in Positive blood culture",
+                "include": true
+              },
+              {
+                "code": "85777-1",
+                "display": "Serratia marcescens DNA [Presence] by NAA with non-probe detection in Positive blood culture",
+                "include": true
+              },
+              {
+                "code": "87318-2",
+                "display": "Escherichia coli eaeA gene [Presence] in Isolate by NAA with probe detection",
+                "include": true
+              },
+              {
+                "code": "87319-0",
+                "display": "Escherichia coli enteroaggregative astA gene [Presence] in Isolate by NAA with probe detection",
+                "include": true
+              },
+              {
+                "code": "87320-8",
+                "display": "Escherichia coli enterotoxigenic heat-labile toxin DNA [Presence] in Isolate by NAA with probe detection",
+                "include": true
+              },
+              {
+                "code": "87321-6",
+                "display": "Escherichia coli enterotoxigenic sta gene [Presence] in Isolate by NAA with probe detection",
+                "include": true
+              },
+              {
+                "code": "87322-4",
+                "display": "Escherichia coli enterotoxigenic stb gene [Presence] in Isolate by NAA with probe detection",
+                "include": true
+              },
+              {
+                "code": "87370-3",
+                "display": "Escherichia coli fasA gene [Presence] in Isolate by NAA with probe detection",
+                "include": true
+              },
+              {
+                "code": "87371-1",
+                "display": "Escherichia coli fedF gene [Presence] in Isolate by NAA with probe detection",
+                "include": true
+              },
+              {
+                "code": "87372-9",
+                "display": "Escherichia coli FimF41a gene [Presence] in Isolate by NAA with probe detection",
+                "include": true
+              },
+              {
+                "code": "87373-7",
+                "display": "Escherichia coli K88 DNA [Presence] in Isolate by NAA with probe detection",
+                "include": true
+              },
+              {
+                "code": "87374-5",
+                "display": "Escherichia coli K99 DNA [Presence] in Isolate by NAA with probe detection",
+                "include": true
+              },
+              {
+                "code": "87375-2",
+                "display": "Escherichia coli paa gene [Presence] in Isolate by NAA with probe detection",
+                "include": true
+              },
+              {
+                "code": "87376-0",
+                "display": "Escherichia coli Stx1 toxin stx1 gene [Presence] in Isolate by NAA with probe detection",
+                "include": true
+              },
+              {
+                "code": "87377-8",
+                "display": "Escherichia coli Stx2 toxin stx2 gene [Presence] in Isolate by NAA with probe detection",
+                "include": true
+              },
+              {
+                "code": "87380-2",
+                "display": "Escherichia coli Stx2e toxin stx2e gene [Presence] in Isolate by NAA with probe detection",
+                "include": true
+              },
+              {
+                "code": "87402-4",
+                "display": "Escherichia coli aidA-I gene [Presence] in Isolate by NAA with probe detection",
+                "include": true
+              },
+              {
+                "code": "88254-8",
+                "display": "Citrobacter sp ompA+mrkC genes [Presence] by Probe in Positive blood culture",
+                "include": true
+              },
+              {
+                "code": "88255-5",
+                "display": "Enterobacter sp gyrB+metB genes [Presence] by Probe in Positive blood culture",
+                "include": true
+              },
+              {
+                "code": "88258-9",
+                "display": "Escherichia coli oppA gene [Presence] by Probe in Positive blood culture",
+                "include": true
+              },
+              {
+                "code": "88263-9",
+                "display": "Klebsiella oxytoca ompA gene [Presence] by Probe in Positive blood culture",
+                "include": true
+              },
+              {
+                "code": "88264-7",
+                "display": "Klebsiella pneumoniae yggE gene [Presence] by Probe in Positive blood culture",
+                "include": true
+              },
+              {
+                "code": "88586-3",
+                "display": "Shigella sp identified in Stool by Organism specific culture",
+                "include": true
+              },
+              {
+                "code": "90067-0",
+                "display": "Enterobacteriaceae identified in Isolate by Organism specific culture",
+                "include": true
+              },
+              {
+                "code": "93384-6",
+                "display": "Serratia sp DNA [Presence] by NAA with probe detection in Positive blood culture",
+                "include": true
+              },
+              {
+                "code": "93385-3",
+                "display": "Salmonella sp DNA [Presence] by NAA with probe detection in Positive blood culture",
+                "include": true
+              },
+              {
+                "code": "93392-9",
+                "display": "Serratia marcescens DNA [Presence] by NAA with probe detection in Positive blood culture",
+                "include": true
+              },
+              {
+                "code": "93395-2",
+                "display": "Klebsiella pneumoniae DNA [Presence] by NAA with probe detection in Positive blood culture",
+                "include": true
+              },
+              {
+                "code": "93398-6",
+                "display": "Klebsiella oxytoca DNA [Presence] by NAA with probe detection in Positive blood culture",
+                "include": true
+              },
+              {
+                "code": "93400-0",
+                "display": "Enterobacter aerogenes+Enterobacter amnigenus+Enterobacter gergoviae DNA [Presence] by NAA with probe detection in Positive blood culture",
+                "include": true
+              },
+              {
+                "code": "93401-8",
+                "display": "Escherichia coli DNA [Presence] by NAA with probe detection in Positive blood culture",
+                "include": true
+              },
+              {
+                "code": "93402-6",
+                "display": "Cronobacter sakazakii DNA [Presence] by NAA with probe detection in Positive blood culture",
+                "include": true
+              },
+              {
+                "code": "93403-4",
+                "display": "Citrobacter sp DNA [Presence] by NAA with probe detection in Positive blood culture",
+                "include": true
+              },
+              {
+                "code": "93404-2",
+                "display": "Enterobacter cloacae complex DNA [Presence] by NAA with probe detection in Positive blood culture",
+                "include": true
+              },
+              {
+                "code": "96306-6",
+                "display": "Enterobacterales DNA [Presence] by NAA with non-probe detection in Positive blood culture",
+                "include": true
+              },
+              {
+                "code": "96307-4",
+                "display": "Klebsiella pneumoniae+Klebsiella variicola+Klebsiella quasipneumoniae DNA [Presence] by NAA with non-probe detection in Positive blood culture",
+                "include": true
+              },
+              {
+                "code": "96308-2",
+                "display": "Klebsiella aerogenes DNA [Presence] by NAA with non-probe detection in Positive blood culture",
+                "include": true
+              },
+              {
+                "code": "96313-2",
+                "display": "Salmonella sp DNA [Presence] by NAA with non-probe detection in Positive blood culture",
+                "include": true
+              }
+            ]
+          },
+          "2.16.840.1.113762.1.4.1146.2466_20250219": {
+            "valueSetId": "2.16.840.1.113762.1.4.1146.2466_20250219",
+            "valueSetVersion": "20250219",
+            "valueSetName": "CRE (Tests for Proteus spp., Providencia spp., and Morganella spp. by Culture and Identification Method)",
+            "valueSetExternalId": "2.16.840.1.113762.1.4.1146.2466",
+            "author": "CSTE Steward",
+            "system": "http://loinc.org",
+            "ersdConceptType": "labs",
+            "dibbsConceptType": "labs",
+            "includeValueSet": true,
+            "concepts": [
+              {
+                "code": "105767-8",
+                "display": "Proteus sp DNA [Cycle Threshold #] in Positive blood culture by NAA with probe detection",
+                "include": true
+              },
+              {
+                "code": "85776-3",
+                "display": "Proteus sp DNA [Presence] by NAA with non-probe detection in Positive blood culture",
+                "include": true
+              },
+              {
+                "code": "88267-0",
+                "display": "Proteus sp atpD gene [Presence] by Probe in Positive blood culture",
+                "include": true
+              },
+              {
+                "code": "93387-9",
+                "display": "Proteus mirabilis DNA [Presence] by NAA with probe detection in Positive blood culture",
+                "include": true
+              },
+              {
+                "code": "93393-7",
+                "display": "Proteus sp DNA [Presence] by NAA with probe detection in Positive blood culture",
+                "include": true
+              },
+              {
+                "code": "93394-5",
+                "display": "Morganella morganii DNA [Presence] by NAA with probe detection in Positive blood culture",
+                "include": true
+              }
+            ]
+          },
+          "2.16.840.1.113762.1.4.1146.1880_20250219": {
+            "valueSetId": "2.16.840.1.113762.1.4.1146.1880_20250219",
+            "valueSetVersion": "20250219",
+            "valueSetName": "Tests for Enterobacter spp., E. coli, or Klebsiella spp. Nucleic Acid",
+            "valueSetExternalId": "2.16.840.1.113762.1.4.1146.1880",
+            "author": "CSTE Steward",
+            "system": "http://loinc.org",
+            "ersdConceptType": "labs",
+            "dibbsConceptType": "labs",
+            "includeValueSet": true,
+            "concepts": [
+              {
+                "code": "101558-5",
+                "display": "Escherichia coli enteroinvasive DNA [Presence] in Stool by NAA with probe detection",
+                "include": true
+              },
+              {
+                "code": "103162-4",
+                "display": "Escherichia coli enteropathogenic DNA [Presence] in Wound by NAA with probe detection",
+                "include": true
+              },
+              {
+                "code": "103173-1",
+                "display": "Enterobacter aerogenes+Enterobacter cloacae DNA [Presence] in Specimen by NAA with probe detection",
+                "include": true
+              },
+              {
+                "code": "103174-9",
+                "display": "Enterobacter spp DNA [Presence] in Wound by NAA with probe detection",
+                "include": true
+              },
+              {
+                "code": "103176-4",
+                "display": "Escherichia coli enteroinvasive DNA [Presence] in Wound by NAA with probe detection",
+                "include": true
+              },
+              {
+                "code": "103177-2",
+                "display": "Escherichia coli enterotoxigenic DNA [Presence] in Wound by NAA with probe detection",
+                "include": true
+              },
+              {
+                "code": "103187-1",
+                "display": "Klebsiella pneumoniae DNA [Presence] in Respiratory system specimen by NAA with probe detection",
+                "include": true
+              },
+              {
+                "code": "103555-9",
+                "display": "Escherichia coli O157:H7 DNA [Presence] in Wound by NAA with probe detection",
+                "include": true
+              },
+              {
+                "code": "103622-7",
+                "display": "Enterobacter spp DNA [Presence] in Specimen by NAA with probe detection",
+                "include": true
+              },
+              {
+                "code": "105650-6",
+                "display": "Enterobacter cloacae DNA [Presence] in Specimen by NAA with probe detection",
+                "include": true
+              },
+              {
+                "code": "105651-4",
+                "display": "Enterobacter cloacae complex DNA [Presence] in Specimen by NAA with probe detection",
+                "include": true
+              },
+              {
+                "code": "105652-2",
+                "display": "Enterobacter hormaechei DNA [Presence] in Specimen by NAA with probe detection",
+                "include": true
+              },
+              {
+                "code": "105653-0",
+                "display": "Enterobacter roggenkampii DNA [Presence] in Specimen by NAA with probe detection",
+                "include": true
+              },
+              {
+                "code": "105662-1",
+                "display": "Klebsiella oxytoca DNA [Presence] in Specimen by NAA with probe detection",
+                "include": true
+              },
+              {
+                "code": "105663-9",
+                "display": "Klebsiella variicola subspecies. tropica DNA [Presence] in Specimen by NAA with probe detection",
+                "include": true
+              },
+              {
+                "code": "38990-8",
+                "display": "Escherichia coli O157:H7 DNA [Presence] in Specimen by NAA with probe detection",
+                "include": true
+              },
+              {
+                "code": "44088-3",
+                "display": "Escherichia coli O157:H7 DNA [Identifier] in Specimen by NAA with probe detection",
+                "include": true
+              },
+              {
+                "code": "53947-8",
+                "display": "Escherichia coli Stx1 and Stx2 toxin stx1 and stx2 and H7 flagellar fliC genes [Identifier] in Specimen by NAA with probe detection",
+                "include": true
+              },
+              {
+                "code": "61361-2",
+                "display": "Klebsiella aerogenes DNA [Presence] in Specimen by NAA with probe detection",
+                "include": true
+              },
+              {
+                "code": "61398-4",
+                "display": "Escherichia coli DNA [Presence] in Specimen by NAA with probe detection",
+                "include": true
+              },
+              {
+                "code": "61399-2",
+                "display": "Klebsiella pneumoniae DNA [Presence] in Specimen by NAA with probe detection",
+                "include": true
+              },
+              {
+                "code": "63423-8",
+                "display": "Escherichia coli eaeA gene [Presence] in Specimen by NAA with probe detection",
+                "include": true
+              },
+              {
+                "code": "63427-9",
+                "display": "Escherichia coli Stx1 toxin stx1 gene [Presence] in Specimen by NAA with probe detection",
+                "include": true
+              },
+              {
+                "code": "63428-7",
+                "display": "Escherichia coli Stx2 toxin stx2 gene [Presence] in Specimen by NAA with probe detection",
+                "include": true
+              },
+              {
+                "code": "70019-5",
+                "display": "Klebsiella oxytoca DNA [Presence] in Blood by NAA with probe detection",
+                "include": true
+              },
+              {
+                "code": "76583-4",
+                "display": "Klebsiella pneumoniae phoE gene [Presence] in Swab specimen by NAA with probe detection",
+                "include": true
+              },
+              {
+                "code": "76598-2",
+                "display": "Klebsiella pneumoniae phoE gene [#/mass] in XXX.tissue by NAA with probe detection",
+                "include": true
+              },
+              {
+                "code": "76611-3",
+                "display": "Klebsiella pneumoniae phoE gene [#/volume] in XXX.body fluid by NAA with probe detection",
+                "include": true
+              },
+              {
+                "code": "79386-9",
+                "display": "Escherichia coli Stx1 toxin stx1 gene [Presence] in Stool by NAA with probe detection",
+                "include": true
+              },
+              {
+                "code": "79387-7",
+                "display": "Escherichia coli Stx2 toxin stx2 gene [Presence] in Stool by NAA with probe detection",
+                "include": true
+              },
+              {
+                "code": "80348-6",
+                "display": "Escherichia coli enteropathogenic eae gene [Presence] in Stool by NAA with non-probe detection",
+                "include": true
+              },
+              {
+                "code": "80349-4",
+                "display": "Escherichia coli enteroaggregative pAA plasmid aggR+aatA genes [Presence] in Stool by NAA with non-probe detection",
+                "include": true
+              },
+              {
+                "code": "80351-0",
+                "display": "Escherichia coli enterotoxigenic ltA+st1a+st1b genes [Presence] in Stool by NAA with non-probe detection",
+                "include": true
+              },
+              {
+                "code": "80676-0",
+                "display": "Escherichia coli O157 rfbE gene [Presence] in Stool by NAA with probe detection",
+                "include": true
+              },
+              {
+                "code": "80677-8",
+                "display": "Escherichia coli enterotoxigenic eltA+estB genes [Presence] in Stool by NAA with probe detection",
+                "include": true
+              },
+              {
+                "code": "80679-4",
+                "display": "Escherichia coli Stx1 and Stx2 toxin stx1+stx2 genes [Presence] in Stool by NAA with probe detection",
+                "include": true
+              },
+              {
+                "code": "81285-9",
+                "display": "Escherichia coli Stx1 and Stx2 toxin stx1 and stx2 genes [Identifier] in Stool by NAA with probe detection",
+                "include": true
+              },
+              {
+                "code": "81659-5",
+                "display": "Escherichia coli Stx1 and Stx2 toxin stx1 and stx2 genes panel - Stool by NAA with probe detection",
+                "include": true
+              },
+              {
+                "code": "82182-7",
+                "display": "Escherichia coli K1 DNA [Presence] in Cerebral spinal fluid by NAA with non-probe detection",
+                "include": true
+              },
+              {
+                "code": "82203-1",
+                "display": "Escherichia coli Stx1 and Stx2 toxin stx1+stx2 genes [Presence] in Stool by NAA with non-probe detection",
+                "include": true
+              },
+              {
+                "code": "82204-9",
+                "display": "Escherichia coli O157 DNA [Presence] in Stool by NAA with non-probe detection",
+                "include": true
+              },
+              {
+                "code": "87318-2",
+                "display": "Escherichia coli eaeA gene [Presence] in Isolate by NAA with probe detection",
+                "include": true
+              },
+              {
+                "code": "87319-0",
+                "display": "Escherichia coli enteroaggregative astA gene [Presence] in Isolate by NAA with probe detection",
+                "include": true
+              },
+              {
+                "code": "87320-8",
+                "display": "Escherichia coli enterotoxigenic heat-labile toxin DNA [Presence] in Isolate by NAA with probe detection",
+                "include": true
+              },
+              {
+                "code": "87321-6",
+                "display": "Escherichia coli enterotoxigenic sta gene [Presence] in Isolate by NAA with probe detection",
+                "include": true
+              },
+              {
+                "code": "87322-4",
+                "display": "Escherichia coli enterotoxigenic stb gene [Presence] in Isolate by NAA with probe detection",
+                "include": true
+              },
+              {
+                "code": "87370-3",
+                "display": "Escherichia coli fasA gene [Presence] in Isolate by NAA with probe detection",
+                "include": true
+              },
+              {
+                "code": "87371-1",
+                "display": "Escherichia coli fedF gene [Presence] in Isolate by NAA with probe detection",
+                "include": true
+              },
+              {
+                "code": "87372-9",
+                "display": "Escherichia coli FimF41a gene [Presence] in Isolate by NAA with probe detection",
+                "include": true
+              },
+              {
+                "code": "87373-7",
+                "display": "Escherichia coli K88 DNA [Presence] in Isolate by NAA with probe detection",
+                "include": true
+              },
+              {
+                "code": "87374-5",
+                "display": "Escherichia coli K99 DNA [Presence] in Isolate by NAA with probe detection",
+                "include": true
+              },
+              {
+                "code": "87375-2",
+                "display": "Escherichia coli paa gene [Presence] in Isolate by NAA with probe detection",
+                "include": true
+              },
+              {
+                "code": "87376-0",
+                "display": "Escherichia coli Stx1 toxin stx1 gene [Presence] in Isolate by NAA with probe detection",
+                "include": true
+              },
+              {
+                "code": "87377-8",
+                "display": "Escherichia coli Stx2 toxin stx2 gene [Presence] in Isolate by NAA with probe detection",
+                "include": true
+              },
+              {
+                "code": "87380-2",
+                "display": "Escherichia coli Stx2e toxin stx2e gene [Presence] in Isolate by NAA with probe detection",
+                "include": true
+              },
+              {
+                "code": "87402-4",
+                "display": "Escherichia coli aidA-I gene [Presence] in Isolate by NAA with probe detection",
+                "include": true
+              },
+              {
+                "code": "87951-0",
+                "display": "Escherichia coli eaeA gene [Presence] in Stool by NAA with probe detection",
+                "include": true
+              },
+              {
+                "code": "88116-9",
+                "display": "Escherichia coli gene panel - Specimen by NAA with probe detection",
+                "include": true
+              },
+              {
+                "code": "88125-0",
+                "display": "Escherichia coli enterotoxigenic gene panel - Specimen by NAA with probe detection",
+                "include": true
+              },
+              {
+                "code": "92970-3",
+                "display": "Klebsiella pneumoniae+Klebsiella variicola+Klebsiella quasipneumoniae DNA [NCncRange] in Sputum by NAA with non-probe detection",
+                "include": true
+              },
+              {
+                "code": "92971-1",
+                "display": "Klebsiella pneumoniae+Klebsiella variicola+Klebsiella quasipneumoniae DNA [NCncRange] in Bronchoalveolar lavage by NAA with non-probe detection",
+                "include": true
+              },
+              {
+                "code": "92972-9",
+                "display": "Klebsiella oxytoca DNA [NCncRange] in Sputum by NAA with non-probe detection",
+                "include": true
+              },
+              {
+                "code": "92973-7",
+                "display": "Klebsiella oxytoca DNA [NCncRange] in Bronchoalveolar lavage by NAA with non-probe detection",
+                "include": true
+              },
+              {
+                "code": "92974-5",
+                "display": "Klebsiella aerogenes DNA [NCncRange] in Sputum by NAA with non-probe detection",
+                "include": true
+              },
+              {
+                "code": "92975-2",
+                "display": "Klebsiella aerogenes DNA [NCncRange] in Bronchoalveolar lavage by NAA with non-probe detection",
+                "include": true
+              },
+              {
+                "code": "92982-8",
+                "display": "Escherichia coli DNA [NCncRange] in Sputum by NAA with non-probe detection",
+                "include": true
+              },
+              {
+                "code": "92983-6",
+                "display": "Escherichia coli DNA [NCncRange] in Bronchoalveolar lavage by NAA with non-probe detection",
+                "include": true
+              },
+              {
+                "code": "92984-4",
+                "display": "Enterobacter cloacae complex DNA [NCncRange] in Sputum by NAA with non-probe detection",
+                "include": true
+              },
+              {
+                "code": "92985-1",
+                "display": "Enterobacter cloacae complex DNA [NCncRange] in Bronchoalveolar lavage by NAA with non-probe detection",
+                "include": true
+              },
+              {
+                "code": "94374-6",
+                "display": "Klebsiella pneumoniae DNA [Presence] in Lower respiratory specimen by NAA with probe detection",
+                "include": true
+              },
+              {
+                "code": "94375-3",
+                "display": "Klebsiella oxytoca DNA [Presence] in Lower respiratory specimen by NAA with probe detection",
+                "include": true
+              },
+              {
+                "code": "94376-1",
+                "display": "Klebsiella aerogenes DNA [Presence] in Lower respiratory specimen by NAA with probe detection",
+                "include": true
+              },
+              {
+                "code": "94378-7",
+                "display": "Escherichia coli DNA [Presence] in Lower respiratory specimen by NAA with probe detection",
+                "include": true
+              },
+              {
+                "code": "94379-5",
+                "display": "Enterobacter cloacae complex DNA [Presence] in Lower respiratory specimen by NAA with probe detection",
+                "include": true
+              },
+              {
+                "code": "94632-7",
+                "display": "Escherichia coli K99 DNA [Cycle Threshold #] in Specimen by NAA with probe detection",
+                "include": true
+              },
+              {
+                "code": "96318-1",
+                "display": "Enterobacter cloacae complex DNA [NCncRange] in Lower respiratory specimen by NAA with non-probe detection",
+                "include": true
+              },
+              {
+                "code": "96319-9",
+                "display": "Escherichia coli DNA [NCncRange] in Lower respiratory specimen by NAA with non-probe detection",
+                "include": true
+              },
+              {
+                "code": "96322-3",
+                "display": "Klebsiella oxytoca DNA [NCncRange] in Lower respiratory specimen by NAA with non-probe detection",
+                "include": true
+              },
+              {
+                "code": "96323-1",
+                "display": "Klebsiella aerogenes DNA [NCncRange] in Lower respiratory specimen by NAA with non-probe detection",
+                "include": true
+              },
+              {
+                "code": "96324-9",
+                "display": "Klebsiella pneumoniae+Klebsiella variicola+Klebsiella quasipneumoniae DNA [NCncRange] in Lower respiratory specimen by NAA with non-probe detection",
+                "include": true
+              },
+              {
+                "code": "97317-2",
+                "display": "Escherichia coli enteroaggregative DNA [Presence] in Stool by NAA with probe detection",
+                "include": true
+              },
+              {
+                "code": "97318-0",
+                "display": "Escherichia coli enteropathogenic DNA [Presence] in Stool by NAA with probe detection",
+                "include": true
+              },
+              {
+                "code": "97319-8",
+                "display": "Escherichia coli enterotoxigenic DNA [Presence] in Stool by NAA with probe detection",
+                "include": true
+              },
+              {
+                "code": "97320-6",
+                "display": "Escherichia coli O157 DNA [Presence] in Stool by NAA with probe detection",
+                "include": true
+              },
+              {
+                "code": "97616-7",
+                "display": "Enterobacter cloacae complex DNA [Presence] in Synovial fluid by NAA with non-probe detection",
+                "include": true
+              },
+              {
+                "code": "97619-1",
+                "display": "Escherichia coli DNA [Presence] in Synovial fluid by NAA with non-probe detection",
+                "include": true
+              },
+              {
+                "code": "97623-3",
+                "display": "Klebsiella aerogenes DNA [Presence] in Synovial fluid by NAA with non-probe detection",
+                "include": true
+              },
+              {
+                "code": "97624-1",
+                "display": "Klebsiella pneumoniae+Klebsiella variicola+Klebsiella quasipneumoniae DNA [Presence] in Synovial fluid by NAA with non-probe detection",
+                "include": true
+              },
+              {
+                "code": "99016-8",
+                "display": "Enterobacter cloacae complex DNA [Presence] in Urine by NAA with probe detection",
+                "include": true
+              },
+              {
+                "code": "99019-2",
+                "display": "Escherichia coli DNA [Presence] in Urine by NAA with probe detection",
+                "include": true
+              },
+              {
+                "code": "99020-0",
+                "display": "Klebsiella aerogenes DNA [Presence] in Urine by NAA with probe detection",
+                "include": true
+              },
+              {
+                "code": "99021-8",
+                "display": "Klebsiella oxytoca DNA [Presence] in Urine by NAA with probe detection",
+                "include": true
+              },
+              {
+                "code": "99022-6",
+                "display": "Klebsiella pneumoniae DNA [Presence] in Urine by NAA with probe detection",
+                "include": true
+              },
+              {
+                "code": "99089-5",
+                "display": "Escherichia coli K1 DNA [Presence] in Cerebral spinal fluid by NAA with probe detection",
+                "include": true
+              }
+            ]
+          },
+          "2.16.840.1.113762.1.4.1146.1219_20250219": {
+            "valueSetId": "2.16.840.1.113762.1.4.1146.1219_20250219",
+            "valueSetVersion": "20250219",
+            "valueSetName": "Tests for Enterobacter spp., E. coli, or Klebsiella spp. by Culture and Identification Method",
+            "valueSetExternalId": "2.16.840.1.113762.1.4.1146.1219",
+            "author": "CSTE Steward",
+            "system": "http://loinc.org",
+            "ersdConceptType": "labs",
+            "dibbsConceptType": "labs",
+            "includeValueSet": true,
+            "concepts": [
+              {
+                "code": "105764-5",
+                "display": "Enterobacter spp DNA [Cycle Threshold #] in Positive blood culture by NAA with probe detection",
+                "include": true
+              },
+              {
+                "code": "105766-0",
+                "display": "Klebsiella spp DNA [Cycle Threshold #] in Positive blood culture by NAA with probe detection",
+                "include": true
+              },
+              {
+                "code": "10851-4",
+                "display": "Escherichia coli O157:H7 [Presence] in Stool by Organism specific culture",
+                "include": true
+              },
+              {
+                "code": "13318-1",
+                "display": "Escherichia coli enteroinvasive identified in Stool by Organism specific culture",
+                "include": true
+              },
+              {
+                "code": "16832-8",
+                "display": "Escherichia coli enterotoxic identified in Stool by Organism specific culture",
+                "include": true
+              },
+              {
+                "code": "16835-1",
+                "display": "Escherichia coli shiga-like toxin identified in Stool by Organism specific culture",
+                "include": true
+              },
+              {
+                "code": "16836-9",
+                "display": "Escherichia coli verotoxic identified in Stool by Organism specific culture",
+                "include": true
+              },
+              {
+                "code": "20789-4",
+                "display": "Escherichia coli serotype [Identifier] in Isolate",
+                "include": true
+              },
+              {
+                "code": "20811-6",
+                "display": "Escherichia coli [Presence] in Specimen by Culture FDA method",
+                "include": true
+              },
+              {
+                "code": "20813-2",
+                "display": "Escherichia coli F41 [Presence] in Isolate by Agglutination",
+                "include": true
+              },
+              {
+                "code": "20816-5",
+                "display": "Escherichia coli K88 [Presence] in Isolate by Agglutination",
+                "include": true
+              },
+              {
+                "code": "20819-9",
+                "display": "Escherichia coli K99 [Presence] in Isolate by Agglutination",
+                "include": true
+              },
+              {
+                "code": "44089-1",
+                "display": "Escherichia coli O157:H7 [Identifier] in Specimen by Organism specific culture",
+                "include": true
+              },
+              {
+                "code": "44090-9",
+                "display": "Escherichia coli O157:H7 [Presence] in Isolate by Organism specific culture",
+                "include": true
+              },
+              {
+                "code": "45162-5",
+                "display": "Escherichia coli O157 Ag [Presence] in Isolate by Latex agglutination",
+                "include": true
+              },
+              {
+                "code": "48806-4",
+                "display": "Salmonella sp+Shigella sp+Escherichia coli enterotoxic identified in Stool by Organism specific culture",
+                "include": true
+              },
+              {
+                "code": "53944-5",
+                "display": "Escherichia coli enteroinvasive [Presence] in Isolate",
+                "include": true
+              },
+              {
+                "code": "53945-2",
+                "display": "Escherichia coli adherence pattern [Identifier] in Isolate by Hep2 substrate",
+                "include": true
+              },
+              {
+                "code": "53955-1",
+                "display": "Escherichia coli O157 identified in Isolate by Organism specific culture",
+                "include": true
+              },
+              {
+                "code": "6595-3",
+                "display": "Klebsiella granulomatis [Presence] in Isolate by Organism specific culture",
+                "include": true
+              },
+              {
+                "code": "73961-5",
+                "display": "Escherichia coli and Klebsiella pneumoniae and Pseudomonas aeruginosa rRNA [Identifier] by FISH in Positive blood culture",
+                "include": true
+              },
+              {
+                "code": "82303-9",
+                "display": "Escherichia coli O157 [Presence] in Stool by Culture",
+                "include": true
+              },
+              {
+                "code": "85761-5",
+                "display": "Klebsiella pneumoniae DNA [Presence] by NAA with non-probe detection in Positive blood culture",
+                "include": true
+              },
+              {
+                "code": "85772-2",
+                "display": "Enterobacter cloacae complex DNA [Presence] by NAA with non-probe detection in Positive blood culture",
+                "include": true
+              },
+              {
+                "code": "85773-0",
+                "display": "Escherichia coli DNA [Presence] by NAA with non-probe detection in Positive blood culture",
+                "include": true
+              },
+              {
+                "code": "85774-8",
+                "display": "Klebsiella oxytoca DNA [Presence] by NAA with non-probe detection in Positive blood culture",
+                "include": true
+              },
+              {
+                "code": "87318-2",
+                "display": "Escherichia coli eaeA gene [Presence] in Isolate by NAA with probe detection",
+                "include": true
+              },
+              {
+                "code": "87319-0",
+                "display": "Escherichia coli enteroaggregative astA gene [Presence] in Isolate by NAA with probe detection",
+                "include": true
+              },
+              {
+                "code": "87320-8",
+                "display": "Escherichia coli enterotoxigenic heat-labile toxin DNA [Presence] in Isolate by NAA with probe detection",
+                "include": true
+              },
+              {
+                "code": "87321-6",
+                "display": "Escherichia coli enterotoxigenic sta gene [Presence] in Isolate by NAA with probe detection",
+                "include": true
+              },
+              {
+                "code": "87322-4",
+                "display": "Escherichia coli enterotoxigenic stb gene [Presence] in Isolate by NAA with probe detection",
+                "include": true
+              },
+              {
+                "code": "87370-3",
+                "display": "Escherichia coli fasA gene [Presence] in Isolate by NAA with probe detection",
+                "include": true
+              },
+              {
+                "code": "87371-1",
+                "display": "Escherichia coli fedF gene [Presence] in Isolate by NAA with probe detection",
+                "include": true
+              },
+              {
+                "code": "87372-9",
+                "display": "Escherichia coli FimF41a gene [Presence] in Isolate by NAA with probe detection",
+                "include": true
+              },
+              {
+                "code": "87373-7",
+                "display": "Escherichia coli K88 DNA [Presence] in Isolate by NAA with probe detection",
+                "include": true
+              },
+              {
+                "code": "87374-5",
+                "display": "Escherichia coli K99 DNA [Presence] in Isolate by NAA with probe detection",
+                "include": true
+              },
+              {
+                "code": "87375-2",
+                "display": "Escherichia coli paa gene [Presence] in Isolate by NAA with probe detection",
+                "include": true
+              },
+              {
+                "code": "87376-0",
+                "display": "Escherichia coli Stx1 toxin stx1 gene [Presence] in Isolate by NAA with probe detection",
+                "include": true
+              },
+              {
+                "code": "87377-8",
+                "display": "Escherichia coli Stx2 toxin stx2 gene [Presence] in Isolate by NAA with probe detection",
+                "include": true
+              },
+              {
+                "code": "87380-2",
+                "display": "Escherichia coli Stx2e toxin stx2e gene [Presence] in Isolate by NAA with probe detection",
+                "include": true
+              },
+              {
+                "code": "87402-4",
+                "display": "Escherichia coli aidA-I gene [Presence] in Isolate by NAA with probe detection",
+                "include": true
+              },
+              {
+                "code": "88255-5",
+                "display": "Enterobacter sp gyrB+metB genes [Presence] by Probe in Positive blood culture",
+                "include": true
+              },
+              {
+                "code": "88258-9",
+                "display": "Escherichia coli oppA gene [Presence] by Probe in Positive blood culture",
+                "include": true
+              },
+              {
+                "code": "88263-9",
+                "display": "Klebsiella oxytoca ompA gene [Presence] by Probe in Positive blood culture",
+                "include": true
+              },
+              {
+                "code": "88264-7",
+                "display": "Klebsiella pneumoniae yggE gene [Presence] by Probe in Positive blood culture",
+                "include": true
+              },
+              {
+                "code": "93395-2",
+                "display": "Klebsiella pneumoniae DNA [Presence] by NAA with probe detection in Positive blood culture",
+                "include": true
+              },
+              {
+                "code": "93398-6",
+                "display": "Klebsiella oxytoca DNA [Presence] by NAA with probe detection in Positive blood culture",
+                "include": true
+              },
+              {
+                "code": "93400-0",
+                "display": "Enterobacter aerogenes+Enterobacter amnigenus+Enterobacter gergoviae DNA [Presence] by NAA with probe detection in Positive blood culture",
+                "include": true
+              },
+              {
+                "code": "93401-8",
+                "display": "Escherichia coli DNA [Presence] by NAA with probe detection in Positive blood culture",
+                "include": true
+              },
+              {
+                "code": "93404-2",
+                "display": "Enterobacter cloacae complex DNA [Presence] by NAA with probe detection in Positive blood culture",
+                "include": true
+              },
+              {
+                "code": "96307-4",
+                "display": "Klebsiella pneumoniae+Klebsiella variicola+Klebsiella quasipneumoniae DNA [Presence] by NAA with non-probe detection in Positive blood culture",
+                "include": true
+              },
+              {
+                "code": "96308-2",
+                "display": "Klebsiella aerogenes DNA [Presence] by NAA with non-probe detection in Positive blood culture",
+                "include": true
+              }
+            ]
+          },
+          "2.16.840.1.113762.1.4.1146.1216_20250219": {
+            "valueSetId": "2.16.840.1.113762.1.4.1146.1216_20250219",
+            "valueSetVersion": "20250219",
+            "valueSetName": "Tests for carbapenemase resistance mechanism",
+            "valueSetExternalId": "2.16.840.1.113762.1.4.1146.1216",
+            "author": "CSTE Steward",
+            "system": "http://loinc.org",
+            "ersdConceptType": "labs",
+            "dibbsConceptType": "labs",
+            "includeValueSet": true,
+            "concepts": [
+              {
+                "code": "100899-4",
+                "display": "Enterobacteriaceae.extended spectrum beta lactamase resistance phenotype [Identifier] in Specimen by Organism specific culture",
+                "include": true
+              },
+              {
+                "code": "100901-8",
+                "display": "Enterobacteriaceae.carbapenemase resistance phenotype [Identifier] in Anal by Organism specific culture",
+                "include": true
+              },
+              {
+                "code": "100902-6",
+                "display": "Enterobacteriaceae.carbapenemase resistance phenotype.OXA-48 [Identifier] in Anal by Organism specific culture",
+                "include": true
+              },
+              {
+                "code": "101123-8",
+                "display": "Bacterial carbapenem resistance blaIMI gene [Presence] by Molecular method",
+                "include": true
+              },
+              {
+                "code": "101124-6",
+                "display": "Bacterial carbapenem resistance blaIMI+blaNMC genes [Presence] by Molecular method",
+                "include": true
+              },
+              {
+                "code": "101125-3",
+                "display": "Bacterial carbapenem resistance blaOXA-235-like gene [Presence] by Molecular method",
+                "include": true
+              },
+              {
+                "code": "101126-1",
+                "display": "Bacterial carbapenem resistance blaOXA-24+blaOXA-40 gene [Presence] by Molecular method",
+                "include": true
+              },
+              {
+                "code": "101127-9",
+                "display": "Bacterial carbapenem resistance blaSIM gene [Presence] by Molecular method",
+                "include": true
+              },
+              {
+                "code": "101673-2",
+                "display": "KPC carbapenemase [Presence] in Isolate by Rapid immunoassay",
+                "include": true
+              },
+              {
+                "code": "101674-0",
+                "display": "OXA-48-like carbapenemase [Presence] in Isolate by Rapid immunoassay",
+                "include": true
+              },
+              {
+                "code": "101675-7",
+                "display": "IMP Carbapenemase [Presence] in Isolate by Rapid immunoassay",
+                "include": true
+              },
+              {
+                "code": "101676-5",
+                "display": "VIM Carbapenemase [Presence] in Isolate by Rapid immunoassay",
+                "include": true
+              },
+              {
+                "code": "101677-3",
+                "display": "NDM Carbapenemase [Presence] in Isolate by Rapid immunoassay",
+                "include": true
+              },
+              {
+                "code": "105013-7",
+                "display": "Bacterial carbapenem resistance blaGES-11 gene [Presence] by Molecular method",
+                "include": true
+              },
+              {
+                "code": "105014-5",
+                "display": "Bacterial Carbapenem resistance blaGES-5 gene [Presence] by Molecular method",
+                "include": true
+              },
+              {
+                "code": "105015-2",
+                "display": "Bacterial Carbapenem resistance blaGIM-1 gene [Presence] by Molecular method",
+                "include": true
+              },
+              {
+                "code": "105016-0",
+                "display": "Bacterial Carbapenem resistance blaKPC-18 gene [Presence] by Molecular method",
+                "include": true
+              },
+              {
+                "code": "105017-8",
+                "display": "Bacterial Carbapenem resistance blaKPC-2 gene [Presence] by Molecular method",
+                "include": true
+              },
+              {
+                "code": "105018-6",
+                "display": "Bacterial Carbapenem resistance blaKPC-3 gene [Presence] by Molecular method",
+                "include": true
+              },
+              {
+                "code": "105019-4",
+                "display": "Bacterial Carbapenem resistance blaNDM-1 gene [Presence] by Molecular method",
+                "include": true
+              },
+              {
+                "code": "105020-2",
+                "display": "Bacterial Carbapenem resistance blaNDM-19 gene [Presence] by Molecular method",
+                "include": true
+              },
+              {
+                "code": "105021-0",
+                "display": "Bacterial Carbapenem resistance blaNDM-4 gene [Presence] by Molecular method",
+                "include": true
+              },
+              {
+                "code": "105022-8",
+                "display": "Bacterial Carbapenem resistance blaNDM-5 gene [Presence] by Molecular method",
+                "include": true
+              },
+              {
+                "code": "105023-6",
+                "display": "Bacterial Carbapenem resistance blaNDM-7 gene [Presence] by Molecular method",
+                "include": true
+              },
+              {
+                "code": "105024-4",
+                "display": "Bacterial Carbapenem resistance blaNDM-9 gene [Presence] by Molecular method",
+                "include": true
+              },
+              {
+                "code": "105025-1",
+                "display": "Bacterial Carbapenem resistance blaOXA 181 gene [Presence] by Molecular method",
+                "include": true
+              },
+              {
+                "code": "105026-9",
+                "display": "Bacterial Carbapenem resistance blaOXA-162 gene [Presence] by Molecular method",
+                "include": true
+              },
+              {
+                "code": "105027-7",
+                "display": "Bacterial Carbapenem resistance blaOXA-23 gene [Presence] by Molecular method",
+                "include": true
+              },
+              {
+                "code": "105028-5",
+                "display": "Bacterial Carbapenem resistance blaOXA-232 gene [Presence] by Molecular method",
+                "include": true
+              },
+              {
+                "code": "105029-3",
+                "display": "Bacterial Carbapenem resistance blaOXA24/40 gene [Presence] by Molecular method",
+                "include": true
+              },
+              {
+                "code": "105030-1",
+                "display": "Bacterial Carbapenem resistance blaOXA-244 gene [Presence] by Molecular method",
+                "include": true
+              },
+              {
+                "code": "105031-9",
+                "display": "Bacterial Carbapenem resistance blaOXA-58 gene [Presence] by Molecular method",
+                "include": true
+              },
+              {
+                "code": "105032-7",
+                "display": "Bacterial Carbapenem resistance blaOXA-72 gene [Presence] by Molecular method",
+                "include": true
+              },
+              {
+                "code": "105033-5",
+                "display": "Bacterial Carbapenem resistance ISAba1 upstream blaOXA-51 gene [Presence] by Molecular method",
+                "include": true
+              },
+              {
+                "code": "105034-3",
+                "display": "Bacterial Carbapenem resistance blaVIM-1 gene [Presence] by Molecular method",
+                "include": true
+              },
+              {
+                "code": "105035-0",
+                "display": "Bacterial Carbapenem resistance blaVIM-2 gene [Presence] by Molecular method",
+                "include": true
+              },
+              {
+                "code": "105036-8",
+                "display": "Bacterial Carbapenem resistance blaVIM-4 gene [Presence] by Molecular method",
+                "include": true
+              },
+              {
+                "code": "105785-0",
+                "display": "Bacterial Carbapenem resistance blaOXA-23 gene [Cycle Threshold #] in Positive blood culture by NAA with probe detection",
+                "include": true
+              },
+              {
+                "code": "105786-8",
+                "display": "Bacterial carbapenem resistance blaOXA-24+blaOXA-40 gene [Cycle Threshold #] in Positive blood culture by NAA with probe detection",
+                "include": true
+              },
+              {
+                "code": "105788-4",
+                "display": "Bacterial carbapenem resistance blaOXA-58 [Cycle Threshold #] in Positive blood culture by NAA with probe detection",
+                "include": true
+              },
+              {
+                "code": "105791-8",
+                "display": "Bacterial carbapenem resistance SPM gene [Cycle Threshold #] in Positive blood culture by NAA with probe detection",
+                "include": true
+              },
+              {
+                "code": "49617-4",
+                "display": "Carbapenem resistance blaKPC gene [Presence] by Molecular method",
+                "include": true
+              },
+              {
+                "code": "63368-5",
+                "display": "Carbapenem resistance genes [Identifier] by NAA with probe detection",
+                "include": true
+              },
+              {
+                "code": "73834-4",
+                "display": "Bacteria.carbapenem resistant identified in Anal by Organism specific culture",
+                "include": true
+              },
+              {
+                "code": "73982-1",
+                "display": "Carbapenem resistance blaNDM gene [Presence] by Molecular method",
+                "include": true
+              },
+              {
+                "code": "77924-9",
+                "display": "Enterobacteriaceae.carbapenem resistant [Presence] in Anorectal or stool specimen by Organism specific culture",
+                "include": true
+              },
+              {
+                "code": "85498-4",
+                "display": "Carbapenem resistance blaIMP gene [Presence] by Molecular method",
+                "include": true
+              },
+              {
+                "code": "85499-2",
+                "display": "Carbapenem resistance blaKPC gene [Presence] by NAA with probe detection",
+                "include": true
+              },
+              {
+                "code": "85500-7",
+                "display": "Carbapenem resistance blaNDM gene [Presence] by NAA with probe detection",
+                "include": true
+              },
+              {
+                "code": "85501-5",
+                "display": "Carbapenem resistance blaVIM gene [Presence] by Molecular method",
+                "include": true
+              },
+              {
+                "code": "85503-1",
+                "display": "Carbapenem resistance blaOXA-48 gene [Presence] by Molecular method",
+                "include": true
+              },
+              {
+                "code": "85788-8",
+                "display": "Carbapenem resistance blaKPC gene [Presence] by NAA with non-probe detection in Positive blood culture",
+                "include": true
+              },
+              {
+                "code": "85823-3",
+                "display": "Carbapenem resistance blaGES gene [Presence] by Molecular method",
+                "include": true
+              },
+              {
+                "code": "85824-1",
+                "display": "Carbapenem resistance blaIMP gene [Presence] by NAA with probe detection",
+                "include": true
+              },
+              {
+                "code": "85825-8",
+                "display": "Carbapenem resistance blaOXA-23-like gene [Presence] by Molecular method",
+                "include": true
+              },
+              {
+                "code": "85826-6",
+                "display": "Carbapenem resistance blaOXA-24-like gene [Presence] by Molecular method",
+                "include": true
+              },
+              {
+                "code": "85827-4",
+                "display": "Carbapenem resistance bla OXA-48-like gene [Presence] by Molecular method",
+                "include": true
+              },
+              {
+                "code": "85828-2",
+                "display": "Carbapenem resistance blaOXA-58-like gene [Presence] by Molecular method",
+                "include": true
+              },
+              {
+                "code": "85829-0",
+                "display": "Carbapenem resistance blaSPM gene [Presence] by Molecular method",
+                "include": true
+              },
+              {
+                "code": "85830-8",
+                "display": "Carbapenem resistance blaVIM gene [Presence] by NAA with probe detection",
+                "include": true
+              },
+              {
+                "code": "85833-2",
+                "display": "Carbapenem resistance blaGIM gene [Presence] by Molecular method",
+                "include": true
+              },
+              {
+                "code": "86220-1",
+                "display": "Carbapenem resistance blaOXA-48 gene [Presence] in Specimen by NAA with probe detection",
+                "include": true
+              },
+              {
+                "code": "86712-7",
+                "display": "Carbapenem resistance blaOXA gene [Presence] by Molecular method",
+                "include": true
+              },
+              {
+                "code": "86713-5",
+                "display": "Carbapenem resistance blaOXA-134-like gene [Presence] by Molecular method",
+                "include": true
+              },
+              {
+                "code": "86714-3",
+                "display": "Carbapenem resistance blaOXA-51-like gene [Presence] by Molecular method",
+                "include": true
+              },
+              {
+                "code": "88245-6",
+                "display": "Carbapenem resistance blaIMP gene [Presence] by Probe in Positive blood culture",
+                "include": true
+              },
+              {
+                "code": "88246-4",
+                "display": "Carbapenem resistance blaKPC gene [Presence] by Probe in Positive blood culture",
+                "include": true
+              },
+              {
+                "code": "88247-2",
+                "display": "Carbapenem resistance blaNDM gene [Presence] by Probe in Positive blood culture",
+                "include": true
+              },
+              {
+                "code": "88248-0",
+                "display": "Carbapenem resistance blaOXA gene [Presence] by Probe in Positive blood culture",
+                "include": true
+              },
+              {
+                "code": "88249-8",
+                "display": "Carbapenem resistance blaVIM gene [Presence] by Probe in Positive blood culture",
+                "include": true
+              },
+              {
+                "code": "93390-3",
+                "display": "Carbapenem resistance blaOXA-23-like+blaOXA-48-like genes [Presence] in Isolate or Specimen by Molecular method",
+                "include": true
+              },
+              {
+                "code": "94151-8",
+                "display": "Bacteria.carbapenem resistant identified in Specimen by Organism specific culture",
+                "include": true
+              },
+              {
+                "code": "95540-1",
+                "display": "Carbapenem resistance blaIMP+blaVIM genes [Presence] by Molecular method",
+                "include": true
+              },
+              {
+                "code": "95809-0",
+                "display": "Carbapenem resistance genes [Presence] by Molecular method",
+                "include": true
+              },
+              {
+                "code": "98065-6",
+                "display": "Carbapenem resistance blaOXA-143 gene [Presence] by Molecular method",
+                "include": true
+              }
+            ]
+          },
+          "2.16.840.1.113762.1.4.1146.1215_20250219": {
+            "valueSetId": "2.16.840.1.113762.1.4.1146.1215_20250219",
+            "valueSetVersion": "20250219",
+            "valueSetName": "Tests for carbapenemase production",
+            "valueSetExternalId": "2.16.840.1.113762.1.4.1146.1215",
+            "author": "CSTE Steward",
+            "system": "http://loinc.org",
+            "ersdConceptType": "labs",
+            "dibbsConceptType": "labs",
+            "includeValueSet": true,
+            "concepts": [
+              {
+                "code": "102120-3",
+                "display": "Carbapenemase [Type] in Isolate by Immunoassay",
+                "include": true
+              },
+              {
+                "code": "74676-8",
+                "display": "Carbapenemase [Type] in Isolate by Carba NP",
+                "include": true
+              },
+              {
+                "code": "85047-9",
+                "display": "MBL by meropenem to meropenem-EDTA IC ratio [Presence] by ARD gradient strip",
+                "include": true
+              },
+              {
+                "code": "85053-7",
+                "display": "MBL by imipenem to imipenem-EDTA IC ratio [Presence] by ARD gradient strip",
+                "include": true
+              },
+              {
+                "code": "86930-5",
+                "display": "Carbapenemase [Presence] in Isolate",
+                "include": true
+              }
+            ]
+          }
+        },
+        "734350003": {},
+        "715174007": {
+          "2.16.840.1.113762.1.4.1146.1670_20220602": {
+            "valueSetId": "2.16.840.1.113762.1.4.1146.1670_20220602",
+            "valueSetVersion": "20220602",
+            "valueSetName": "CRAB (Disorders) (SNOMED)",
+            "valueSetExternalId": "2.16.840.1.113762.1.4.1146.1670",
+            "author": "CSTE Steward",
+            "system": "http://snomed.info/sct",
+            "ersdConceptType": "conditions",
+            "dibbsConceptType": "conditions",
+            "includeValueSet": true,
+            "concepts": [
+              {
+                "code": "445780006",
+                "display": "Infection caused by carbapenem resistant Acinetobacter (disorder)",
+                "include": true
+              }
+            ]
+          },
+          "2.16.840.1.113762.1.4.1146.1674_20220602": {
+            "valueSetId": "2.16.840.1.113762.1.4.1146.1674_20220602",
+            "valueSetVersion": "20220602",
+            "valueSetName": "Acinetobacter baumannii [Carbapenemase Producing] (Organism or Substance in Lab Results)",
+            "valueSetExternalId": "2.16.840.1.113762.1.4.1146.1674",
+            "author": "CSTE Steward",
+            "system": "http://snomed.info/sct",
+            "ersdConceptType": "labs",
+            "dibbsConceptType": "labs",
+            "includeValueSet": true,
+            "concepts": [
+              {
+                "code": "1085401000112103",
+                "display": "Carbapenemase-producing Acinetobacter baumannii-Acinetobacter calcoaceticus complex (organism)",
+                "include": true
+              },
+              {
+                "code": "737526007",
+                "display": "Carbapenemase-producing Acinetobacter baumannii (organism)",
+                "include": true
+              }
+            ]
+          },
+          "2.16.840.1.113762.1.4.1146.1673_20220602": {
+            "valueSetId": "2.16.840.1.113762.1.4.1146.1673_20220602",
+            "valueSetVersion": "20220602",
+            "valueSetName": "Acinetobacter baumannii [Carbapenem Resistant] (Organism or Substance in Lab Results)",
+            "valueSetExternalId": "2.16.840.1.113762.1.4.1146.1673",
+            "author": "CSTE Steward",
+            "system": "http://snomed.info/sct",
+            "ersdConceptType": "labs",
+            "dibbsConceptType": "labs",
+            "includeValueSet": true,
+            "concepts": [
+              {
+                "code": "715174007",
+                "display": "Carbapenem resistant Acinetobacter baumannii (organism)",
+                "include": true
+              },
+              {
+                "code": "816084004",
+                "display": "Carbapenem-resistant Acinetobacter baumannii-calcoaceticus complex (organism)",
+                "include": true
+              }
+            ]
+          },
+          "2.16.840.1.113762.1.4.1146.1671_20220602": {
+            "valueSetId": "2.16.840.1.113762.1.4.1146.1671_20220602",
+            "valueSetVersion": "20220602",
+            "valueSetName": "Acinetobacter baumannii (Organism or Substance in Lab Results)",
+            "valueSetExternalId": "2.16.840.1.113762.1.4.1146.1671",
+            "author": "CSTE Steward",
+            "system": "http://snomed.info/sct",
+            "ersdConceptType": "labs",
+            "dibbsConceptType": "labs",
+            "includeValueSet": true,
+            "concepts": [
+              {
+                "code": "1085401000112103",
+                "display": "Carbapenemase-producing Acinetobacter baumannii-Acinetobacter calcoaceticus complex (organism)",
+                "include": true
+              },
+              {
+                "code": "447891000124105",
+                "display": "Multidrug resistant Acinetobacter baumannii (organism)",
+                "include": true
+              },
+              {
+                "code": "708137003",
+                "display": "Deoxyribonucleic acid of Acinetobacter baumannii (substance)",
+                "include": true
+              },
+              {
+                "code": "715174007",
+                "display": "Carbapenem resistant Acinetobacter baumannii (organism)",
+                "include": true
+              },
+              {
+                "code": "715353004",
+                "display": "Multiple drug-resistant Acinetobacter baumannii (organism)",
+                "include": true
+              },
+              {
+                "code": "737526007",
+                "display": "Carbapenemase-producing Acinetobacter baumannii (organism)",
+                "include": true
+              },
+              {
+                "code": "816084004",
+                "display": "Carbapenem-resistant Acinetobacter baumannii-calcoaceticus complex (organism)",
+                "include": true
+              },
+              {
+                "code": "91288006",
+                "display": "Acinetobacter baumannii (organism)",
+                "include": true
+              }
+            ]
+          },
+          "2.16.840.1.113762.1.4.1146.1676_20230602": {
+            "valueSetId": "2.16.840.1.113762.1.4.1146.1676_20230602",
+            "valueSetVersion": "20230602",
+            "valueSetName": "Tests for Acinetobacter baumannii Nucleic Acid",
+            "valueSetExternalId": "2.16.840.1.113762.1.4.1146.1676",
+            "author": "CSTE Steward",
+            "system": "http://loinc.org",
+            "ersdConceptType": "labs",
+            "dibbsConceptType": "labs",
+            "includeValueSet": true,
+            "concepts": [
+              {
+                "code": "61360-4",
+                "display": "Acinetobacter baumannii DNA [Presence] in Specimen by NAA with probe detection",
+                "include": true
+              },
+              {
+                "code": "94380-3",
+                "display": "Acinetobacter baumannii DNA [Presence] in Lower respiratory specimen by NAA with probe detection",
+                "include": true
+              },
+              {
+                "code": "99013-5",
+                "display": "Acinetobacter baumannii DNA [Presence] in Urine by NAA with probe detection",
+                "include": true
+              }
+            ]
+          },
+          "2.16.840.1.113762.1.4.1146.1675_20220602": {
+            "valueSetId": "2.16.840.1.113762.1.4.1146.1675_20220602",
+            "valueSetVersion": "20220602",
+            "valueSetName": "Tests for Acinetobacter baumannii by Culture and Identification Method",
+            "valueSetExternalId": "2.16.840.1.113762.1.4.1146.1675",
+            "author": "CSTE Steward",
+            "system": "http://loinc.org",
+            "ersdConceptType": "labs",
+            "dibbsConceptType": "labs",
+            "includeValueSet": true,
+            "concepts": [
+              {
+                "code": "85770-6",
+                "display": "Acinetobacter baumannii DNA [Presence] by NAA with non-probe detection in Positive blood culture",
+                "include": true
+              },
+              {
+                "code": "93406-7",
+                "display": "Acinetobacter baumannii DNA [Presence] by NAA with probe detection in Positive blood culture",
+                "include": true
+              }
+            ]
+          }
+        },
+        "726492000": {
+          "2.16.840.1.113762.1.4.1146.1679_20240620": {
+            "valueSetId": "2.16.840.1.113762.1.4.1146.1679_20240620",
+            "valueSetVersion": "20240620",
+            "valueSetName": "Pseudomonas aeruginosa (Organism or Substance in Lab Results)",
+            "valueSetExternalId": "2.16.840.1.113762.1.4.1146.1679",
+            "author": "CSTE Steward",
+            "system": "http://snomed.info/sct",
+            "ersdConceptType": "labs",
+            "dibbsConceptType": "labs",
+            "includeValueSet": true,
+            "concepts": [
+              {
+                "code": "1104601000112108",
+                "display": "Metallo-beta-lactamase producing Pseudomonas aeruginosa (organism)",
+                "include": true
+              },
+              {
+                "code": "1104701000112104",
+                "display": "Metallo-beta-lactamase producing mucoid Pseudomonas aeruginosa (organism)",
+                "include": true
+              },
+              {
+                "code": "1104801000112107",
+                "display": "Metallo-beta-lactamase producing non-mucoid Pseudomonas aeruginosa (organism)",
+                "include": true
+              },
+              {
+                "code": "52499004",
+                "display": "Pseudomonas aeruginosa (organism)",
+                "include": true
+              },
+              {
+                "code": "541101000124105",
+                "display": "Extended spectrum beta-lactamase producing Pseudomonas aeruginosa (organism)",
+                "include": true
+              },
+              {
+                "code": "708411005",
+                "display": "Deoxyribonucleic acid of Pseudomonas aeruginosa (substance)",
+                "include": true
+              },
+              {
+                "code": "710332005",
+                "display": "Multidrug-resistant Pseudomonas aeruginosa (organism)",
+                "include": true
+              },
+              {
+                "code": "726492000",
+                "display": "Carbapenem resistant Pseudomonas aeruginosa (organism)",
+                "include": true
+              },
+              {
+                "code": "733537009",
+                "display": "Mucoid Pseudomonas aeruginosa (organism)",
+                "include": true
+              },
+              {
+                "code": "733538004",
+                "display": "Non-mucoid Pseudomonas aeruginosa (organism)",
+                "include": true
+              },
+              {
+                "code": "737527003",
+                "display": "Carbapenemase-producing Pseudomonas aeruginosa (organism)",
+                "include": true
+              },
+              {
+                "code": "772067008",
+                "display": "Pseudomonas aeruginosa Liverpool epidemic strain (organism)",
+                "include": true
+              }
+            ]
+          },
+          "2.16.840.1.113762.1.4.1146.1681_20220602": {
+            "valueSetId": "2.16.840.1.113762.1.4.1146.1681_20220602",
+            "valueSetVersion": "20220602",
+            "valueSetName": "Pseudomonas aeruginosa [Carbapenemase Producing] (Organism or Substance in Lab Results)",
+            "valueSetExternalId": "2.16.840.1.113762.1.4.1146.1681",
+            "author": "CSTE Steward",
+            "system": "http://snomed.info/sct",
+            "ersdConceptType": "labs",
+            "dibbsConceptType": "labs",
+            "includeValueSet": true,
+            "concepts": [
+              {
+                "code": "1104601000112108",
+                "display": "Metallo-beta-lactamase producing Pseudomonas aeruginosa (organism)",
+                "include": true
+              },
+              {
+                "code": "737527003",
+                "display": "Carbapenemase-producing Pseudomonas aeruginosa (organism)",
+                "include": true
+              }
+            ]
+          },
+          "2.16.840.1.113762.1.4.1146.1680_20220602": {
+            "valueSetId": "2.16.840.1.113762.1.4.1146.1680_20220602",
+            "valueSetVersion": "20220602",
+            "valueSetName": "Pseudomonas aeruginosa [Carbapenem Resistant] (Organism or Substance in Lab Results)",
+            "valueSetExternalId": "2.16.840.1.113762.1.4.1146.1680",
+            "author": "CSTE Steward",
+            "system": "http://snomed.info/sct",
+            "ersdConceptType": "labs",
+            "dibbsConceptType": "labs",
+            "includeValueSet": true,
+            "concepts": [
+              {
+                "code": "726492000",
+                "display": "Carbapenem resistant Pseudomonas aeruginosa (organism)",
+                "include": true
+              }
+            ]
+          },
+          "2.16.840.1.113762.1.4.1146.1678_20250621": {
+            "valueSetId": "2.16.840.1.113762.1.4.1146.1678_20250621",
+            "valueSetVersion": "20250621",
+            "valueSetName": "Tests for Pseudomonas aeruginosa Nucleic Acid",
+            "valueSetExternalId": "2.16.840.1.113762.1.4.1146.1678",
+            "author": "CSTE Steward",
+            "system": "http://loinc.org",
+            "ersdConceptType": "labs",
+            "dibbsConceptType": "labs",
+            "includeValueSet": true,
+            "concepts": [
+              {
+                "code": "106601-8",
+                "display": "Pseudomonas aeruginosa DNA [Presence] in Body fluid by NAA with non-probe detection",
+                "include": true
+              },
+              {
+                "code": "61401-6",
+                "display": "Pseudomonas aeruginosa DNA [Presence] in Specimen by NAA with probe detection",
+                "include": true
+              },
+              {
+                "code": "76578-4",
+                "display": "Pseudomonas aeruginosa regA gene [Presence] in Swab specimen by NAA with probe detection",
+                "include": true
+              },
+              {
+                "code": "76593-3",
+                "display": "Pseudomonas aeruginosa regA gene [#/mass] in XXX.tissue by NAA with probe detection",
+                "include": true
+              },
+              {
+                "code": "76606-3",
+                "display": "Pseudomonas aeruginosa regA gene [#/volume] in XXX.body fluid by NAA with probe detection",
+                "include": true
+              },
+              {
+                "code": "92959-6",
+                "display": "Pseudomonas aeruginosa DNA [NCncRange] in Sputum by NAA with non-probe detection",
+                "include": true
+              },
+              {
+                "code": "92960-4",
+                "display": "Pseudomonas aeruginosa DNA [NCncRange] in Bronchoalveolar lavage by NAA with non-probe detection",
+                "include": true
+              },
+              {
+                "code": "94371-2",
+                "display": "Pseudomonas aeruginosa DNA [Presence] in Lower respiratory specimen by NAA with probe detection",
+                "include": true
+              },
+              {
+                "code": "96326-4",
+                "display": "Pseudomonas aeruginosa DNA [NCncRange] in Lower respiratory specimen by NAA with non-probe detection",
+                "include": true
+              },
+              {
+                "code": "97631-6",
+                "display": "Pseudomonas aeruginosa DNA [Presence] in Synovial fluid by NAA with non-probe detection",
+                "include": true
+              },
+              {
+                "code": "99027-5",
+                "display": "Pseudomonas aeruginosa DNA [Presence] in Urine by NAA with probe detection",
+                "include": true
+              }
+            ]
+          },
+          "2.16.840.1.113762.1.4.1146.1677_20250621": {
+            "valueSetId": "2.16.840.1.113762.1.4.1146.1677_20250621",
+            "valueSetVersion": "20250621",
+            "valueSetName": "Tests for Pseudomonas aeruginosa by Culture and Identification Method",
+            "valueSetExternalId": "2.16.840.1.113762.1.4.1146.1677",
+            "author": "CSTE Steward",
+            "system": "http://loinc.org",
+            "ersdConceptType": "labs",
+            "dibbsConceptType": "labs",
+            "includeValueSet": true,
+            "concepts": [
+              {
+                "code": "100908-3",
+                "display": "Pseudomonas aeruginosa [Presence] in Lower respiratory specimen by Organism specific culture",
+                "include": true
+              },
+              {
+                "code": "105770-2",
+                "display": "Pseudomonas aeruginosa DNA [Cycle Threshold #] in Positive blood culture by NAA with probe detection",
+                "include": true
+              },
+              {
+                "code": "105789-2",
+                "display": "Pseudomonas aeruginosa regA gene [Cycle Threshold #] in Positive blood culture by NAA with probe detection",
+                "include": true
+              },
+              {
+                "code": "63480-8",
+                "display": "Pseudomonas aeruginosa.multidrug resistant isolate [Presence] in Specimen by Organism specific culture",
+                "include": true
+              },
+              {
+                "code": "85780-5",
+                "display": "Pseudomonas aeruginosa DNA [Presence] by NAA with non-probe detection in Positive blood culture",
+                "include": true
+              },
+              {
+                "code": "88268-8",
+                "display": "Pseudomonas aeruginosa sodA gene [Presence] by Probe in Positive blood culture",
+                "include": true
+              },
+              {
+                "code": "93386-1",
+                "display": "Pseudomonas aeruginosa DNA [Presence] by NAA with probe detection in Positive blood culture",
+                "include": true
+              }
+            ]
+          }
+        },
+        "865929003": {
+          "2.16.840.1.113762.1.4.1146.1579_20220118": {
+            "valueSetId": "2.16.840.1.113762.1.4.1146.1579_20220118",
+            "valueSetVersion": "20220118",
+            "valueSetName": "Candida auris Infection (Disorders) (SNOMED)",
+            "valueSetExternalId": "2.16.840.1.113762.1.4.1146.1579",
+            "author": "CSTE Steward",
+            "system": "http://snomed.info/sct",
+            "ersdConceptType": "conditions",
+            "dibbsConceptType": "conditions",
+            "includeValueSet": true,
+            "concepts": [
+              {
+                "code": "865929003",
+                "display": "Infection caused by Candida auris (disorder)",
+                "include": true
+              }
+            ]
+          },
+          "2.16.840.1.113762.1.4.1146.1043_20190609": {
+            "valueSetId": "2.16.840.1.113762.1.4.1146.1043_20190609",
+            "valueSetVersion": "20190609",
+            "valueSetName": "Candida auris Infection [Candida auris] (Organism or Substance in Lab Results)",
+            "valueSetExternalId": "2.16.840.1.113762.1.4.1146.1043",
+            "author": "CSTE Steward",
+            "system": "http://snomed.info/sct",
+            "ersdConceptType": "labs",
+            "dibbsConceptType": "labs",
+            "includeValueSet": true,
+            "concepts": [
+              {
+                "code": "3491000146109",
+                "display": "Candida auris (organism)",
+                "include": true
+              }
+            ]
+          },
+          "2.16.840.1.113762.1.4.1146.1045_20230125": {
+            "valueSetId": "2.16.840.1.113762.1.4.1146.1045_20230125",
+            "valueSetVersion": "20230125",
+            "valueSetName": "Candida auris Infection (Tests for Candida auris Nucleic Acid)",
+            "valueSetExternalId": "2.16.840.1.113762.1.4.1146.1045",
+            "author": "CSTE Steward",
+            "system": "http://loinc.org",
+            "ersdConceptType": "labs",
+            "dibbsConceptType": "labs",
+            "includeValueSet": true,
+            "concepts": [
+              {
+                "code": "87620-1",
+                "display": "Candida auris ITS2 gene [Presence] in Specimen by NAA with probe detection",
+                "include": true
+              },
+              {
+                "code": "95764-7",
+                "display": "Candida auris DNA [Presence] in Urine by NAA with non-probe detection",
+                "include": true
+              },
+              {
+                "code": "95765-4",
+                "display": "Candida auris DNA [Presence] in Specimen by NAA with non-probe detection",
+                "include": true
+              },
+              {
+                "code": "95766-2",
+                "display": "Candida auris DNA [Presence] in Blood by NAA with non-probe detection",
+                "include": true
+              },
+              {
+                "code": "96302-5",
+                "display": "Candida auris DNA [Presence] by NAA with non-probe detection in Positive blood culture",
+                "include": true
+              },
+              {
+                "code": "97936-9",
+                "display": "Candida auris DNA [Presence] in Specimen by NAA with probe detection",
+                "include": true
+              }
+            ]
+          },
+          "2.16.840.1.113762.1.4.1146.1044_20250219": {
+            "valueSetId": "2.16.840.1.113762.1.4.1146.1044_20250219",
+            "valueSetVersion": "20250219",
+            "valueSetName": "Candida auris Infection (Tests for Candida auris by Culture and Identification Method)",
+            "valueSetExternalId": "2.16.840.1.113762.1.4.1146.1044",
+            "author": "CSTE Steward",
+            "system": "http://loinc.org",
+            "ersdConceptType": "labs",
+            "dibbsConceptType": "labs",
+            "includeValueSet": true,
+            "concepts": [
+              {
+                "code": "105806-4",
+                "display": "Candida auris DNA [Cycle Threshold #] in Positive blood culture by NAA with probe detection",
+                "include": true
+              },
+              {
+                "code": "90002-7",
+                "display": "Candida auris [Presence] in Specimen by Organism specific culture",
+                "include": true
+              },
+              {
+                "code": "92791-3",
+                "display": "Candida auris DNA [Presence] by NAA with probe detection in Positive blood culture",
+                "include": true
+              },
+              {
+                "code": "94419-9",
+                "display": "Candida auris [Presence] in Isolate by MS.MALDI-TOF",
+                "include": true
+              },
+              {
+                "code": "96302-5",
+                "display": "Candida auris DNA [Presence] by NAA with non-probe detection in Positive blood culture",
+                "include": true
+              }
+            ]
+          }
+        }
+      }
     }
   ]
 }

--- a/src/app/assets/dibbs_db_seed_query.json
+++ b/src/app/assets/dibbs_db_seed_query.json
@@ -7564,6 +7564,335 @@
                 "include": true
               }
             ]
+          },
+          "2.16.840.1.113762.1.4.1146.1156_20250218": {
+            "valueSetId": "2.16.840.1.113762.1.4.1146.1156_20250218",
+            "valueSetVersion": "20250218",
+            "valueSetName": "Staphylococcus aureus (Organism or Substance in Lab Results)",
+            "valueSetExternalId": "2.16.840.1.113762.1.4.1146.1156",
+            "author": "CSTE Steward",
+            "system": "http://snomed.info/sct",
+            "ersdConceptType": "labs",
+            "dibbsConceptType": "labs",
+            "includeValueSet": true,
+            "concepts": [
+              {
+                "code": "1108501000112102",
+                "display": "Borderline oxacillin-resistant Staphylococcus aureus (organism)",
+                "include": true
+              },
+              {
+                "code": "113961008",
+                "display": "Staphylococcus aureus ss aureus (organism)",
+                "include": true
+              },
+              {
+                "code": "115329001",
+                "display": "Methicillin resistant Staphylococcus aureus (organism)",
+                "include": true
+              },
+              {
+                "code": "117269003",
+                "display": "Ribosomal ribonucleic acid of Staphylococcus aureus (substance)",
+                "include": true
+              },
+              {
+                "code": "3092008",
+                "display": "Staphylococcus aureus (organism)",
+                "include": true
+              },
+              {
+                "code": "404679009",
+                "display": "Glycopeptide resistant Staphylococcus aureus (organism)",
+                "include": true
+              },
+              {
+                "code": "404680007",
+                "display": "Vancomycin resistant Staphylococcus aureus (organism)",
+                "include": true
+              },
+              {
+                "code": "406576009",
+                "display": "Vancomycin intermediate/resistant Staphylococcus aureus (organism)",
+                "include": true
+              },
+              {
+                "code": "406605001",
+                "display": "Glycopeptide intermediate Staphylococcus aureus (organism)",
+                "include": true
+              },
+              {
+                "code": "406606000",
+                "display": "Glycopeptide intermediate/resistant Staphylococcus aureus (organism)",
+                "include": true
+              },
+              {
+                "code": "406962002",
+                "display": "Vancomycin intermediate Staphylococcus aureus (organism)",
+                "include": true
+              },
+              {
+                "code": "417943000",
+                "display": "Methicillin susceptible Staphylococcus aureus (organism)",
+                "include": true
+              },
+              {
+                "code": "418595000",
+                "display": "Staphylococcus aureus enterotoxin G (substance)",
+                "include": true
+              },
+              {
+                "code": "418864000",
+                "display": "Staphylococcus aureus enterotoxin C (substance)",
+                "include": true
+              },
+              {
+                "code": "418911003",
+                "display": "Staphylococcus aureus enterotoxin (substance)",
+                "include": true
+              },
+              {
+                "code": "418950004",
+                "display": "Staphylococcus aureus enterotoxin A (substance)",
+                "include": true
+              },
+              {
+                "code": "419175007",
+                "display": "Staphylococcus aureus enterotoxin D (substance)",
+                "include": true
+              },
+              {
+                "code": "419488004",
+                "display": "Staphylococcus aureus enterotoxin B (substance)",
+                "include": true
+              },
+              {
+                "code": "444684000",
+                "display": "Staphylococcus aureus enterotoxin E (substance)",
+                "include": true
+              },
+              {
+                "code": "44651000087108",
+                "display": "Staphylococcus aureus complex (organism)",
+                "include": true
+              },
+              {
+                "code": "50269000",
+                "display": "Staphylococcus aureus ss. anaerobius (organism)",
+                "include": true
+              },
+              {
+                "code": "698216001",
+                "display": "Vancomycin susceptible Staphylococcus aureus (organism)",
+                "include": true
+              },
+              {
+                "code": "708429000",
+                "display": "Deoxyribonucleic acid of Staphylococcus aureus (substance)",
+                "include": true
+              },
+              {
+                "code": "710564002",
+                "display": "Panton-Valentine leukocidin producing Staphylococcus aureus (organism)",
+                "include": true
+              },
+              {
+                "code": "711317006",
+                "display": "Staphylococcus aureus toxic shock syndrome toxin 1 (substance)",
+                "include": true
+              },
+              {
+                "code": "716530009",
+                "display": "Non-multiple drug resistant methicillin resistant Staphylococcus aureus (organism)",
+                "include": true
+              },
+              {
+                "code": "716531008",
+                "display": "Multiple drug resistant methicillin resistant Staphylococcus aureus (organism)",
+                "include": true
+              },
+              {
+                "code": "720301008",
+                "display": "Deoxyribonucleic acid of methicillin resistant Staphylococcus aureus (substance)",
+                "include": true
+              },
+              {
+                "code": "782499002",
+                "display": "Staphylococcus aureus toxin (substance)",
+                "include": true
+              }
+            ]
+          },
+          "2.16.840.1.113762.1.4.1146.1139_20250218": {
+            "valueSetId": "2.16.840.1.113762.1.4.1146.1139_20250218",
+            "valueSetVersion": "20250218",
+            "valueSetName": "VISA/VRSA\u00a0(Tests for\u00a0Vancomycin Resistance Gene)",
+            "valueSetExternalId": "2.16.840.1.113762.1.4.1146.1139",
+            "author": "CSTE Steward",
+            "system": "http://loinc.org",
+            "ersdConceptType": "labs",
+            "dibbsConceptType": "labs",
+            "includeValueSet": true,
+            "concepts": [
+              {
+                "code": "105816-3",
+                "display": "Vancomycin resistance vanA gene [Cycle Threshold #] in Positive blood culture by NAA with probe detection",
+                "include": true
+              },
+              {
+                "code": "105817-1",
+                "display": "Vancomycin resistance vanB gene [Cycle Threshold #] in Positive blood culture by NAA with probe detection",
+                "include": true
+              },
+              {
+                "code": "48814-8",
+                "display": "Vancomycin resistance vanA gene [Presence] by Molecular method",
+                "include": true
+              },
+              {
+                "code": "62261-3",
+                "display": "Vancomycin resistance vanA + vanB genes [Presence] by Molecular method",
+                "include": true
+              },
+              {
+                "code": "69379-6",
+                "display": "Vancomycin resistance vanA and vanB and vanC1 and vanC2 genes [Identifier] by Molecular method",
+                "include": true
+              },
+              {
+                "code": "72421-1",
+                "display": "Vancomycin resistance vanB gene [Presence] by Molecular method",
+                "include": true
+              },
+              {
+                "code": "72836-0",
+                "display": "Vancomycin resistance vanC2+vanC3 genes [Presence] by Molecular method",
+                "include": true
+              },
+              {
+                "code": "72837-8",
+                "display": "Vancomycin resistance vanC1 gene [Presence] by Molecular method",
+                "include": true
+              },
+              {
+                "code": "75753-4",
+                "display": "Vancomycin resistance vanD gene [Presence] by Molecular method",
+                "include": true
+              },
+              {
+                "code": "85787-0",
+                "display": "Vancomycin resistance vanA + vanB genes [Presence] by NAA with non-probe detection in Positive blood culture",
+                "include": true
+              },
+              {
+                "code": "88252-2",
+                "display": "Vancomycin resistance vanA gene [Presence] by Probe in Positive blood culture",
+                "include": true
+              },
+              {
+                "code": "88253-0",
+                "display": "Vancomycin resistance vanB gene [Presence] by Probe in Positive blood culture",
+                "include": true
+              },
+              {
+                "code": "92241-9",
+                "display": "Vancomycin [Susceptibility] by Genotype method",
+                "include": true
+              }
+            ]
+          },
+          "2.16.840.1.113762.1.4.1146.1138_20250218": {
+            "valueSetId": "2.16.840.1.113762.1.4.1146.1138_20250218",
+            "valueSetVersion": "20250218",
+            "valueSetName": "Staphylococcus Aureus (Tests\u202fby Culture and Identification Method)",
+            "valueSetExternalId": "2.16.840.1.113762.1.4.1146.1138",
+            "author": "CSTE Steward",
+            "system": "http://loinc.org",
+            "ersdConceptType": "labs",
+            "dibbsConceptType": "labs",
+            "includeValueSet": true,
+            "concepts": [
+              {
+                "code": "100897-8",
+                "display": "Staphylococcus aureus [Presence] in Specimen by Organism specific culture",
+                "include": true
+              },
+              {
+                "code": "103141-8",
+                "display": "Staphylococcus aureus MLVA complex [Type] in Isolate or Specimen by Molecular genetics method",
+                "include": true
+              },
+              {
+                "code": "105796-7",
+                "display": "Staphylococcus aureus DNA [Cycle Threshold #] in Positive blood culture by NAA with probe detection",
+                "include": true
+              },
+              {
+                "code": "106044-1",
+                "display": "Methicillin resistant Staphylococcus aureus [Presence] in Skin by Organism specific culture",
+                "include": true
+              },
+              {
+                "code": "106046-6",
+                "display": "Methicillin resistant Staphylococcus aureus [Presence] in Axilla by Organism specific culture",
+                "include": true
+              },
+              {
+                "code": "13317-3",
+                "display": "Methicillin resistant Staphylococcus aureus [Presence] in Specimen by Organism specific culture",
+                "include": true
+              },
+              {
+                "code": "52969-3",
+                "display": "Methicillin resistant Staphylococcus aureus [Presence] in Nose by Organism specific culture",
+                "include": true
+              },
+              {
+                "code": "53572-4",
+                "display": "Methicillin resistant Staphylococcus aureus [Presence] in Genital specimen by Organism specific culture",
+                "include": true
+              },
+              {
+                "code": "73558-9",
+                "display": "Staphylococcus aureus and Staphylococcus sp.coagulase negative rRNA [Identifier] by FISH in Positive blood culture",
+                "include": true
+              },
+              {
+                "code": "76081-9",
+                "display": "Methicillin resistant Staphylococcus aureus [Presence] in Pharynx by Organism specific culture",
+                "include": true
+              },
+              {
+                "code": "85042-0",
+                "display": "Staphylococcus aureus glycopeptide resistant identified [Type] in Isolate",
+                "include": true
+              },
+              {
+                "code": "85045-3",
+                "display": "Staphylococcus aureus glycopeptide resistant based on vancomycin and teicoplanin IC [Identifier] by ARD gradient strip",
+                "include": true
+              },
+              {
+                "code": "85765-6",
+                "display": "Staphylococcus aureus DNA [Presence] by NAA with non-probe detection in Positive blood culture",
+                "include": true
+              },
+              {
+                "code": "88269-6",
+                "display": "Staphylococcus aureus gyrB gene [Presence] by Probe in Positive blood culture",
+                "include": true
+              },
+              {
+                "code": "92777-2",
+                "display": "Staphylococcus aureus DNA [Presence] by NAA with probe detection in Positive blood culture",
+                "include": true
+              },
+              {
+                "code": "97325-5",
+                "display": "Staphylococcus aureus VNTR pattern [Type] in Isolate or Specimen by Molecular genetics method",
+                "include": true
+              }
+            ]
           }
         },
         "404681006": {
@@ -7634,6 +7963,335 @@
               {
                 "code": "406606000",
                 "display": "Glycopeptide intermediate/resistant Staphylococcus aureus (organism)",
+                "include": true
+              }
+            ]
+          },
+          "2.16.840.1.113762.1.4.1146.1156_20250218": {
+            "valueSetId": "2.16.840.1.113762.1.4.1146.1156_20250218",
+            "valueSetVersion": "20250218",
+            "valueSetName": "Staphylococcus aureus (Organism or Substance in Lab Results)",
+            "valueSetExternalId": "2.16.840.1.113762.1.4.1146.1156",
+            "author": "CSTE Steward",
+            "system": "http://snomed.info/sct",
+            "ersdConceptType": "labs",
+            "dibbsConceptType": "labs",
+            "includeValueSet": true,
+            "concepts": [
+              {
+                "code": "1108501000112102",
+                "display": "Borderline oxacillin-resistant Staphylococcus aureus (organism)",
+                "include": true
+              },
+              {
+                "code": "113961008",
+                "display": "Staphylococcus aureus ss aureus (organism)",
+                "include": true
+              },
+              {
+                "code": "115329001",
+                "display": "Methicillin resistant Staphylococcus aureus (organism)",
+                "include": true
+              },
+              {
+                "code": "117269003",
+                "display": "Ribosomal ribonucleic acid of Staphylococcus aureus (substance)",
+                "include": true
+              },
+              {
+                "code": "3092008",
+                "display": "Staphylococcus aureus (organism)",
+                "include": true
+              },
+              {
+                "code": "404679009",
+                "display": "Glycopeptide resistant Staphylococcus aureus (organism)",
+                "include": true
+              },
+              {
+                "code": "404680007",
+                "display": "Vancomycin resistant Staphylococcus aureus (organism)",
+                "include": true
+              },
+              {
+                "code": "406576009",
+                "display": "Vancomycin intermediate/resistant Staphylococcus aureus (organism)",
+                "include": true
+              },
+              {
+                "code": "406605001",
+                "display": "Glycopeptide intermediate Staphylococcus aureus (organism)",
+                "include": true
+              },
+              {
+                "code": "406606000",
+                "display": "Glycopeptide intermediate/resistant Staphylococcus aureus (organism)",
+                "include": true
+              },
+              {
+                "code": "406962002",
+                "display": "Vancomycin intermediate Staphylococcus aureus (organism)",
+                "include": true
+              },
+              {
+                "code": "417943000",
+                "display": "Methicillin susceptible Staphylococcus aureus (organism)",
+                "include": true
+              },
+              {
+                "code": "418595000",
+                "display": "Staphylococcus aureus enterotoxin G (substance)",
+                "include": true
+              },
+              {
+                "code": "418864000",
+                "display": "Staphylococcus aureus enterotoxin C (substance)",
+                "include": true
+              },
+              {
+                "code": "418911003",
+                "display": "Staphylococcus aureus enterotoxin (substance)",
+                "include": true
+              },
+              {
+                "code": "418950004",
+                "display": "Staphylococcus aureus enterotoxin A (substance)",
+                "include": true
+              },
+              {
+                "code": "419175007",
+                "display": "Staphylococcus aureus enterotoxin D (substance)",
+                "include": true
+              },
+              {
+                "code": "419488004",
+                "display": "Staphylococcus aureus enterotoxin B (substance)",
+                "include": true
+              },
+              {
+                "code": "444684000",
+                "display": "Staphylococcus aureus enterotoxin E (substance)",
+                "include": true
+              },
+              {
+                "code": "44651000087108",
+                "display": "Staphylococcus aureus complex (organism)",
+                "include": true
+              },
+              {
+                "code": "50269000",
+                "display": "Staphylococcus aureus ss. anaerobius (organism)",
+                "include": true
+              },
+              {
+                "code": "698216001",
+                "display": "Vancomycin susceptible Staphylococcus aureus (organism)",
+                "include": true
+              },
+              {
+                "code": "708429000",
+                "display": "Deoxyribonucleic acid of Staphylococcus aureus (substance)",
+                "include": true
+              },
+              {
+                "code": "710564002",
+                "display": "Panton-Valentine leukocidin producing Staphylococcus aureus (organism)",
+                "include": true
+              },
+              {
+                "code": "711317006",
+                "display": "Staphylococcus aureus toxic shock syndrome toxin 1 (substance)",
+                "include": true
+              },
+              {
+                "code": "716530009",
+                "display": "Non-multiple drug resistant methicillin resistant Staphylococcus aureus (organism)",
+                "include": true
+              },
+              {
+                "code": "716531008",
+                "display": "Multiple drug resistant methicillin resistant Staphylococcus aureus (organism)",
+                "include": true
+              },
+              {
+                "code": "720301008",
+                "display": "Deoxyribonucleic acid of methicillin resistant Staphylococcus aureus (substance)",
+                "include": true
+              },
+              {
+                "code": "782499002",
+                "display": "Staphylococcus aureus toxin (substance)",
+                "include": true
+              }
+            ]
+          },
+          "2.16.840.1.113762.1.4.1146.1139_20250218": {
+            "valueSetId": "2.16.840.1.113762.1.4.1146.1139_20250218",
+            "valueSetVersion": "20250218",
+            "valueSetName": "VISA/VRSA\u00a0(Tests for\u00a0Vancomycin Resistance Gene)",
+            "valueSetExternalId": "2.16.840.1.113762.1.4.1146.1139",
+            "author": "CSTE Steward",
+            "system": "http://loinc.org",
+            "ersdConceptType": "labs",
+            "dibbsConceptType": "labs",
+            "includeValueSet": true,
+            "concepts": [
+              {
+                "code": "105816-3",
+                "display": "Vancomycin resistance vanA gene [Cycle Threshold #] in Positive blood culture by NAA with probe detection",
+                "include": true
+              },
+              {
+                "code": "105817-1",
+                "display": "Vancomycin resistance vanB gene [Cycle Threshold #] in Positive blood culture by NAA with probe detection",
+                "include": true
+              },
+              {
+                "code": "48814-8",
+                "display": "Vancomycin resistance vanA gene [Presence] by Molecular method",
+                "include": true
+              },
+              {
+                "code": "62261-3",
+                "display": "Vancomycin resistance vanA + vanB genes [Presence] by Molecular method",
+                "include": true
+              },
+              {
+                "code": "69379-6",
+                "display": "Vancomycin resistance vanA and vanB and vanC1 and vanC2 genes [Identifier] by Molecular method",
+                "include": true
+              },
+              {
+                "code": "72421-1",
+                "display": "Vancomycin resistance vanB gene [Presence] by Molecular method",
+                "include": true
+              },
+              {
+                "code": "72836-0",
+                "display": "Vancomycin resistance vanC2+vanC3 genes [Presence] by Molecular method",
+                "include": true
+              },
+              {
+                "code": "72837-8",
+                "display": "Vancomycin resistance vanC1 gene [Presence] by Molecular method",
+                "include": true
+              },
+              {
+                "code": "75753-4",
+                "display": "Vancomycin resistance vanD gene [Presence] by Molecular method",
+                "include": true
+              },
+              {
+                "code": "85787-0",
+                "display": "Vancomycin resistance vanA + vanB genes [Presence] by NAA with non-probe detection in Positive blood culture",
+                "include": true
+              },
+              {
+                "code": "88252-2",
+                "display": "Vancomycin resistance vanA gene [Presence] by Probe in Positive blood culture",
+                "include": true
+              },
+              {
+                "code": "88253-0",
+                "display": "Vancomycin resistance vanB gene [Presence] by Probe in Positive blood culture",
+                "include": true
+              },
+              {
+                "code": "92241-9",
+                "display": "Vancomycin [Susceptibility] by Genotype method",
+                "include": true
+              }
+            ]
+          },
+          "2.16.840.1.113762.1.4.1146.1138_20250218": {
+            "valueSetId": "2.16.840.1.113762.1.4.1146.1138_20250218",
+            "valueSetVersion": "20250218",
+            "valueSetName": "Staphylococcus Aureus (Tests\u202fby Culture and Identification Method)",
+            "valueSetExternalId": "2.16.840.1.113762.1.4.1146.1138",
+            "author": "CSTE Steward",
+            "system": "http://loinc.org",
+            "ersdConceptType": "labs",
+            "dibbsConceptType": "labs",
+            "includeValueSet": true,
+            "concepts": [
+              {
+                "code": "100897-8",
+                "display": "Staphylococcus aureus [Presence] in Specimen by Organism specific culture",
+                "include": true
+              },
+              {
+                "code": "103141-8",
+                "display": "Staphylococcus aureus MLVA complex [Type] in Isolate or Specimen by Molecular genetics method",
+                "include": true
+              },
+              {
+                "code": "105796-7",
+                "display": "Staphylococcus aureus DNA [Cycle Threshold #] in Positive blood culture by NAA with probe detection",
+                "include": true
+              },
+              {
+                "code": "106044-1",
+                "display": "Methicillin resistant Staphylococcus aureus [Presence] in Skin by Organism specific culture",
+                "include": true
+              },
+              {
+                "code": "106046-6",
+                "display": "Methicillin resistant Staphylococcus aureus [Presence] in Axilla by Organism specific culture",
+                "include": true
+              },
+              {
+                "code": "13317-3",
+                "display": "Methicillin resistant Staphylococcus aureus [Presence] in Specimen by Organism specific culture",
+                "include": true
+              },
+              {
+                "code": "52969-3",
+                "display": "Methicillin resistant Staphylococcus aureus [Presence] in Nose by Organism specific culture",
+                "include": true
+              },
+              {
+                "code": "53572-4",
+                "display": "Methicillin resistant Staphylococcus aureus [Presence] in Genital specimen by Organism specific culture",
+                "include": true
+              },
+              {
+                "code": "73558-9",
+                "display": "Staphylococcus aureus and Staphylococcus sp.coagulase negative rRNA [Identifier] by FISH in Positive blood culture",
+                "include": true
+              },
+              {
+                "code": "76081-9",
+                "display": "Methicillin resistant Staphylococcus aureus [Presence] in Pharynx by Organism specific culture",
+                "include": true
+              },
+              {
+                "code": "85042-0",
+                "display": "Staphylococcus aureus glycopeptide resistant identified [Type] in Isolate",
+                "include": true
+              },
+              {
+                "code": "85045-3",
+                "display": "Staphylococcus aureus glycopeptide resistant based on vancomycin and teicoplanin IC [Identifier] by ARD gradient strip",
+                "include": true
+              },
+              {
+                "code": "85765-6",
+                "display": "Staphylococcus aureus DNA [Presence] by NAA with non-probe detection in Positive blood culture",
+                "include": true
+              },
+              {
+                "code": "88269-6",
+                "display": "Staphylococcus aureus gyrB gene [Presence] by Probe in Positive blood culture",
+                "include": true
+              },
+              {
+                "code": "92777-2",
+                "display": "Staphylococcus aureus DNA [Presence] by NAA with probe detection in Positive blood culture",
+                "include": true
+              },
+              {
+                "code": "97325-5",
+                "display": "Staphylococcus aureus VNTR pattern [Type] in Isolate or Specimen by Molecular genetics method",
                 "include": true
               }
             ]
@@ -11313,7 +11971,793 @@
             ]
           }
         },
-        "734350003": {},
+        "734350003": {
+          "2.16.840.1.113762.1.4.1146.2255_20240123": {
+            "valueSetId": "2.16.840.1.113762.1.4.1146.2255_20240123",
+            "valueSetVersion": "20240123",
+            "valueSetName": "Carbapenem Resistant Bacterial Infection [Carbapenemase Producing] (SNOMED)",
+            "valueSetExternalId": "2.16.840.1.113762.1.4.1146.2255",
+            "author": "CSTE Steward",
+            "system": "http://snomed.info/sct",
+            "ersdConceptType": "conditions",
+            "dibbsConceptType": "conditions",
+            "includeValueSet": true,
+            "concepts": [
+              {
+                "code": "34521000087103",
+                "display": "Infection caused by carbapenemase-producing Enterobacteriaceae (disorder)",
+                "include": true
+              }
+            ]
+          },
+          "2.16.840.1.113762.1.4.1146.1882_20250219": {
+            "valueSetId": "2.16.840.1.113762.1.4.1146.1882_20250219",
+            "valueSetVersion": "20250219",
+            "valueSetName": "Carbapenemase production (Organism or Substance in Lab Results)",
+            "valueSetExternalId": "2.16.840.1.113762.1.4.1146.1882",
+            "author": "CSTE Steward",
+            "system": "http://snomed.info/sct",
+            "ersdConceptType": "labs",
+            "dibbsConceptType": "labs",
+            "includeValueSet": true,
+            "concepts": [
+              {
+                "code": "1085301000112105",
+                "display": "Carbapenemase-producing Acinetobacter calcoaceticus (organism)",
+                "include": true
+              },
+              {
+                "code": "1085401000112103",
+                "display": "Carbapenemase-producing Acinetobacter baumannii-Acinetobacter calcoaceticus complex (organism)",
+                "include": true
+              },
+              {
+                "code": "1085501000112104",
+                "display": "Carbapenemase-producing Acinetobacter (organism)",
+                "include": true
+              },
+              {
+                "code": "1085701000112109",
+                "display": "Carbapenemase-producing Acinetobacter johnsonii (organism)",
+                "include": true
+              },
+              {
+                "code": "1085801000112101",
+                "display": "Carbapenemase-producing Acinetobacter junii (organism)",
+                "include": true
+              },
+              {
+                "code": "1085901000112106",
+                "display": "Carbapenemase-producing Acinetobacter lwoffii (organism)",
+                "include": true
+              },
+              {
+                "code": "1086001000112103",
+                "display": "Carbapenemase-producing Acinetobacter nosocomialis (organism)",
+                "include": true
+              },
+              {
+                "code": "1086101000112102",
+                "display": "Carbapenemase-producing Acinetobacter radioresistens (organism)",
+                "include": true
+              },
+              {
+                "code": "1086201000112108",
+                "display": "Carbapenemase-producing Acinetobacter ursingii (organism)",
+                "include": true
+              },
+              {
+                "code": "1089101000112105",
+                "display": "Carbapenemase-producing Citrobacter amalonaticus (organism)",
+                "include": true
+              },
+              {
+                "code": "1089301000112107",
+                "display": "Carbapenemase-producing Citrobacter braakii (organism)",
+                "include": true
+              },
+              {
+                "code": "1089501000112101",
+                "display": "Carbapenemase-producing Citrobacter (organism)",
+                "include": true
+              },
+              {
+                "code": "1089701000112106",
+                "display": "Carbapenemase-producing Citrobacter farmeri (organism)",
+                "include": true
+              },
+              {
+                "code": "1089901000112108",
+                "display": "Carbapenemase-producing Citrobacter freundii (organism)",
+                "include": true
+              },
+              {
+                "code": "1090401000112109",
+                "display": "Carbapenemase-producing Citrobacter koseri (organism)",
+                "include": true
+              },
+              {
+                "code": "1091201000112104",
+                "display": "Carbapenemase-producing Citrobacter werkmanii (organism)",
+                "include": true
+              },
+              {
+                "code": "1091401000112100",
+                "display": "Carbapenemase-producing Citrobacter youngae (organism)",
+                "include": true
+              },
+              {
+                "code": "1092401000112105",
+                "display": "Carbapenemase-producing Cronobacter sakazakii (organism)",
+                "include": true
+              },
+              {
+                "code": "1093401000112101",
+                "display": "Carbapenemase-producing Enterobacter (organism)",
+                "include": true
+              },
+              {
+                "code": "1093601000112103",
+                "display": "Carbapenemase-producing Enterobacter asburiae (organism)",
+                "include": true
+              },
+              {
+                "code": "1094301000112105",
+                "display": "Carbapenemase-producing Enterobacter hormaechei (organism)",
+                "include": true
+              },
+              {
+                "code": "1096801000112108",
+                "display": "Carbapenemase-producing Klebsiella (organism)",
+                "include": true
+              },
+              {
+                "code": "1098201000112108",
+                "display": "Carbapenemase-producing Klebsiella pneumoniae (organism)",
+                "include": true
+              },
+              {
+                "code": "1099001000112108",
+                "display": "Carbapenemase-producing Kluyvera (organism)",
+                "include": true
+              },
+              {
+                "code": "1099201000112103",
+                "display": "Carbapenemase-producing Kluyvera ascorbata (organism)",
+                "include": true
+              },
+              {
+                "code": "1099401000112104",
+                "display": "Carbapenemase-producing Kluyvera cryocrescens (organism)",
+                "include": true
+              },
+              {
+                "code": "1099601000112101",
+                "display": "Carbapenemase-producing Kluyvera georgiana (organism)",
+                "include": true
+              },
+              {
+                "code": "1099801000112102",
+                "display": "Carbapenemase-producing Kluyvera intermedia (organism)",
+                "include": true
+              },
+              {
+                "code": "1100001000112108",
+                "display": "Carbapenemase-producing Leclercia (organism)",
+                "include": true
+              },
+              {
+                "code": "1100201000112103",
+                "display": "Carbapenemase-producing Leclercia adecarboxylata (organism)",
+                "include": true
+              },
+              {
+                "code": "1101601000112106",
+                "display": "Carbapenemase-producing Morganella morganii (organism)",
+                "include": true
+              },
+              {
+                "code": "1102601000112100",
+                "display": "Carbapenemase-producing Proteus (organism)",
+                "include": true
+              },
+              {
+                "code": "1103001000112103",
+                "display": "Carbapenemase-producing Proteus mirabilis (organism)",
+                "include": true
+              },
+              {
+                "code": "1103601000112105",
+                "display": "Carbapenemase-producing Providencia (organism)",
+                "include": true
+              },
+              {
+                "code": "1104001000112101",
+                "display": "Carbapenemase-producing Providencia rettgeri (organism)",
+                "include": true
+              },
+              {
+                "code": "1105401000112106",
+                "display": "Carbapenemase-producing Raoultella ornithinolytica (organism)",
+                "include": true
+              },
+              {
+                "code": "1105601000112109",
+                "display": "Carbapenemase-producing Raoultella planticola (organism)",
+                "include": true
+              },
+              {
+                "code": "1106001000112106",
+                "display": "Carbapenemase-producing Salmonella (organism)",
+                "include": true
+              },
+              {
+                "code": "1106601000112104",
+                "display": "Carbapenemase-producing Serratia fonticola (organism)",
+                "include": true
+              },
+              {
+                "code": "1107201000112104",
+                "display": "Carbapenemase-producing Serratia marcescens (organism)",
+                "include": true
+              },
+              {
+                "code": "1112101000112106",
+                "display": "Carbapenemase-producing Lelliottia amnigena (organism)",
+                "include": true
+              },
+              {
+                "code": "30731000112102",
+                "display": "Carbapenemase-producing Acinetobacter seifertii (organism)",
+                "include": true
+              },
+              {
+                "code": "33691000087101",
+                "display": "Carbapenemase-producing Klebsiella variicola (organism)",
+                "include": true
+              },
+              {
+                "code": "44601000087107",
+                "display": "Carbapenemase-producing Citrobacter freundii complex (organism)",
+                "include": true
+              },
+              {
+                "code": "51271000087100",
+                "display": "Carbapenemase-producing Klebsiella oxytoca (organism)",
+                "include": true
+              },
+              {
+                "code": "51281000087103",
+                "display": "Carbapenemase-producing Enterobacterales (organism)",
+                "include": true
+              },
+              {
+                "code": "713171002",
+                "display": "Klebsiella pneumoniae carbapenemase 2 producing Klebsiella pneumoniae (organism)",
+                "include": true
+              },
+              {
+                "code": "734350003",
+                "display": "Carbapenemase-producing bacteria (organism)",
+                "include": true
+              },
+              {
+                "code": "734351004",
+                "display": "Carbapenemase-producing Enterobacteriaceae (organism)",
+                "include": true
+              },
+              {
+                "code": "734352006",
+                "display": "Carbapenemase-producing Klebsiella aerogenes (organism)",
+                "include": true
+              },
+              {
+                "code": "734353001",
+                "display": "Carbapenemase-producing Enterobacter cloacae complex (organism)",
+                "include": true
+              },
+              {
+                "code": "737526007",
+                "display": "Carbapenemase-producing Acinetobacter baumannii (organism)",
+                "include": true
+              },
+              {
+                "code": "737527003",
+                "display": "Carbapenemase-producing Pseudomonas aeruginosa (organism)",
+                "include": true
+              },
+              {
+                "code": "737528008",
+                "display": "Carbapenemase-producing Escherichia coli (organism)",
+                "include": true
+              },
+              {
+                "code": "737529000",
+                "display": "Carbapenemase-producing Enterobacter cloacae (organism)",
+                "include": true
+              },
+              {
+                "code": "762987008",
+                "display": "Extended spectrum beta-lactamase and carbapenemase producing bacteria (organism)",
+                "include": true
+              },
+              {
+                "code": "770392005",
+                "display": "Carbapenemase-producing Raoultella (organism)",
+                "include": true
+              },
+              {
+                "code": "773734006",
+                "display": "OXA-48 carbapenemase-producing bacteria (organism)",
+                "include": true
+              }
+            ]
+          },
+          "2.16.840.1.113762.1.4.1146.1214_20230122": {
+            "valueSetId": "2.16.840.1.113762.1.4.1146.1214_20230122",
+            "valueSetVersion": "20230122",
+            "valueSetName": "Carbapenemase resistance mechanism (Organism or Substance in Lab Results)",
+            "valueSetExternalId": "2.16.840.1.113762.1.4.1146.1214",
+            "author": "CSTE Steward",
+            "system": "http://snomed.info/sct",
+            "ersdConceptType": "labs",
+            "dibbsConceptType": "labs",
+            "includeValueSet": true,
+            "concepts": [
+              {
+                "code": "1104601000112108",
+                "display": "Metallo-beta-lactamase producing Pseudomonas aeruginosa (organism)",
+                "include": true
+              },
+              {
+                "code": "713171002",
+                "display": "Klebsiella pneumoniae carbapenemase 2 producing Klebsiella pneumoniae (organism)",
+                "include": true
+              },
+              {
+                "code": "762987008",
+                "display": "Extended spectrum beta-lactamase and carbapenemase producing bacteria (organism)",
+                "include": true
+              },
+              {
+                "code": "773734006",
+                "display": "OXA-48 carbapenemase-producing bacteria (organism)",
+                "include": true
+              },
+              {
+                "code": "870562001",
+                "display": "Metallo-beta-lactamase producing bacteria (organism)",
+                "include": true
+              }
+            ]
+          },
+          "2.16.840.1.113762.1.4.1146.1216_20250219": {
+            "valueSetId": "2.16.840.1.113762.1.4.1146.1216_20250219",
+            "valueSetVersion": "20250219",
+            "valueSetName": "Tests for carbapenemase resistance mechanism",
+            "valueSetExternalId": "2.16.840.1.113762.1.4.1146.1216",
+            "author": "CSTE Steward",
+            "system": "http://loinc.org",
+            "ersdConceptType": "labs",
+            "dibbsConceptType": "labs",
+            "includeValueSet": true,
+            "concepts": [
+              {
+                "code": "100899-4",
+                "display": "Enterobacteriaceae.extended spectrum beta lactamase resistance phenotype [Identifier] in Specimen by Organism specific culture",
+                "include": true
+              },
+              {
+                "code": "100901-8",
+                "display": "Enterobacteriaceae.carbapenemase resistance phenotype [Identifier] in Anal by Organism specific culture",
+                "include": true
+              },
+              {
+                "code": "100902-6",
+                "display": "Enterobacteriaceae.carbapenemase resistance phenotype.OXA-48 [Identifier] in Anal by Organism specific culture",
+                "include": true
+              },
+              {
+                "code": "101123-8",
+                "display": "Bacterial carbapenem resistance blaIMI gene [Presence] by Molecular method",
+                "include": true
+              },
+              {
+                "code": "101124-6",
+                "display": "Bacterial carbapenem resistance blaIMI+blaNMC genes [Presence] by Molecular method",
+                "include": true
+              },
+              {
+                "code": "101125-3",
+                "display": "Bacterial carbapenem resistance blaOXA-235-like gene [Presence] by Molecular method",
+                "include": true
+              },
+              {
+                "code": "101126-1",
+                "display": "Bacterial carbapenem resistance blaOXA-24+blaOXA-40 gene [Presence] by Molecular method",
+                "include": true
+              },
+              {
+                "code": "101127-9",
+                "display": "Bacterial carbapenem resistance blaSIM gene [Presence] by Molecular method",
+                "include": true
+              },
+              {
+                "code": "101673-2",
+                "display": "KPC carbapenemase [Presence] in Isolate by Rapid immunoassay",
+                "include": true
+              },
+              {
+                "code": "101674-0",
+                "display": "OXA-48-like carbapenemase [Presence] in Isolate by Rapid immunoassay",
+                "include": true
+              },
+              {
+                "code": "101675-7",
+                "display": "IMP Carbapenemase [Presence] in Isolate by Rapid immunoassay",
+                "include": true
+              },
+              {
+                "code": "101676-5",
+                "display": "VIM Carbapenemase [Presence] in Isolate by Rapid immunoassay",
+                "include": true
+              },
+              {
+                "code": "101677-3",
+                "display": "NDM Carbapenemase [Presence] in Isolate by Rapid immunoassay",
+                "include": true
+              },
+              {
+                "code": "105013-7",
+                "display": "Bacterial carbapenem resistance blaGES-11 gene [Presence] by Molecular method",
+                "include": true
+              },
+              {
+                "code": "105014-5",
+                "display": "Bacterial Carbapenem resistance blaGES-5 gene [Presence] by Molecular method",
+                "include": true
+              },
+              {
+                "code": "105015-2",
+                "display": "Bacterial Carbapenem resistance blaGIM-1 gene [Presence] by Molecular method",
+                "include": true
+              },
+              {
+                "code": "105016-0",
+                "display": "Bacterial Carbapenem resistance blaKPC-18 gene [Presence] by Molecular method",
+                "include": true
+              },
+              {
+                "code": "105017-8",
+                "display": "Bacterial Carbapenem resistance blaKPC-2 gene [Presence] by Molecular method",
+                "include": true
+              },
+              {
+                "code": "105018-6",
+                "display": "Bacterial Carbapenem resistance blaKPC-3 gene [Presence] by Molecular method",
+                "include": true
+              },
+              {
+                "code": "105019-4",
+                "display": "Bacterial Carbapenem resistance blaNDM-1 gene [Presence] by Molecular method",
+                "include": true
+              },
+              {
+                "code": "105020-2",
+                "display": "Bacterial Carbapenem resistance blaNDM-19 gene [Presence] by Molecular method",
+                "include": true
+              },
+              {
+                "code": "105021-0",
+                "display": "Bacterial Carbapenem resistance blaNDM-4 gene [Presence] by Molecular method",
+                "include": true
+              },
+              {
+                "code": "105022-8",
+                "display": "Bacterial Carbapenem resistance blaNDM-5 gene [Presence] by Molecular method",
+                "include": true
+              },
+              {
+                "code": "105023-6",
+                "display": "Bacterial Carbapenem resistance blaNDM-7 gene [Presence] by Molecular method",
+                "include": true
+              },
+              {
+                "code": "105024-4",
+                "display": "Bacterial Carbapenem resistance blaNDM-9 gene [Presence] by Molecular method",
+                "include": true
+              },
+              {
+                "code": "105025-1",
+                "display": "Bacterial Carbapenem resistance blaOXA 181 gene [Presence] by Molecular method",
+                "include": true
+              },
+              {
+                "code": "105026-9",
+                "display": "Bacterial Carbapenem resistance blaOXA-162 gene [Presence] by Molecular method",
+                "include": true
+              },
+              {
+                "code": "105027-7",
+                "display": "Bacterial Carbapenem resistance blaOXA-23 gene [Presence] by Molecular method",
+                "include": true
+              },
+              {
+                "code": "105028-5",
+                "display": "Bacterial Carbapenem resistance blaOXA-232 gene [Presence] by Molecular method",
+                "include": true
+              },
+              {
+                "code": "105029-3",
+                "display": "Bacterial Carbapenem resistance blaOXA24/40 gene [Presence] by Molecular method",
+                "include": true
+              },
+              {
+                "code": "105030-1",
+                "display": "Bacterial Carbapenem resistance blaOXA-244 gene [Presence] by Molecular method",
+                "include": true
+              },
+              {
+                "code": "105031-9",
+                "display": "Bacterial Carbapenem resistance blaOXA-58 gene [Presence] by Molecular method",
+                "include": true
+              },
+              {
+                "code": "105032-7",
+                "display": "Bacterial Carbapenem resistance blaOXA-72 gene [Presence] by Molecular method",
+                "include": true
+              },
+              {
+                "code": "105033-5",
+                "display": "Bacterial Carbapenem resistance ISAba1 upstream blaOXA-51 gene [Presence] by Molecular method",
+                "include": true
+              },
+              {
+                "code": "105034-3",
+                "display": "Bacterial Carbapenem resistance blaVIM-1 gene [Presence] by Molecular method",
+                "include": true
+              },
+              {
+                "code": "105035-0",
+                "display": "Bacterial Carbapenem resistance blaVIM-2 gene [Presence] by Molecular method",
+                "include": true
+              },
+              {
+                "code": "105036-8",
+                "display": "Bacterial Carbapenem resistance blaVIM-4 gene [Presence] by Molecular method",
+                "include": true
+              },
+              {
+                "code": "105785-0",
+                "display": "Bacterial Carbapenem resistance blaOXA-23 gene [Cycle Threshold #] in Positive blood culture by NAA with probe detection",
+                "include": true
+              },
+              {
+                "code": "105786-8",
+                "display": "Bacterial carbapenem resistance blaOXA-24+blaOXA-40 gene [Cycle Threshold #] in Positive blood culture by NAA with probe detection",
+                "include": true
+              },
+              {
+                "code": "105788-4",
+                "display": "Bacterial carbapenem resistance blaOXA-58 [Cycle Threshold #] in Positive blood culture by NAA with probe detection",
+                "include": true
+              },
+              {
+                "code": "105791-8",
+                "display": "Bacterial carbapenem resistance SPM gene [Cycle Threshold #] in Positive blood culture by NAA with probe detection",
+                "include": true
+              },
+              {
+                "code": "49617-4",
+                "display": "Carbapenem resistance blaKPC gene [Presence] by Molecular method",
+                "include": true
+              },
+              {
+                "code": "63368-5",
+                "display": "Carbapenem resistance genes [Identifier] by NAA with probe detection",
+                "include": true
+              },
+              {
+                "code": "73834-4",
+                "display": "Bacteria.carbapenem resistant identified in Anal by Organism specific culture",
+                "include": true
+              },
+              {
+                "code": "73982-1",
+                "display": "Carbapenem resistance blaNDM gene [Presence] by Molecular method",
+                "include": true
+              },
+              {
+                "code": "77924-9",
+                "display": "Enterobacteriaceae.carbapenem resistant [Presence] in Anorectal or stool specimen by Organism specific culture",
+                "include": true
+              },
+              {
+                "code": "85498-4",
+                "display": "Carbapenem resistance blaIMP gene [Presence] by Molecular method",
+                "include": true
+              },
+              {
+                "code": "85499-2",
+                "display": "Carbapenem resistance blaKPC gene [Presence] by NAA with probe detection",
+                "include": true
+              },
+              {
+                "code": "85500-7",
+                "display": "Carbapenem resistance blaNDM gene [Presence] by NAA with probe detection",
+                "include": true
+              },
+              {
+                "code": "85501-5",
+                "display": "Carbapenem resistance blaVIM gene [Presence] by Molecular method",
+                "include": true
+              },
+              {
+                "code": "85503-1",
+                "display": "Carbapenem resistance blaOXA-48 gene [Presence] by Molecular method",
+                "include": true
+              },
+              {
+                "code": "85788-8",
+                "display": "Carbapenem resistance blaKPC gene [Presence] by NAA with non-probe detection in Positive blood culture",
+                "include": true
+              },
+              {
+                "code": "85823-3",
+                "display": "Carbapenem resistance blaGES gene [Presence] by Molecular method",
+                "include": true
+              },
+              {
+                "code": "85824-1",
+                "display": "Carbapenem resistance blaIMP gene [Presence] by NAA with probe detection",
+                "include": true
+              },
+              {
+                "code": "85825-8",
+                "display": "Carbapenem resistance blaOXA-23-like gene [Presence] by Molecular method",
+                "include": true
+              },
+              {
+                "code": "85826-6",
+                "display": "Carbapenem resistance blaOXA-24-like gene [Presence] by Molecular method",
+                "include": true
+              },
+              {
+                "code": "85827-4",
+                "display": "Carbapenem resistance bla OXA-48-like gene [Presence] by Molecular method",
+                "include": true
+              },
+              {
+                "code": "85828-2",
+                "display": "Carbapenem resistance blaOXA-58-like gene [Presence] by Molecular method",
+                "include": true
+              },
+              {
+                "code": "85829-0",
+                "display": "Carbapenem resistance blaSPM gene [Presence] by Molecular method",
+                "include": true
+              },
+              {
+                "code": "85830-8",
+                "display": "Carbapenem resistance blaVIM gene [Presence] by NAA with probe detection",
+                "include": true
+              },
+              {
+                "code": "85833-2",
+                "display": "Carbapenem resistance blaGIM gene [Presence] by Molecular method",
+                "include": true
+              },
+              {
+                "code": "86220-1",
+                "display": "Carbapenem resistance blaOXA-48 gene [Presence] in Specimen by NAA with probe detection",
+                "include": true
+              },
+              {
+                "code": "86712-7",
+                "display": "Carbapenem resistance blaOXA gene [Presence] by Molecular method",
+                "include": true
+              },
+              {
+                "code": "86713-5",
+                "display": "Carbapenem resistance blaOXA-134-like gene [Presence] by Molecular method",
+                "include": true
+              },
+              {
+                "code": "86714-3",
+                "display": "Carbapenem resistance blaOXA-51-like gene [Presence] by Molecular method",
+                "include": true
+              },
+              {
+                "code": "88245-6",
+                "display": "Carbapenem resistance blaIMP gene [Presence] by Probe in Positive blood culture",
+                "include": true
+              },
+              {
+                "code": "88246-4",
+                "display": "Carbapenem resistance blaKPC gene [Presence] by Probe in Positive blood culture",
+                "include": true
+              },
+              {
+                "code": "88247-2",
+                "display": "Carbapenem resistance blaNDM gene [Presence] by Probe in Positive blood culture",
+                "include": true
+              },
+              {
+                "code": "88248-0",
+                "display": "Carbapenem resistance blaOXA gene [Presence] by Probe in Positive blood culture",
+                "include": true
+              },
+              {
+                "code": "88249-8",
+                "display": "Carbapenem resistance blaVIM gene [Presence] by Probe in Positive blood culture",
+                "include": true
+              },
+              {
+                "code": "93390-3",
+                "display": "Carbapenem resistance blaOXA-23-like+blaOXA-48-like genes [Presence] in Isolate or Specimen by Molecular method",
+                "include": true
+              },
+              {
+                "code": "94151-8",
+                "display": "Bacteria.carbapenem resistant identified in Specimen by Organism specific culture",
+                "include": true
+              },
+              {
+                "code": "95540-1",
+                "display": "Carbapenem resistance blaIMP+blaVIM genes [Presence] by Molecular method",
+                "include": true
+              },
+              {
+                "code": "95809-0",
+                "display": "Carbapenem resistance genes [Presence] by Molecular method",
+                "include": true
+              },
+              {
+                "code": "98065-6",
+                "display": "Carbapenem resistance blaOXA-143 gene [Presence] by Molecular method",
+                "include": true
+              }
+            ]
+          },
+          "2.16.840.1.113762.1.4.1146.1215_20250219": {
+            "valueSetId": "2.16.840.1.113762.1.4.1146.1215_20250219",
+            "valueSetVersion": "20250219",
+            "valueSetName": "Tests for carbapenemase production",
+            "valueSetExternalId": "2.16.840.1.113762.1.4.1146.1215",
+            "author": "CSTE Steward",
+            "system": "http://loinc.org",
+            "ersdConceptType": "labs",
+            "dibbsConceptType": "labs",
+            "includeValueSet": true,
+            "concepts": [
+              {
+                "code": "102120-3",
+                "display": "Carbapenemase [Type] in Isolate by Immunoassay",
+                "include": true
+              },
+              {
+                "code": "74676-8",
+                "display": "Carbapenemase [Type] in Isolate by Carba NP",
+                "include": true
+              },
+              {
+                "code": "85047-9",
+                "display": "MBL by meropenem to meropenem-EDTA IC ratio [Presence] by ARD gradient strip",
+                "include": true
+              },
+              {
+                "code": "85053-7",
+                "display": "MBL by imipenem to imipenem-EDTA IC ratio [Presence] by ARD gradient strip",
+                "include": true
+              },
+              {
+                "code": "86930-5",
+                "display": "Carbapenemase [Presence] in Isolate",
+                "include": true
+              }
+            ]
+          }
+        },
         "715174007": {
           "2.16.840.1.113762.1.4.1146.1670_20220602": {
             "valueSetId": "2.16.840.1.113762.1.4.1146.1670_20220602",
@@ -11479,6 +12923,347 @@
               {
                 "code": "93406-7",
                 "display": "Acinetobacter baumannii DNA [Presence] by NAA with probe detection in Positive blood culture",
+                "include": true
+              }
+            ]
+          },
+          "2.16.840.1.113762.1.4.1146.1882_20250219": {
+            "valueSetId": "2.16.840.1.113762.1.4.1146.1882_20250219",
+            "valueSetVersion": "20250219",
+            "valueSetName": "Carbapenemase production (Organism or Substance in Lab Results)",
+            "valueSetExternalId": "2.16.840.1.113762.1.4.1146.1882",
+            "author": "CSTE Steward",
+            "system": "http://snomed.info/sct",
+            "ersdConceptType": "labs",
+            "dibbsConceptType": "labs",
+            "includeValueSet": true,
+            "concepts": [
+              {
+                "code": "1085301000112105",
+                "display": "Carbapenemase-producing Acinetobacter calcoaceticus (organism)",
+                "include": true
+              },
+              {
+                "code": "1085401000112103",
+                "display": "Carbapenemase-producing Acinetobacter baumannii-Acinetobacter calcoaceticus complex (organism)",
+                "include": true
+              },
+              {
+                "code": "1085501000112104",
+                "display": "Carbapenemase-producing Acinetobacter (organism)",
+                "include": true
+              },
+              {
+                "code": "1085701000112109",
+                "display": "Carbapenemase-producing Acinetobacter johnsonii (organism)",
+                "include": true
+              },
+              {
+                "code": "1085801000112101",
+                "display": "Carbapenemase-producing Acinetobacter junii (organism)",
+                "include": true
+              },
+              {
+                "code": "1085901000112106",
+                "display": "Carbapenemase-producing Acinetobacter lwoffii (organism)",
+                "include": true
+              },
+              {
+                "code": "1086001000112103",
+                "display": "Carbapenemase-producing Acinetobacter nosocomialis (organism)",
+                "include": true
+              },
+              {
+                "code": "1086101000112102",
+                "display": "Carbapenemase-producing Acinetobacter radioresistens (organism)",
+                "include": true
+              },
+              {
+                "code": "1086201000112108",
+                "display": "Carbapenemase-producing Acinetobacter ursingii (organism)",
+                "include": true
+              },
+              {
+                "code": "1089101000112105",
+                "display": "Carbapenemase-producing Citrobacter amalonaticus (organism)",
+                "include": true
+              },
+              {
+                "code": "1089301000112107",
+                "display": "Carbapenemase-producing Citrobacter braakii (organism)",
+                "include": true
+              },
+              {
+                "code": "1089501000112101",
+                "display": "Carbapenemase-producing Citrobacter (organism)",
+                "include": true
+              },
+              {
+                "code": "1089701000112106",
+                "display": "Carbapenemase-producing Citrobacter farmeri (organism)",
+                "include": true
+              },
+              {
+                "code": "1089901000112108",
+                "display": "Carbapenemase-producing Citrobacter freundii (organism)",
+                "include": true
+              },
+              {
+                "code": "1090401000112109",
+                "display": "Carbapenemase-producing Citrobacter koseri (organism)",
+                "include": true
+              },
+              {
+                "code": "1091201000112104",
+                "display": "Carbapenemase-producing Citrobacter werkmanii (organism)",
+                "include": true
+              },
+              {
+                "code": "1091401000112100",
+                "display": "Carbapenemase-producing Citrobacter youngae (organism)",
+                "include": true
+              },
+              {
+                "code": "1092401000112105",
+                "display": "Carbapenemase-producing Cronobacter sakazakii (organism)",
+                "include": true
+              },
+              {
+                "code": "1093401000112101",
+                "display": "Carbapenemase-producing Enterobacter (organism)",
+                "include": true
+              },
+              {
+                "code": "1093601000112103",
+                "display": "Carbapenemase-producing Enterobacter asburiae (organism)",
+                "include": true
+              },
+              {
+                "code": "1094301000112105",
+                "display": "Carbapenemase-producing Enterobacter hormaechei (organism)",
+                "include": true
+              },
+              {
+                "code": "1096801000112108",
+                "display": "Carbapenemase-producing Klebsiella (organism)",
+                "include": true
+              },
+              {
+                "code": "1098201000112108",
+                "display": "Carbapenemase-producing Klebsiella pneumoniae (organism)",
+                "include": true
+              },
+              {
+                "code": "1099001000112108",
+                "display": "Carbapenemase-producing Kluyvera (organism)",
+                "include": true
+              },
+              {
+                "code": "1099201000112103",
+                "display": "Carbapenemase-producing Kluyvera ascorbata (organism)",
+                "include": true
+              },
+              {
+                "code": "1099401000112104",
+                "display": "Carbapenemase-producing Kluyvera cryocrescens (organism)",
+                "include": true
+              },
+              {
+                "code": "1099601000112101",
+                "display": "Carbapenemase-producing Kluyvera georgiana (organism)",
+                "include": true
+              },
+              {
+                "code": "1099801000112102",
+                "display": "Carbapenemase-producing Kluyvera intermedia (organism)",
+                "include": true
+              },
+              {
+                "code": "1100001000112108",
+                "display": "Carbapenemase-producing Leclercia (organism)",
+                "include": true
+              },
+              {
+                "code": "1100201000112103",
+                "display": "Carbapenemase-producing Leclercia adecarboxylata (organism)",
+                "include": true
+              },
+              {
+                "code": "1101601000112106",
+                "display": "Carbapenemase-producing Morganella morganii (organism)",
+                "include": true
+              },
+              {
+                "code": "1102601000112100",
+                "display": "Carbapenemase-producing Proteus (organism)",
+                "include": true
+              },
+              {
+                "code": "1103001000112103",
+                "display": "Carbapenemase-producing Proteus mirabilis (organism)",
+                "include": true
+              },
+              {
+                "code": "1103601000112105",
+                "display": "Carbapenemase-producing Providencia (organism)",
+                "include": true
+              },
+              {
+                "code": "1104001000112101",
+                "display": "Carbapenemase-producing Providencia rettgeri (organism)",
+                "include": true
+              },
+              {
+                "code": "1105401000112106",
+                "display": "Carbapenemase-producing Raoultella ornithinolytica (organism)",
+                "include": true
+              },
+              {
+                "code": "1105601000112109",
+                "display": "Carbapenemase-producing Raoultella planticola (organism)",
+                "include": true
+              },
+              {
+                "code": "1106001000112106",
+                "display": "Carbapenemase-producing Salmonella (organism)",
+                "include": true
+              },
+              {
+                "code": "1106601000112104",
+                "display": "Carbapenemase-producing Serratia fonticola (organism)",
+                "include": true
+              },
+              {
+                "code": "1107201000112104",
+                "display": "Carbapenemase-producing Serratia marcescens (organism)",
+                "include": true
+              },
+              {
+                "code": "1112101000112106",
+                "display": "Carbapenemase-producing Lelliottia amnigena (organism)",
+                "include": true
+              },
+              {
+                "code": "30731000112102",
+                "display": "Carbapenemase-producing Acinetobacter seifertii (organism)",
+                "include": true
+              },
+              {
+                "code": "33691000087101",
+                "display": "Carbapenemase-producing Klebsiella variicola (organism)",
+                "include": true
+              },
+              {
+                "code": "44601000087107",
+                "display": "Carbapenemase-producing Citrobacter freundii complex (organism)",
+                "include": true
+              },
+              {
+                "code": "51271000087100",
+                "display": "Carbapenemase-producing Klebsiella oxytoca (organism)",
+                "include": true
+              },
+              {
+                "code": "51281000087103",
+                "display": "Carbapenemase-producing Enterobacterales (organism)",
+                "include": true
+              },
+              {
+                "code": "713171002",
+                "display": "Klebsiella pneumoniae carbapenemase 2 producing Klebsiella pneumoniae (organism)",
+                "include": true
+              },
+              {
+                "code": "734350003",
+                "display": "Carbapenemase-producing bacteria (organism)",
+                "include": true
+              },
+              {
+                "code": "734351004",
+                "display": "Carbapenemase-producing Enterobacteriaceae (organism)",
+                "include": true
+              },
+              {
+                "code": "734352006",
+                "display": "Carbapenemase-producing Klebsiella aerogenes (organism)",
+                "include": true
+              },
+              {
+                "code": "734353001",
+                "display": "Carbapenemase-producing Enterobacter cloacae complex (organism)",
+                "include": true
+              },
+              {
+                "code": "737526007",
+                "display": "Carbapenemase-producing Acinetobacter baumannii (organism)",
+                "include": true
+              },
+              {
+                "code": "737527003",
+                "display": "Carbapenemase-producing Pseudomonas aeruginosa (organism)",
+                "include": true
+              },
+              {
+                "code": "737528008",
+                "display": "Carbapenemase-producing Escherichia coli (organism)",
+                "include": true
+              },
+              {
+                "code": "737529000",
+                "display": "Carbapenemase-producing Enterobacter cloacae (organism)",
+                "include": true
+              },
+              {
+                "code": "762987008",
+                "display": "Extended spectrum beta-lactamase and carbapenemase producing bacteria (organism)",
+                "include": true
+              },
+              {
+                "code": "770392005",
+                "display": "Carbapenemase-producing Raoultella (organism)",
+                "include": true
+              },
+              {
+                "code": "773734006",
+                "display": "OXA-48 carbapenemase-producing bacteria (organism)",
+                "include": true
+              }
+            ]
+          },
+          "2.16.840.1.113762.1.4.1146.1214_20230122": {
+            "valueSetId": "2.16.840.1.113762.1.4.1146.1214_20230122",
+            "valueSetVersion": "20230122",
+            "valueSetName": "Carbapenemase resistance mechanism (Organism or Substance in Lab Results)",
+            "valueSetExternalId": "2.16.840.1.113762.1.4.1146.1214",
+            "author": "CSTE Steward",
+            "system": "http://snomed.info/sct",
+            "ersdConceptType": "labs",
+            "dibbsConceptType": "labs",
+            "includeValueSet": true,
+            "concepts": [
+              {
+                "code": "1104601000112108",
+                "display": "Metallo-beta-lactamase producing Pseudomonas aeruginosa (organism)",
+                "include": true
+              },
+              {
+                "code": "713171002",
+                "display": "Klebsiella pneumoniae carbapenemase 2 producing Klebsiella pneumoniae (organism)",
+                "include": true
+              },
+              {
+                "code": "762987008",
+                "display": "Extended spectrum beta-lactamase and carbapenemase producing bacteria (organism)",
+                "include": true
+              },
+              {
+                "code": "773734006",
+                "display": "OXA-48 carbapenemase-producing bacteria (organism)",
+                "include": true
+              },
+              {
+                "code": "870562001",
+                "display": "Metallo-beta-lactamase producing bacteria (organism)",
                 "include": true
               }
             ]
@@ -11711,6 +13496,347 @@
               {
                 "code": "93386-1",
                 "display": "Pseudomonas aeruginosa DNA [Presence] by NAA with probe detection in Positive blood culture",
+                "include": true
+              }
+            ]
+          },
+          "2.16.840.1.113762.1.4.1146.1882_20250219": {
+            "valueSetId": "2.16.840.1.113762.1.4.1146.1882_20250219",
+            "valueSetVersion": "20250219",
+            "valueSetName": "Carbapenemase production (Organism or Substance in Lab Results)",
+            "valueSetExternalId": "2.16.840.1.113762.1.4.1146.1882",
+            "author": "CSTE Steward",
+            "system": "http://snomed.info/sct",
+            "ersdConceptType": "labs",
+            "dibbsConceptType": "labs",
+            "includeValueSet": true,
+            "concepts": [
+              {
+                "code": "1085301000112105",
+                "display": "Carbapenemase-producing Acinetobacter calcoaceticus (organism)",
+                "include": true
+              },
+              {
+                "code": "1085401000112103",
+                "display": "Carbapenemase-producing Acinetobacter baumannii-Acinetobacter calcoaceticus complex (organism)",
+                "include": true
+              },
+              {
+                "code": "1085501000112104",
+                "display": "Carbapenemase-producing Acinetobacter (organism)",
+                "include": true
+              },
+              {
+                "code": "1085701000112109",
+                "display": "Carbapenemase-producing Acinetobacter johnsonii (organism)",
+                "include": true
+              },
+              {
+                "code": "1085801000112101",
+                "display": "Carbapenemase-producing Acinetobacter junii (organism)",
+                "include": true
+              },
+              {
+                "code": "1085901000112106",
+                "display": "Carbapenemase-producing Acinetobacter lwoffii (organism)",
+                "include": true
+              },
+              {
+                "code": "1086001000112103",
+                "display": "Carbapenemase-producing Acinetobacter nosocomialis (organism)",
+                "include": true
+              },
+              {
+                "code": "1086101000112102",
+                "display": "Carbapenemase-producing Acinetobacter radioresistens (organism)",
+                "include": true
+              },
+              {
+                "code": "1086201000112108",
+                "display": "Carbapenemase-producing Acinetobacter ursingii (organism)",
+                "include": true
+              },
+              {
+                "code": "1089101000112105",
+                "display": "Carbapenemase-producing Citrobacter amalonaticus (organism)",
+                "include": true
+              },
+              {
+                "code": "1089301000112107",
+                "display": "Carbapenemase-producing Citrobacter braakii (organism)",
+                "include": true
+              },
+              {
+                "code": "1089501000112101",
+                "display": "Carbapenemase-producing Citrobacter (organism)",
+                "include": true
+              },
+              {
+                "code": "1089701000112106",
+                "display": "Carbapenemase-producing Citrobacter farmeri (organism)",
+                "include": true
+              },
+              {
+                "code": "1089901000112108",
+                "display": "Carbapenemase-producing Citrobacter freundii (organism)",
+                "include": true
+              },
+              {
+                "code": "1090401000112109",
+                "display": "Carbapenemase-producing Citrobacter koseri (organism)",
+                "include": true
+              },
+              {
+                "code": "1091201000112104",
+                "display": "Carbapenemase-producing Citrobacter werkmanii (organism)",
+                "include": true
+              },
+              {
+                "code": "1091401000112100",
+                "display": "Carbapenemase-producing Citrobacter youngae (organism)",
+                "include": true
+              },
+              {
+                "code": "1092401000112105",
+                "display": "Carbapenemase-producing Cronobacter sakazakii (organism)",
+                "include": true
+              },
+              {
+                "code": "1093401000112101",
+                "display": "Carbapenemase-producing Enterobacter (organism)",
+                "include": true
+              },
+              {
+                "code": "1093601000112103",
+                "display": "Carbapenemase-producing Enterobacter asburiae (organism)",
+                "include": true
+              },
+              {
+                "code": "1094301000112105",
+                "display": "Carbapenemase-producing Enterobacter hormaechei (organism)",
+                "include": true
+              },
+              {
+                "code": "1096801000112108",
+                "display": "Carbapenemase-producing Klebsiella (organism)",
+                "include": true
+              },
+              {
+                "code": "1098201000112108",
+                "display": "Carbapenemase-producing Klebsiella pneumoniae (organism)",
+                "include": true
+              },
+              {
+                "code": "1099001000112108",
+                "display": "Carbapenemase-producing Kluyvera (organism)",
+                "include": true
+              },
+              {
+                "code": "1099201000112103",
+                "display": "Carbapenemase-producing Kluyvera ascorbata (organism)",
+                "include": true
+              },
+              {
+                "code": "1099401000112104",
+                "display": "Carbapenemase-producing Kluyvera cryocrescens (organism)",
+                "include": true
+              },
+              {
+                "code": "1099601000112101",
+                "display": "Carbapenemase-producing Kluyvera georgiana (organism)",
+                "include": true
+              },
+              {
+                "code": "1099801000112102",
+                "display": "Carbapenemase-producing Kluyvera intermedia (organism)",
+                "include": true
+              },
+              {
+                "code": "1100001000112108",
+                "display": "Carbapenemase-producing Leclercia (organism)",
+                "include": true
+              },
+              {
+                "code": "1100201000112103",
+                "display": "Carbapenemase-producing Leclercia adecarboxylata (organism)",
+                "include": true
+              },
+              {
+                "code": "1101601000112106",
+                "display": "Carbapenemase-producing Morganella morganii (organism)",
+                "include": true
+              },
+              {
+                "code": "1102601000112100",
+                "display": "Carbapenemase-producing Proteus (organism)",
+                "include": true
+              },
+              {
+                "code": "1103001000112103",
+                "display": "Carbapenemase-producing Proteus mirabilis (organism)",
+                "include": true
+              },
+              {
+                "code": "1103601000112105",
+                "display": "Carbapenemase-producing Providencia (organism)",
+                "include": true
+              },
+              {
+                "code": "1104001000112101",
+                "display": "Carbapenemase-producing Providencia rettgeri (organism)",
+                "include": true
+              },
+              {
+                "code": "1105401000112106",
+                "display": "Carbapenemase-producing Raoultella ornithinolytica (organism)",
+                "include": true
+              },
+              {
+                "code": "1105601000112109",
+                "display": "Carbapenemase-producing Raoultella planticola (organism)",
+                "include": true
+              },
+              {
+                "code": "1106001000112106",
+                "display": "Carbapenemase-producing Salmonella (organism)",
+                "include": true
+              },
+              {
+                "code": "1106601000112104",
+                "display": "Carbapenemase-producing Serratia fonticola (organism)",
+                "include": true
+              },
+              {
+                "code": "1107201000112104",
+                "display": "Carbapenemase-producing Serratia marcescens (organism)",
+                "include": true
+              },
+              {
+                "code": "1112101000112106",
+                "display": "Carbapenemase-producing Lelliottia amnigena (organism)",
+                "include": true
+              },
+              {
+                "code": "30731000112102",
+                "display": "Carbapenemase-producing Acinetobacter seifertii (organism)",
+                "include": true
+              },
+              {
+                "code": "33691000087101",
+                "display": "Carbapenemase-producing Klebsiella variicola (organism)",
+                "include": true
+              },
+              {
+                "code": "44601000087107",
+                "display": "Carbapenemase-producing Citrobacter freundii complex (organism)",
+                "include": true
+              },
+              {
+                "code": "51271000087100",
+                "display": "Carbapenemase-producing Klebsiella oxytoca (organism)",
+                "include": true
+              },
+              {
+                "code": "51281000087103",
+                "display": "Carbapenemase-producing Enterobacterales (organism)",
+                "include": true
+              },
+              {
+                "code": "713171002",
+                "display": "Klebsiella pneumoniae carbapenemase 2 producing Klebsiella pneumoniae (organism)",
+                "include": true
+              },
+              {
+                "code": "734350003",
+                "display": "Carbapenemase-producing bacteria (organism)",
+                "include": true
+              },
+              {
+                "code": "734351004",
+                "display": "Carbapenemase-producing Enterobacteriaceae (organism)",
+                "include": true
+              },
+              {
+                "code": "734352006",
+                "display": "Carbapenemase-producing Klebsiella aerogenes (organism)",
+                "include": true
+              },
+              {
+                "code": "734353001",
+                "display": "Carbapenemase-producing Enterobacter cloacae complex (organism)",
+                "include": true
+              },
+              {
+                "code": "737526007",
+                "display": "Carbapenemase-producing Acinetobacter baumannii (organism)",
+                "include": true
+              },
+              {
+                "code": "737527003",
+                "display": "Carbapenemase-producing Pseudomonas aeruginosa (organism)",
+                "include": true
+              },
+              {
+                "code": "737528008",
+                "display": "Carbapenemase-producing Escherichia coli (organism)",
+                "include": true
+              },
+              {
+                "code": "737529000",
+                "display": "Carbapenemase-producing Enterobacter cloacae (organism)",
+                "include": true
+              },
+              {
+                "code": "762987008",
+                "display": "Extended spectrum beta-lactamase and carbapenemase producing bacteria (organism)",
+                "include": true
+              },
+              {
+                "code": "770392005",
+                "display": "Carbapenemase-producing Raoultella (organism)",
+                "include": true
+              },
+              {
+                "code": "773734006",
+                "display": "OXA-48 carbapenemase-producing bacteria (organism)",
+                "include": true
+              }
+            ]
+          },
+          "2.16.840.1.113762.1.4.1146.1214_20230122": {
+            "valueSetId": "2.16.840.1.113762.1.4.1146.1214_20230122",
+            "valueSetVersion": "20230122",
+            "valueSetName": "Carbapenemase resistance mechanism (Organism or Substance in Lab Results)",
+            "valueSetExternalId": "2.16.840.1.113762.1.4.1146.1214",
+            "author": "CSTE Steward",
+            "system": "http://snomed.info/sct",
+            "ersdConceptType": "labs",
+            "dibbsConceptType": "labs",
+            "includeValueSet": true,
+            "concepts": [
+              {
+                "code": "1104601000112108",
+                "display": "Metallo-beta-lactamase producing Pseudomonas aeruginosa (organism)",
+                "include": true
+              },
+              {
+                "code": "713171002",
+                "display": "Klebsiella pneumoniae carbapenemase 2 producing Klebsiella pneumoniae (organism)",
+                "include": true
+              },
+              {
+                "code": "762987008",
+                "display": "Extended spectrum beta-lactamase and carbapenemase producing bacteria (organism)",
+                "include": true
+              },
+              {
+                "code": "773734006",
+                "display": "OXA-48 carbapenemase-producing bacteria (organism)",
+                "include": true
+              },
+              {
+                "code": "870562001",
+                "display": "Metallo-beta-lactamase producing bacteria (organism)",
                 "include": true
               }
             ]

--- a/src/app/backend/query-execution/custom-query.ts
+++ b/src/app/backend/query-execution/custom-query.ts
@@ -190,6 +190,15 @@ export class CustomQuery {
         }
       });
     });
+
+    // A value set can be attached to several of a query's conditions (the
+    // carbapenemase sets, for instance, belong to CRE, CPO, CRAB and CRPA), so
+    // the same code arrives once per condition. Left as-is those repeats are
+    // sent verbatim in the search body: the MDRO query's 1,314 lab codes are
+    // only 655 distinct ones.
+    this.labCodes = [...new Set(this.labCodes)];
+    this.conditionCodes = [...new Set(this.conditionCodes)];
+    this.medicationCodes = [...new Set(this.medicationCodes)];
   }
 
   /**

--- a/src/app/constants.ts
+++ b/src/app/constants.ts
@@ -172,12 +172,7 @@ export type BuildStep = "selection" | "condition" | "valueset";
 
 /* Mode that all pages can be in; used to set page data in context */
 export type PageType =
-  | "/"
-  | "queryBuilding"
-  | "fhir-servers"
-  | "userManagement"
-  | BuildStep
-  | Mode;
+  "/" | "queryBuilding" | "fhir-servers" | "userManagement" | BuildStep | Mode;
 
 export const metadata = {
   title: "Query Connector",
@@ -187,12 +182,7 @@ export const metadata = {
 export const DEFAULT_ERSD_VERSION = "3";
 
 export type ErsdConceptType =
-  | "ostc"
-  | "lotc"
-  | "lrtc"
-  | "mrtc"
-  | "dxtc"
-  | "sdtc";
+  "ostc" | "lotc" | "lrtc" | "mrtc" | "dxtc" | "sdtc";
 
 export const ersdToDibbsConceptMap: {
   [k in ErsdConceptType]: DibbsConceptType;

--- a/src/app/constants.ts
+++ b/src/app/constants.ts
@@ -35,6 +35,11 @@ export const USE_CASE_DETAILS = {
     condition: "Cancer (Leukemia)",
     id: "3389540d-1cca-4253-aa75-c1684dc5430f",
   },
+  mdro: {
+    queryName: "MDRO case investigation",
+    condition: "Healthcare-Associated Events",
+    id: "b4c9d2e7-6a1f-4e83-9c25-7f0a3d8b1e46",
+  },
 } as const;
 
 export type USE_CASES = keyof typeof USE_CASE_DETAILS;
@@ -167,7 +172,12 @@ export type BuildStep = "selection" | "condition" | "valueset";
 
 /* Mode that all pages can be in; used to set page data in context */
 export type PageType =
-  "/" | "queryBuilding" | "fhir-servers" | "userManagement" | BuildStep | Mode;
+  | "/"
+  | "queryBuilding"
+  | "fhir-servers"
+  | "userManagement"
+  | BuildStep
+  | Mode;
 
 export const metadata = {
   title: "Query Connector",
@@ -177,7 +187,12 @@ export const metadata = {
 export const DEFAULT_ERSD_VERSION = "3";
 
 export type ErsdConceptType =
-  "ostc" | "lotc" | "lrtc" | "mrtc" | "dxtc" | "sdtc";
+  | "ostc"
+  | "lotc"
+  | "lrtc"
+  | "mrtc"
+  | "dxtc"
+  | "sdtc";
 
 export const ersdToDibbsConceptMap: {
   [k in ErsdConceptType]: DibbsConceptType;

--- a/src/app/tests/assets/GoldenSickPatient.json
+++ b/src/app/tests/assets/GoldenSickPatient.json
@@ -11095,6 +11095,102 @@
       }
     },
     {
+      "fullUrl": "DiagnosticReport/1f0b7c34-9d52-4a18-bb60-2c4e8a7d5109",
+      "resource": {
+        "resourceType": "DiagnosticReport",
+        "id": "1f0b7c34-9d52-4a18-bb60-2c4e8a7d5109",
+        "status": "final",
+        "category": [
+          {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/v2-0074",
+                "code": "LAB",
+                "display": "Laboratory"
+              }
+            ]
+          }
+        ],
+        "code": {
+          "coding": [
+            {
+              "system": "http://loinc.org",
+              "code": "52969-3",
+              "display": "Methicillin resistant Staphylococcus aureus [Presence] in Nose by Organism specific culture"
+            }
+          ],
+          "text": "Methicillin resistant Staphylococcus aureus [Presence] in Nose by Organism specific culture"
+        },
+        "subject": {
+          "reference": "Patient/f288c654-6885-4f48-999c-48d776dc06af",
+          "display": "Hyper A Unlucky"
+        },
+        "effectiveDateTime": "2026-05-04",
+        "result": [
+          {
+            "reference": "Observation/a38fb8a1-d73e-4e92-84d8-0957d070afd0",
+            "display": "Methicillin resistant Staphylococcus aureus [Presence] in Nose by Organism specific culture"
+          },
+          {
+            "reference": "Observation/8eeef7e0-c1c8-451a-a209-e750ca1f3eef",
+            "display": "Methicillin resistance mecA gene [Presence] by Molecular method"
+          },
+          {
+            "reference": "Observation/b25bc48b-9dda-4645-80a4-67b87d954735",
+            "display": "Vancomycin resistance vanA gene [Presence] by Molecular method"
+          }
+        ]
+      },
+      "request": {
+        "method": "PUT",
+        "url": "DiagnosticReport/1f0b7c34-9d52-4a18-bb60-2c4e8a7d5109"
+      }
+    },
+    {
+      "fullUrl": "DiagnosticReport/6ad24e81-3f97-45c0-9e13-b8752da0c64f",
+      "resource": {
+        "resourceType": "DiagnosticReport",
+        "id": "6ad24e81-3f97-45c0-9e13-b8752da0c64f",
+        "status": "final",
+        "category": [
+          {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/v2-0074",
+                "code": "LAB",
+                "display": "Laboratory"
+              }
+            ]
+          }
+        ],
+        "code": {
+          "coding": [
+            {
+              "system": "http://loinc.org",
+              "code": "59150-3",
+              "display": "Vancomycin resistant enterococcus [Presence] in Anal by Organism specific culture"
+            }
+          ],
+          "text": "Vancomycin resistant enterococcus [Presence] in Anal by Organism specific culture"
+        },
+        "subject": {
+          "reference": "Patient/f288c654-6885-4f48-999c-48d776dc06af",
+          "display": "Hyper A Unlucky"
+        },
+        "effectiveDateTime": "2026-05-04",
+        "result": [
+          {
+            "reference": "Observation/c87a6d2d-370f-45ef-82b4-f1db689f458b",
+            "display": "Vancomycin resistant enterococcus [Presence] in Anal by Organism specific culture"
+          }
+        ]
+      },
+      "request": {
+        "method": "PUT",
+        "url": "DiagnosticReport/6ad24e81-3f97-45c0-9e13-b8752da0c64f"
+      }
+    },
+    {
       "fullUrl": "DiagnosticReport/b78d8981-5151-4120-b931-8c94d9ca7d14",
       "resource": {
         "resourceType": "DiagnosticReport",
@@ -11128,29 +11224,53 @@
         "effectiveDateTime": "2026-05-04",
         "result": [
           {
-            "reference": "Observation/a38fb8a1-d73e-4e92-84d8-0957d070afd0",
-            "display": "Methicillin resistant Staphylococcus aureus [Presence] in Nose by Organism specific culture"
-          },
-          {
-            "reference": "Observation/8eeef7e0-c1c8-451a-a209-e750ca1f3eef",
-            "display": "Methicillin resistance mecA gene [Presence] by Molecular method"
-          },
-          {
-            "reference": "Observation/b25bc48b-9dda-4645-80a4-67b87d954735",
-            "display": "Vancomycin resistance vanA gene [Presence] by Molecular method"
-          },
-          {
-            "reference": "Observation/c87a6d2d-370f-45ef-82b4-f1db689f458b",
-            "display": "Vancomycin resistant enterococcus [Presence] in Anal by Organism specific culture"
-          },
-          {
             "reference": "Observation/697e1ae3-c282-409d-aad7-8b49b3a857d8",
             "display": "Enterobacteriaceae.carbapenemase resistance phenotype [Identifier] in Anal by Organism specific culture"
           },
           {
             "reference": "Observation/8fbbe0ef-5bd1-48f5-912d-31bf64fb0cc4",
             "display": "KPC carbapenemase [Presence] in Isolate by Rapid immunoassay"
-          },
+          }
+        ]
+      },
+      "request": {
+        "method": "PUT",
+        "url": "DiagnosticReport/b78d8981-5151-4120-b931-8c94d9ca7d14"
+      }
+    },
+    {
+      "fullUrl": "DiagnosticReport/d5c31b7a-08e4-4f26-a91d-63be7c40f2d8",
+      "resource": {
+        "resourceType": "DiagnosticReport",
+        "id": "d5c31b7a-08e4-4f26-a91d-63be7c40f2d8",
+        "status": "final",
+        "category": [
+          {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/v2-0074",
+                "code": "LAB",
+                "display": "Laboratory"
+              }
+            ]
+          }
+        ],
+        "code": {
+          "coding": [
+            {
+              "system": "http://loinc.org",
+              "code": "90002-7",
+              "display": "Candida auris [Presence] in Specimen by Organism specific culture"
+            }
+          ],
+          "text": "Candida auris [Presence] in Specimen by Organism specific culture"
+        },
+        "subject": {
+          "reference": "Patient/f288c654-6885-4f48-999c-48d776dc06af",
+          "display": "Hyper A Unlucky"
+        },
+        "effectiveDateTime": "2026-05-04",
+        "result": [
           {
             "reference": "Observation/8b2a0a3b-2f08-4044-98c4-c9a76383c333",
             "display": "Candida auris [Presence] in Specimen by Organism specific culture"
@@ -11159,7 +11279,7 @@
       },
       "request": {
         "method": "PUT",
-        "url": "DiagnosticReport/b78d8981-5151-4120-b931-8c94d9ca7d14"
+        "url": "DiagnosticReport/d5c31b7a-08e4-4f26-a91d-63be7c40f2d8"
       }
     },
     {

--- a/src/app/tests/assets/GoldenSickPatient.json
+++ b/src/app/tests/assets/GoldenSickPatient.json
@@ -10613,6 +10613,778 @@
         "method": "PUT",
         "url": "MedicationStatement/b7d3c2a1-4e5f-4a6b-8c9d-0e1f2a3b4c5d"
       }
+    },
+    {
+      "fullUrl": "Observation/a38fb8a1-d73e-4e92-84d8-0957d070afd0",
+      "resource": {
+        "resourceType": "Observation",
+        "id": "a38fb8a1-d73e-4e92-84d8-0957d070afd0",
+        "status": "final",
+        "category": [
+          {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/observation-category",
+                "code": "laboratory",
+                "display": "Laboratory"
+              }
+            ],
+            "text": "Laboratory"
+          }
+        ],
+        "code": {
+          "coding": [
+            {
+              "system": "http://loinc.org",
+              "code": "52969-3",
+              "display": "Methicillin resistant Staphylococcus aureus [Presence] in Nose by Organism specific culture"
+            }
+          ],
+          "text": "Methicillin resistant Staphylococcus aureus [Presence] in Nose by Organism specific culture"
+        },
+        "subject": {
+          "reference": "Patient/f288c654-6885-4f48-999c-48d776dc06af"
+        },
+        "effectiveDateTime": "2026-05-04",
+        "valueCodeableConcept": {
+          "coding": [
+            {
+              "system": "http://snomed.info/sct",
+              "code": "115329001",
+              "display": "Methicillin resistant Staphylococcus aureus (organism)"
+            }
+          ],
+          "text": "Methicillin resistant Staphylococcus aureus (organism)"
+        },
+        "interpretation": [
+          {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/v3-ObservationInterpretation",
+                "code": "POS",
+                "display": "Positive"
+              }
+            ],
+            "text": "Positive"
+          }
+        ]
+      },
+      "request": {
+        "method": "PUT",
+        "url": "Observation/a38fb8a1-d73e-4e92-84d8-0957d070afd0"
+      }
+    },
+    {
+      "fullUrl": "Observation/8eeef7e0-c1c8-451a-a209-e750ca1f3eef",
+      "resource": {
+        "resourceType": "Observation",
+        "id": "8eeef7e0-c1c8-451a-a209-e750ca1f3eef",
+        "status": "final",
+        "category": [
+          {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/observation-category",
+                "code": "laboratory",
+                "display": "Laboratory"
+              }
+            ],
+            "text": "Laboratory"
+          }
+        ],
+        "code": {
+          "coding": [
+            {
+              "system": "http://loinc.org",
+              "code": "48813-0",
+              "display": "Methicillin resistance mecA gene [Presence] by Molecular method"
+            }
+          ],
+          "text": "Methicillin resistance mecA gene [Presence] by Molecular method"
+        },
+        "subject": {
+          "reference": "Patient/f288c654-6885-4f48-999c-48d776dc06af"
+        },
+        "effectiveDateTime": "2026-05-04",
+        "valueCodeableConcept": {
+          "coding": [
+            {
+              "system": "http://snomed.info/sct",
+              "code": "260373001",
+              "display": "Detected"
+            }
+          ],
+          "text": "Detected"
+        },
+        "interpretation": [
+          {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/v3-ObservationInterpretation",
+                "code": "POS",
+                "display": "Positive"
+              }
+            ],
+            "text": "Positive"
+          }
+        ]
+      },
+      "request": {
+        "method": "PUT",
+        "url": "Observation/8eeef7e0-c1c8-451a-a209-e750ca1f3eef"
+      }
+    },
+    {
+      "fullUrl": "Observation/b25bc48b-9dda-4645-80a4-67b87d954735",
+      "resource": {
+        "resourceType": "Observation",
+        "id": "b25bc48b-9dda-4645-80a4-67b87d954735",
+        "status": "final",
+        "category": [
+          {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/observation-category",
+                "code": "laboratory",
+                "display": "Laboratory"
+              }
+            ],
+            "text": "Laboratory"
+          }
+        ],
+        "code": {
+          "coding": [
+            {
+              "system": "http://loinc.org",
+              "code": "48814-8",
+              "display": "Vancomycin resistance vanA gene [Presence] by Molecular method"
+            }
+          ],
+          "text": "Vancomycin resistance vanA gene [Presence] by Molecular method"
+        },
+        "subject": {
+          "reference": "Patient/f288c654-6885-4f48-999c-48d776dc06af"
+        },
+        "effectiveDateTime": "2026-05-04",
+        "valueCodeableConcept": {
+          "coding": [
+            {
+              "system": "http://snomed.info/sct",
+              "code": "260415000",
+              "display": "Not detected"
+            }
+          ],
+          "text": "Not detected"
+        },
+        "interpretation": [
+          {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/v3-ObservationInterpretation",
+                "code": "NEG",
+                "display": "Negative"
+              }
+            ],
+            "text": "Negative"
+          }
+        ]
+      },
+      "request": {
+        "method": "PUT",
+        "url": "Observation/b25bc48b-9dda-4645-80a4-67b87d954735"
+      }
+    },
+    {
+      "fullUrl": "Observation/c87a6d2d-370f-45ef-82b4-f1db689f458b",
+      "resource": {
+        "resourceType": "Observation",
+        "id": "c87a6d2d-370f-45ef-82b4-f1db689f458b",
+        "status": "final",
+        "category": [
+          {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/observation-category",
+                "code": "laboratory",
+                "display": "Laboratory"
+              }
+            ],
+            "text": "Laboratory"
+          }
+        ],
+        "code": {
+          "coding": [
+            {
+              "system": "http://loinc.org",
+              "code": "59150-3",
+              "display": "Vancomycin resistant enterococcus [Presence] in Anal by Organism specific culture"
+            }
+          ],
+          "text": "Vancomycin resistant enterococcus [Presence] in Anal by Organism specific culture"
+        },
+        "subject": {
+          "reference": "Patient/f288c654-6885-4f48-999c-48d776dc06af"
+        },
+        "effectiveDateTime": "2026-05-04",
+        "valueCodeableConcept": {
+          "coding": [
+            {
+              "system": "http://snomed.info/sct",
+              "code": "113727004",
+              "display": "Vancomycin resistant Enterococcus (organism)"
+            }
+          ],
+          "text": "Vancomycin resistant Enterococcus (organism)"
+        },
+        "interpretation": [
+          {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/v3-ObservationInterpretation",
+                "code": "POS",
+                "display": "Positive"
+              }
+            ],
+            "text": "Positive"
+          }
+        ]
+      },
+      "request": {
+        "method": "PUT",
+        "url": "Observation/c87a6d2d-370f-45ef-82b4-f1db689f458b"
+      }
+    },
+    {
+      "fullUrl": "Observation/697e1ae3-c282-409d-aad7-8b49b3a857d8",
+      "resource": {
+        "resourceType": "Observation",
+        "id": "697e1ae3-c282-409d-aad7-8b49b3a857d8",
+        "status": "final",
+        "category": [
+          {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/observation-category",
+                "code": "laboratory",
+                "display": "Laboratory"
+              }
+            ],
+            "text": "Laboratory"
+          }
+        ],
+        "code": {
+          "coding": [
+            {
+              "system": "http://loinc.org",
+              "code": "100901-8",
+              "display": "Enterobacteriaceae.carbapenemase resistance phenotype [Identifier] in Anal by Organism specific culture"
+            }
+          ],
+          "text": "Enterobacteriaceae.carbapenemase resistance phenotype [Identifier] in Anal by Organism specific culture"
+        },
+        "subject": {
+          "reference": "Patient/f288c654-6885-4f48-999c-48d776dc06af"
+        },
+        "effectiveDateTime": "2026-05-04",
+        "valueCodeableConcept": {
+          "coding": [
+            {
+              "system": "http://snomed.info/sct",
+              "code": "713171002",
+              "display": "Klebsiella pneumoniae carbapenemase 2 producing Klebsiella pneumoniae (organism)"
+            }
+          ],
+          "text": "Klebsiella pneumoniae carbapenemase 2 producing Klebsiella pneumoniae (organism)"
+        },
+        "interpretation": [
+          {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/v3-ObservationInterpretation",
+                "code": "POS",
+                "display": "Positive"
+              }
+            ],
+            "text": "Positive"
+          }
+        ]
+      },
+      "request": {
+        "method": "PUT",
+        "url": "Observation/697e1ae3-c282-409d-aad7-8b49b3a857d8"
+      }
+    },
+    {
+      "fullUrl": "Observation/8fbbe0ef-5bd1-48f5-912d-31bf64fb0cc4",
+      "resource": {
+        "resourceType": "Observation",
+        "id": "8fbbe0ef-5bd1-48f5-912d-31bf64fb0cc4",
+        "status": "final",
+        "category": [
+          {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/observation-category",
+                "code": "laboratory",
+                "display": "Laboratory"
+              }
+            ],
+            "text": "Laboratory"
+          }
+        ],
+        "code": {
+          "coding": [
+            {
+              "system": "http://loinc.org",
+              "code": "101673-2",
+              "display": "KPC carbapenemase [Presence] in Isolate by Rapid immunoassay"
+            }
+          ],
+          "text": "KPC carbapenemase [Presence] in Isolate by Rapid immunoassay"
+        },
+        "subject": {
+          "reference": "Patient/f288c654-6885-4f48-999c-48d776dc06af"
+        },
+        "effectiveDateTime": "2026-05-04",
+        "valueCodeableConcept": {
+          "coding": [
+            {
+              "system": "http://snomed.info/sct",
+              "code": "260373001",
+              "display": "Detected"
+            }
+          ],
+          "text": "Detected"
+        },
+        "interpretation": [
+          {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/v3-ObservationInterpretation",
+                "code": "POS",
+                "display": "Positive"
+              }
+            ],
+            "text": "Positive"
+          }
+        ]
+      },
+      "request": {
+        "method": "PUT",
+        "url": "Observation/8fbbe0ef-5bd1-48f5-912d-31bf64fb0cc4"
+      }
+    },
+    {
+      "fullUrl": "Observation/8b2a0a3b-2f08-4044-98c4-c9a76383c333",
+      "resource": {
+        "resourceType": "Observation",
+        "id": "8b2a0a3b-2f08-4044-98c4-c9a76383c333",
+        "status": "final",
+        "category": [
+          {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/observation-category",
+                "code": "laboratory",
+                "display": "Laboratory"
+              }
+            ],
+            "text": "Laboratory"
+          }
+        ],
+        "code": {
+          "coding": [
+            {
+              "system": "http://loinc.org",
+              "code": "90002-7",
+              "display": "Candida auris [Presence] in Specimen by Organism specific culture"
+            }
+          ],
+          "text": "Candida auris [Presence] in Specimen by Organism specific culture"
+        },
+        "subject": {
+          "reference": "Patient/f288c654-6885-4f48-999c-48d776dc06af"
+        },
+        "effectiveDateTime": "2026-05-04",
+        "valueCodeableConcept": {
+          "coding": [
+            {
+              "system": "http://snomed.info/sct",
+              "code": "260373001",
+              "display": "Detected"
+            }
+          ],
+          "text": "Detected"
+        },
+        "interpretation": [
+          {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/v3-ObservationInterpretation",
+                "code": "POS",
+                "display": "Positive"
+              }
+            ],
+            "text": "Positive"
+          }
+        ]
+      },
+      "request": {
+        "method": "PUT",
+        "url": "Observation/8b2a0a3b-2f08-4044-98c4-c9a76383c333"
+      }
+    },
+    {
+      "fullUrl": "Observation/0984e5ff-4b4a-46cc-ba14-c00f8098fdb1",
+      "resource": {
+        "resourceType": "Observation",
+        "id": "0984e5ff-4b4a-46cc-ba14-c00f8098fdb1",
+        "status": "final",
+        "category": [
+          {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/observation-category",
+                "code": "laboratory",
+                "display": "Laboratory"
+              }
+            ],
+            "text": "Laboratory"
+          }
+        ],
+        "code": {
+          "coding": [
+            {
+              "system": "http://loinc.org",
+              "code": "13317-3",
+              "display": "Methicillin resistant Staphylococcus aureus [Presence] in Specimen by Organism specific culture"
+            }
+          ],
+          "text": "Methicillin resistant Staphylococcus aureus [Presence] in Specimen by Organism specific culture"
+        },
+        "subject": {
+          "reference": "Patient/f288c654-6885-4f48-999c-48d776dc06af"
+        },
+        "effectiveDateTime": "2026-06-18",
+        "valueCodeableConcept": {
+          "coding": [
+            {
+              "system": "http://snomed.info/sct",
+              "code": "115329001",
+              "display": "Methicillin resistant Staphylococcus aureus (organism)"
+            }
+          ],
+          "text": "Methicillin resistant Staphylococcus aureus (organism)"
+        },
+        "interpretation": [
+          {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/v3-ObservationInterpretation",
+                "code": "POS",
+                "display": "Positive"
+              }
+            ],
+            "text": "Positive"
+          }
+        ]
+      },
+      "request": {
+        "method": "PUT",
+        "url": "Observation/0984e5ff-4b4a-46cc-ba14-c00f8098fdb1"
+      }
+    },
+    {
+      "fullUrl": "DiagnosticReport/b78d8981-5151-4120-b931-8c94d9ca7d14",
+      "resource": {
+        "resourceType": "DiagnosticReport",
+        "id": "b78d8981-5151-4120-b931-8c94d9ca7d14",
+        "status": "final",
+        "category": [
+          {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/v2-0074",
+                "code": "LAB",
+                "display": "Laboratory"
+              }
+            ]
+          }
+        ],
+        "code": {
+          "coding": [
+            {
+              "system": "http://loinc.org",
+              "code": "100901-8",
+              "display": "Enterobacteriaceae.carbapenemase resistance phenotype [Identifier] in Anal by Organism specific culture"
+            }
+          ],
+          "text": "Enterobacteriaceae.carbapenemase resistance phenotype [Identifier] in Anal by Organism specific culture"
+        },
+        "subject": {
+          "reference": "Patient/f288c654-6885-4f48-999c-48d776dc06af",
+          "display": "Hyper A Unlucky"
+        },
+        "effectiveDateTime": "2026-05-04",
+        "result": [
+          {
+            "reference": "Observation/a38fb8a1-d73e-4e92-84d8-0957d070afd0",
+            "display": "Methicillin resistant Staphylococcus aureus [Presence] in Nose by Organism specific culture"
+          },
+          {
+            "reference": "Observation/8eeef7e0-c1c8-451a-a209-e750ca1f3eef",
+            "display": "Methicillin resistance mecA gene [Presence] by Molecular method"
+          },
+          {
+            "reference": "Observation/b25bc48b-9dda-4645-80a4-67b87d954735",
+            "display": "Vancomycin resistance vanA gene [Presence] by Molecular method"
+          },
+          {
+            "reference": "Observation/c87a6d2d-370f-45ef-82b4-f1db689f458b",
+            "display": "Vancomycin resistant enterococcus [Presence] in Anal by Organism specific culture"
+          },
+          {
+            "reference": "Observation/697e1ae3-c282-409d-aad7-8b49b3a857d8",
+            "display": "Enterobacteriaceae.carbapenemase resistance phenotype [Identifier] in Anal by Organism specific culture"
+          },
+          {
+            "reference": "Observation/8fbbe0ef-5bd1-48f5-912d-31bf64fb0cc4",
+            "display": "KPC carbapenemase [Presence] in Isolate by Rapid immunoassay"
+          },
+          {
+            "reference": "Observation/8b2a0a3b-2f08-4044-98c4-c9a76383c333",
+            "display": "Candida auris [Presence] in Specimen by Organism specific culture"
+          }
+        ]
+      },
+      "request": {
+        "method": "PUT",
+        "url": "DiagnosticReport/b78d8981-5151-4120-b931-8c94d9ca7d14"
+      }
+    },
+    {
+      "fullUrl": "DiagnosticReport/02ddd5a5-4b0a-42de-a9c7-cac1a9588988",
+      "resource": {
+        "resourceType": "DiagnosticReport",
+        "id": "02ddd5a5-4b0a-42de-a9c7-cac1a9588988",
+        "status": "final",
+        "category": [
+          {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/v2-0074",
+                "code": "LAB",
+                "display": "Laboratory"
+              }
+            ]
+          }
+        ],
+        "code": {
+          "coding": [
+            {
+              "system": "http://loinc.org",
+              "code": "13317-3",
+              "display": "Methicillin resistant Staphylococcus aureus [Presence] in Specimen by Organism specific culture"
+            }
+          ],
+          "text": "Methicillin resistant Staphylococcus aureus [Presence] in Specimen by Organism specific culture"
+        },
+        "subject": {
+          "reference": "Patient/f288c654-6885-4f48-999c-48d776dc06af",
+          "display": "Hyper A Unlucky"
+        },
+        "effectiveDateTime": "2026-06-18",
+        "result": [
+          {
+            "reference": "Observation/0984e5ff-4b4a-46cc-ba14-c00f8098fdb1",
+            "display": "Methicillin resistant Staphylococcus aureus [Presence] in Specimen by Organism specific culture"
+          }
+        ]
+      },
+      "request": {
+        "method": "PUT",
+        "url": "DiagnosticReport/02ddd5a5-4b0a-42de-a9c7-cac1a9588988"
+      }
+    },
+    {
+      "fullUrl": "Condition/c8753b49-389c-4042-ab72-4f662781d93c",
+      "resource": {
+        "resourceType": "Condition",
+        "id": "c8753b49-389c-4042-ab72-4f662781d93c",
+        "clinicalStatus": {
+          "coding": [
+            {
+              "system": "http://terminology.hl7.org/CodeSystem/condition-clinical",
+              "code": "active",
+              "display": "Active"
+            }
+          ],
+          "text": "Active"
+        },
+        "verificationStatus": {
+          "coding": [
+            {
+              "system": "http://terminology.hl7.org/CodeSystem/condition-ver-status",
+              "code": "confirmed",
+              "display": "Confirmed"
+            }
+          ],
+          "text": "Confirmed"
+        },
+        "category": [
+          {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/condition-category",
+                "code": "encounter-diagnosis",
+                "display": "Encounter Diagnosis"
+              }
+            ],
+            "text": "Encounter Diagnosis"
+          }
+        ],
+        "code": {
+          "coding": [
+            {
+              "system": "http://snomed.info/sct",
+              "code": "1176997000",
+              "display": "Skin infection caused by Methicillin resistant Staphylococcus aureus (disorder)"
+            },
+            {
+              "system": "http://hl7.org/fhir/sid/icd-10-cm",
+              "code": "A49.02",
+              "display": "Methicillin resistant Staphylococcus aureus infection, unspecified site"
+            },
+            {
+              "system": "http://hl7.org/fhir/sid/icd-10-cm",
+              "code": "B95.62",
+              "display": "Methicillin resistant Staphylococcus aureus infection as the cause of diseases classified elsewhere"
+            }
+          ],
+          "text": "MRSA skin and soft tissue infection of sacral wound"
+        },
+        "subject": {
+          "reference": "Patient/f288c654-6885-4f48-999c-48d776dc06af",
+          "type": "Patient"
+        },
+        "onsetDateTime": "2026-06-18"
+      },
+      "request": {
+        "method": "PUT",
+        "url": "Condition/c8753b49-389c-4042-ab72-4f662781d93c"
+      }
+    },
+    {
+      "fullUrl": "Condition/f4990d98-d527-47e6-972a-d80b985e0861",
+      "resource": {
+        "resourceType": "Condition",
+        "id": "f4990d98-d527-47e6-972a-d80b985e0861",
+        "clinicalStatus": {
+          "coding": [
+            {
+              "system": "http://terminology.hl7.org/CodeSystem/condition-clinical",
+              "code": "active",
+              "display": "Active"
+            }
+          ],
+          "text": "Active"
+        },
+        "verificationStatus": {
+          "coding": [
+            {
+              "system": "http://terminology.hl7.org/CodeSystem/condition-ver-status",
+              "code": "confirmed",
+              "display": "Confirmed"
+            }
+          ],
+          "text": "Confirmed"
+        },
+        "category": [
+          {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/condition-category",
+                "code": "encounter-diagnosis",
+                "display": "Encounter Diagnosis"
+              }
+            ],
+            "text": "Encounter Diagnosis"
+          }
+        ],
+        "code": {
+          "coding": [
+            {
+              "system": "http://snomed.info/sct",
+              "code": "712830002",
+              "display": "Infection due to carbapenem resistant Enterobacteriaceae (disorder)"
+            }
+          ],
+          "text": "Carbapenem-resistant Klebsiella pneumoniae urinary tract infection"
+        },
+        "subject": {
+          "reference": "Patient/f288c654-6885-4f48-999c-48d776dc06af",
+          "type": "Patient"
+        },
+        "onsetDateTime": "2026-06-18"
+      },
+      "request": {
+        "method": "PUT",
+        "url": "Condition/f4990d98-d527-47e6-972a-d80b985e0861"
+      }
+    },
+    {
+      "fullUrl": "Encounter/464eef6f-3750-44c2-9eb0-52abb1e1a3ab",
+      "resource": {
+        "resourceType": "Encounter",
+        "id": "464eef6f-3750-44c2-9eb0-52abb1e1a3ab",
+        "status": "finished",
+        "class": {
+          "system": "http://terminology.hl7.org/CodeSystem/v3-ActCode",
+          "code": "IMP",
+          "display": "inpatient encounter"
+        },
+        "subject": {
+          "reference": "Patient/f288c654-6885-4f48-999c-48d776dc06af",
+          "type": "Patient"
+        },
+        "period": {
+          "start": "2026-06-18",
+          "end": "2026-06-18"
+        },
+        "reasonCode": [
+          {
+            "coding": [
+              {
+                "system": "http://snomed.info/sct",
+                "code": "712830002",
+                "display": "Infection due to carbapenem resistant Enterobacteriaceae (disorder)"
+              }
+            ],
+            "text": "Infection due to carbapenem resistant Enterobacteriaceae (disorder)"
+          }
+        ],
+        "reasonReference": [
+          {
+            "reference": "Condition/f4990d98-d527-47e6-972a-d80b985e0861",
+            "type": "Condition"
+          }
+        ],
+        "diagnosis": [
+          {
+            "condition": {
+              "reference": "Condition/f4990d98-d527-47e6-972a-d80b985e0861",
+              "type": "Condition"
+            }
+          }
+        ],
+        "serviceProvider": {
+          "display": "Sunrise Long-Term Care Facility"
+        }
+      },
+      "request": {
+        "method": "PUT",
+        "url": "Encounter/464eef6f-3750-44c2-9eb0-52abb1e1a3ab"
+      }
     }
   ]
 }


### PR DESCRIPTION
# PULL REQUEST

## Summary

Adds an **"MDRO case investigation"** saved query and gives the Hyper Unlucky demo patient realistic multidrug-resistant organism results, so the query returns data instead of an empty record. This is the long-term care facility (LTCF) screening use case Tennessee described.

The query spans the nine MDRO conditions in the **Healthcare-Associated Events** category: MRSA, VRE, VISA, VRSA, CRE, CPO, CRAB, CRPA, and *Candida auris*.

**No terminology work was required.** The CSTE-stewarded value sets behind these conditions are already seeded and already carry the right LOINC test codes and SNOMED organism codes. What was missing was patient data matching those codes, and a query selecting the conditions.

### Clinical narrative

The demo patient already has chronic lymphoid leukemia seeded, which makes him plausibly immunocompromised and a realistic LTCF resident. The new data models two encounters:

| Date | Event |
|---|---|
| 2026-05-04 | Admission MDRO screening. Multi-site swabs: nares (MRSA), peri-rectal (VRE, CRE), axilla/groin (*C. auris*). MRSA, VRE, KPC-producing CRE and *C. auris* all positive; vanA negative on the *S. aureus* isolate. |
| 2026-06-18 | Clinical infection. MRSA sacral wound infection and a carbapenem-resistant *K. pneumoniae* UTI. |

That gives positives across all four headline LTCF organisms, one realistic negative, colonization *and* infection, and hits on all four resource branches the query compiles to.

### Modeling note worth a second opinion

Colonization screening is represented as **Observations only** — just the June infections get Conditions, since colonization is not a diagnosis. Representing it otherwise would teach partners the wrong model.

The tradeoff: if a facility reports colonization as `Condition` resources, an Observation-only query won't surface it. Flagging it explicitly because it's the most likely point of pushback.

## Related Issue

Supports the MDRO demo action item from the 2026-07-21 Tennessee sync. Companion to #1006 (race, ethnicity, and gender patient search parameters) from the same meeting.

## Additional Information

**Both seeding paths are covered**, so the query is present however the database is provisioned:

- `vs_dump.sql` — the e2e and integration Docker stacks (mounted as an initdb script)
- `dibbs_db_seed_query.json` — `createDibbsDB()`, which is what dev and fresh deployments use

Worth knowing these are the *only* ways it lands: `createDibbsDB()` early-returns whenever `valuesets` is non-empty, and initdb scripts only run against an empty data directory. An already-seeded environment needs a direct insert — that's how it was applied to queryconnector.dev, where this has been verified end-to-end against the live Aidbox.

**One value set is deliberately omitted.** The 3,873-concept *"Enterobacterales species [excluding Proteus/Providencia/Morganella] (Organism or Substance in Lab Results)"* set is species identification, not resistance-specific. Including it made the compiled `code=` filter roughly six times larger (~51 KB) without matching any of the demo patient's results. Without it the filter is ~9 KB / 655 unique lab codes, and every fixture code still matches.

**CRAB and CRPA have no patient data yet.** They're in the query so the condition list is complete, but nothing returns for them. Easy to add later — the value sets are already seeded.

**Incidental formatting.** The pre-commit Prettier hook reformatted two union types in `constants.ts` that this PR doesn't otherwise touch. The hook pins Prettier 3.1.0 (`mirrors-prettier v4.0.0-alpha.8`) while `package.json` is on 3.9.x, and they disagree on union formatting. Pre-existing drift, unrelated to this change, but it explains the extra hunks — probably worth a separate cleanup.

## Checklist

- [x] Descriptive Pull Request title
- [x] Link to relevant issues
- [x] Provide necessary context for design reviewers
- [x] Ensure test coverage is above agreed upon threshold
- [ ] Update documentation
