### PR TITLE
Release v1.2.0

### DIFF
--- a/app_version.yml
+++ b/app_version.yml
@@ -1,1 +1,1 @@
-version: 1.1.2
+version: 1.2.0

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "query-connector",
-  "version": "1.1.2",
+  "version": "1.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "query-connector",
-      "version": "1.1.2",
+      "version": "1.2.0",
       "dependencies": {
         "@aws-sdk/client-secrets-manager": "^3.1090.0",
         "@axe-core/playwright": "^4.12.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "query-connector",
   "description": "DIBBs Query Connector: a Next.js full-stack application for public health staff to query healthcare organizations for patient records via FHIR and TEFCA networks.",
-  "version": "1.1.2",
+  "version": "1.2.0",
   "private": true,
   "scripts": {
     "dev": "docker compose -f docker-compose-dev.yaml up -d && next dev --turbopack; docker compose -f docker-compose-dev.yaml down --remove-orphans",


### PR DESCRIPTION
## Summary
Bumps the app version to **v1.2.0** to trigger a release.

Minor release containing:
- #1006 — feat: race, ethnicity, and gender patient search parameters
- #1007 — feat: MDRO case investigation demo query and test patient results
- #1004 — Bump the minor-and-patch group with 11 updates
- #1008 — chore(deps): bump the majors group with 3 updates (fhirpath 5, jest-dom 7)