### PR TITLE
fix: send all Epic query strategy searches as GET requests

### DIFF
--- a/src/app/(pages)/fhirServers/page.tsx
+++ b/src/app/(pages)/fhirServers/page.tsx
@@ -18,11 +18,7 @@ import { FhirServersModal } from "./fhirServersModal";
 import { ModalRef } from "@/app/ui/designSystem/modal/Modal";
 
 export type AuthMethodType =
-  | "none"
-  | "basic"
-  | "client_credentials"
-  | "SMART"
-  | "mutual-tls";
+  "none" | "basic" | "client_credentials" | "SMART" | "mutual-tls";
 
 /**
  * The kind of FHIR endpoint a server exposes. Drives which resource the

--- a/src/app/(pages)/fhirServers/page.tsx
+++ b/src/app/(pages)/fhirServers/page.tsx
@@ -18,7 +18,11 @@ import { FhirServersModal } from "./fhirServersModal";
 import { ModalRef } from "@/app/ui/designSystem/modal/Modal";
 
 export type AuthMethodType =
-  "none" | "basic" | "client_credentials" | "SMART" | "mutual-tls";
+  | "none"
+  | "basic"
+  | "client_credentials"
+  | "SMART"
+  | "mutual-tls";
 
 /**
  * The kind of FHIR endpoint a server exposes. Drives which resource the
@@ -46,11 +50,12 @@ const ENDPOINT_TYPE_LABELS: Record<EndpointType, string> = {
  * EndpointType, which routes patient discovery:
  * - "default": spec-standard searches (POST /{Resource}/_search with code
  *   filters, Encounter searched by reason-code)
- * - "epic": Epic-compatible searches — GET-based Condition/Encounter/
- *   MedicationRequest/MedicationStatement queries, medications fetched
- *   patient-wide and filtered to the query's codes client-side, and
- *   Encounters found via references to the patient's matching Conditions
- *   (Epic's reason-code search matches text, not codes)
+ * - "epic": Epic-compatible searches — every search is a GET (Epic documents
+ *   no POST _search) with long code lists chunked across requests;
+ *   medications fetched patient-wide and filtered to the query's codes
+ *   client-side; Encounters found via references to the patient's matching
+ *   Conditions (Epic's reason-code search matches text, not codes); no
+ *   MedicationStatement search (Epic has no R4 endpoint for it)
  */
 export type QueryStrategy = "default" | "epic";
 

--- a/src/app/backend/query-execution/custom-query.test.ts
+++ b/src/app/backend/query-execution/custom-query.test.ts
@@ -8,6 +8,7 @@ import { DibbsValueSet } from "@/app/models/entities/valuesets";
 import { Patient } from "fhir/r4";
 
 const PATIENT_ID = "patient-123";
+const LOINC_CODE = "5199-7";
 const RXNORM_CODE = "1665005";
 const SNOMED_CODE = "240589008";
 
@@ -127,6 +128,43 @@ describe("CustomQuery medication queries", () => {
     expect(customQuery.getQuery("medicationStatement").basePath).toBe("");
   });
 });
+
+function buildLabsQuery(
+  queryStrategy: "default" | "epic" = "default",
+  labCodes: string[] = [LOINC_CODE],
+  timeboxWindows?: QueryTableResult["timeboxWindows"],
+  socialDeterminants = false,
+): CustomQuery {
+  const labsValueSet: DibbsValueSet = {
+    valueSetId: "vs-labs",
+    valueSetVersion: "1",
+    valueSetName: "Test Labs",
+    author: "test",
+    system: "http://loinc.org",
+    dibbsConceptType: "labs",
+    includeValueSet: true,
+    concepts: labCodes.map((code) => ({
+      code,
+      display: `Lab ${code}`,
+      include: true,
+    })),
+    userCreated: false,
+  };
+
+  const savedQuery: QueryTableResult = {
+    queryName: "Test Labs Query",
+    queryId: "query-labs",
+    queryData: { "condition-1": { "vs-labs": labsValueSet } },
+    conditionsList: [],
+    medicalRecordSections: {
+      ...EMPTY_MEDICAL_RECORD_SECTIONS,
+      socialDeterminants,
+    },
+    timeboxWindows,
+  };
+
+  return new CustomQuery(savedQuery, PATIENT_ID, queryStrategy);
+}
 
 describe("CustomQuery epic strategy", () => {
   it("keeps default-mode query shapes unchanged", () => {
@@ -269,6 +307,92 @@ describe("CustomQuery epic strategy", () => {
     const manyIds = Array.from({ length: 60 }, (_, i) => `cond-${i}`);
     expect(customQuery.compileEpicEncounterQueries(manyIds)).toHaveLength(3);
     expect(customQuery.compileEpicEncounterQueries([])).toHaveLength(0);
+  });
+
+  it("does not compile Observation or DiagnosticReport queries into the resource dictionary", () => {
+    const customQuery = buildLabsQuery("epic");
+    expect(customQuery.getQuery("observation").basePath).toBe("");
+    expect(customQuery.getQuery("diagnosticReport").basePath).toBe("");
+    expect(customQuery.compileAllPostRequests()).toHaveLength(0);
+
+    const defaultQuery = buildLabsQuery("default");
+    expect(defaultQuery.getQuery("observation").basePath).toBe(
+      "/Observation/_search",
+    );
+    expect(defaultQuery.getQuery("diagnosticReport").basePath).toBe(
+      "/DiagnosticReport/_search",
+    );
+    expect(defaultQuery.getQuery("observation").params.get("subject")).toBe(
+      `Patient/${PATIENT_ID}`,
+    );
+  });
+
+  it("compiles GET-based Observation and DiagnosticReport queries with the lab codes", () => {
+    const customQuery = buildLabsQuery("epic", [LOINC_CODE], {
+      labs: {
+        timeWindowStart: "2024-01-01T00:00:00Z",
+        timeWindowEnd: "2024-12-31T00:00:00Z",
+      },
+    });
+    const resultQueries = customQuery.compileEpicResultQueries();
+
+    expect(resultQueries.map((q) => q.basePath)).toEqual([
+      "/Observation",
+      "/DiagnosticReport",
+    ]);
+    for (const query of resultQueries) {
+      // Epic's search expects a bare patient id, not a Patient/ reference.
+      expect(query.params.get("patient")).toBe(PATIENT_ID);
+      expect(query.params.get("subject")).toBeNull();
+      expect(query.params.get("code")).toBe(LOINC_CODE);
+      expect(query.params.getAll("date")).toEqual([
+        "ge2024-01-01",
+        "le2024-12-31",
+      ]);
+    }
+    // Each query owns its params (the default path shares one object).
+    expect(resultQueries[0].params).not.toBe(resultQueries[1].params);
+
+    expect(buildLabsQuery("epic", []).compileEpicResultQueries()).toHaveLength(
+      0,
+    );
+  });
+
+  it("chunks long lab code lists across multiple GET queries per resource", () => {
+    const manyCodes = Array.from({ length: 120 }, (_, i) => `${10000 + i}-1`);
+    const resultQueries = buildLabsQuery(
+      "epic",
+      manyCodes,
+    ).compileEpicResultQueries();
+
+    expect(resultQueries).toHaveLength(6);
+    for (const basePath of ["/Observation", "/DiagnosticReport"]) {
+      const codes = resultQueries
+        .filter((q) => q.basePath === basePath)
+        .flatMap((q) => (q.params.get("code") ?? "").split(","));
+      expect(codes).toEqual(manyCodes);
+    }
+  });
+
+  it("builds the social history query as a GET with a bare patient id", () => {
+    const socialHistory = buildLabsQuery("epic", [], undefined, true).getQuery(
+      "socialHistory",
+    );
+    expect(socialHistory.basePath).toBe("/Observation");
+    expect(socialHistory.params.get("patient")).toBe(PATIENT_ID);
+    expect(socialHistory.params.get("subject")).toBeNull();
+    expect(socialHistory.params.get("category")).toBe("social-history");
+
+    const defaultSocialHistory = buildLabsQuery(
+      "default",
+      [],
+      undefined,
+      true,
+    ).getQuery("socialHistory");
+    expect(defaultSocialHistory.basePath).toBe("/Observation/_search");
+    expect(defaultSocialHistory.params.get("subject")).toBe(
+      `Patient/${PATIENT_ID}`,
+    );
   });
 });
 

--- a/src/app/backend/query-execution/custom-query.ts
+++ b/src/app/backend/query-execution/custom-query.ts
@@ -8,12 +8,14 @@ import {
 import { EndpointType, QueryStrategy } from "../../(pages)/fhirServers/page";
 import { HumanName, Patient } from "fhir/r4";
 
-// Epic-mode Condition and Encounter queries go out as GETs, so long code /
-// reference lists are chunked across multiple requests to keep URLs well under
-// common proxy limits. Overlapping results are safe: parseFhirSearch dedupes
-// resources by id.
+// Epic documents GET (never POST _search) as the only search method for every
+// resource, so Epic-mode queries go out as GETs and long code / reference
+// lists are chunked across multiple requests to keep URLs well under common
+// proxy limits. Overlapping results are safe: parseFhirSearch dedupes
+// resources by type and id.
 const EPIC_CONDITION_CODE_CHUNK_SIZE = 50;
 const EPIC_ENCOUNTER_DIAGNOSIS_CHUNK_SIZE = 25;
+const EPIC_RESULT_CODE_CHUNK_SIZE = 50;
 
 // Epic-mode medication searches can't filter by code server-side, so they
 // return every medication in the patient's record. We don't follow bundle
@@ -226,13 +228,23 @@ export class CustomQuery {
     const medicationsTimeFilter = formatTimeFilter(timeboxInfo?.medications);
 
     if (medicalRecordSections && medicalRecordSections.socialDeterminants) {
+      const isEpic = this.queryStrategy === "epic";
       const formattedParams = new URLSearchParams();
-      formattedParams.append("subject", `Patient/${patientId}`);
+      if (isEpic) {
+        // Epic's search expects a bare patient id, not a Patient/ reference.
+        formattedParams.append("patient", patientId);
+      } else {
+        formattedParams.append("subject", `Patient/${patientId}`);
+      }
       formattedParams.append("category", `social-history`);
 
       this.fhirResourceQueries["socialHistory"] = {
-        basePath: `/Observation/_search`,
+        // Epic documents GET-only search; the service layer dispatches this
+        // query itself (GET in Epic mode, POST _search otherwise), so it's
+        // kept out of the POST batch.
+        basePath: isEpic ? `/Observation` : `/Observation/_search`,
         params: formattedParams,
+        excludeFromPost: true,
       };
     }
 
@@ -293,7 +305,7 @@ export class CustomQuery {
       };
     }
 
-    if (labsFilter !== "") {
+    if (labsFilter !== "" && this.queryStrategy !== "epic") {
       const formattedParams = new URLSearchParams();
       formattedParams.append("subject", `Patient/${patientId}`);
       formattedParams.append("code", labsFilter);
@@ -313,6 +325,9 @@ export class CustomQuery {
         params: formattedParams,
       };
     }
+    // In Epic mode, Observation and DiagnosticReport queries aren't compiled
+    // here. Epic documents GET as the only search method, so the service layer
+    // issues chunked GETs built by compileEpicResultQueries() instead.
 
     if (conditionsFilter !== "" && this.queryStrategy !== "epic") {
       const encounterParams = new URLSearchParams();
@@ -418,9 +433,37 @@ export class CustomQuery {
   }
 
   /**
-   * Epic-mode Condition GET queries. Epic's POST _search support is limited
-   * to Observation/DiagnosticReport, so Conditions are searched via GET with
-   * the query's condition codes, chunked to keep URLs bounded.
+   * Epic-mode Observation and DiagnosticReport GET queries. Epic documents
+   * GET as the only search method for every resource (there is no POST
+   * _search), so the query's lab codes are searched via GET, chunked to keep
+   * URLs bounded. Each chunk yields one Observation and one DiagnosticReport
+   * query.
+   * @returns GET query specs for Observation and DiagnosticReport, one pair
+   * per chunk of lab codes; empty when the query has no lab codes.
+   */
+  compileEpicResultQueries(): { basePath: string; params: URLSearchParams }[] {
+    const labsTimeFilter = formatTimeFilter(this.timeboxInfo?.labs);
+
+    return chunkArray(this.labCodes, EPIC_RESULT_CODE_CHUNK_SIZE).flatMap(
+      (codes) =>
+        ["/Observation", "/DiagnosticReport"].map((basePath) => {
+          const params = new URLSearchParams();
+          // Epic's search expects a bare patient id, not a Patient/ reference.
+          params.append("patient", this.patientId);
+          params.append("code", codes.join(","));
+          if (labsTimeFilter) {
+            params.append("date", labsTimeFilter.startDate);
+            params.append("date", labsTimeFilter.endDate);
+          }
+          return { basePath, params };
+        }),
+    );
+  }
+
+  /**
+   * Epic-mode Condition GET queries. Epic documents GET as the only search
+   * method, so Conditions are searched via GET with the query's condition
+   * codes, chunked to keep URLs bounded.
    * @returns One GET query spec per chunk of condition codes; empty when the
    * query has no condition codes.
    */

--- a/src/app/backend/query-execution/epic-strategy.test.ts
+++ b/src/app/backend/query-execution/epic-strategy.test.ts
@@ -47,7 +47,10 @@ const RXNORM_CODE = "1665005";
 const OTHER_RXNORM_CODE = "999999";
 const SNOMED_CODE = "240589008";
 
-function buildSavedQuery(): QueryTableResult {
+function buildSavedQuery(
+  options: { labCodes?: string[]; socialDeterminants?: boolean } = {},
+): QueryTableResult {
+  const labCodes = options.labCodes ?? [LOINC_CODE];
   const labsValueSet: DibbsValueSet = {
     valueSetId: "vs-labs",
     valueSetVersion: "1",
@@ -56,7 +59,11 @@ function buildSavedQuery(): QueryTableResult {
     system: "http://loinc.org",
     dibbsConceptType: "labs",
     includeValueSet: true,
-    concepts: [{ code: LOINC_CODE, display: "HIV test", include: true }],
+    concepts: labCodes.map((code) => ({
+      code,
+      display: `Lab ${code}`,
+      include: true,
+    })),
     userCreated: false,
   };
 
@@ -97,7 +104,10 @@ function buildSavedQuery(): QueryTableResult {
     queryId: "query-hiv",
     queryData,
     conditionsList: [],
-    medicalRecordSections: EMPTY_MEDICAL_RECORD_SECTIONS,
+    medicalRecordSections: {
+      ...EMPTY_MEDICAL_RECORD_SECTIONS,
+      socialDeterminants: options.socialDeterminants ?? false,
+    },
   };
 }
 
@@ -202,19 +212,87 @@ describe("patientRecordsQuery with the epic query strategy", () => {
       `patient=${PATIENT_ID}`,
     );
 
-    // None of these resources are POSTed in epic mode; Observation and
-    // DiagnosticReport still use POST _search.
-    expect(postPaths).toEqual(
-      expect.arrayContaining([
-        "/Observation/_search",
-        "/DiagnosticReport/_search",
-      ]),
+    // Observation and DiagnosticReport are GETs too, scoped by a bare patient
+    // id and filtered by the query's lab codes.
+    const observationPath = getPaths.find((p) => p.startsWith("/Observation?"));
+    expect(observationPath).toContain(
+      `patient=${PATIENT_ID}&code=${LOINC_CODE}`,
     );
-    for (const path of postPaths) {
-      expect(path).not.toMatch(
-        /MedicationRequest|MedicationStatement|Condition|Encounter/,
+    expect(observationPath).not.toContain("Patient%2F");
+    expect(getPaths.find((p) => p.startsWith("/DiagnosticReport?"))).toContain(
+      `patient=${PATIENT_ID}&code=${LOINC_CODE}`,
+    );
+
+    // Epic documents GET-only search, so nothing is POSTed in epic mode.
+    expect(postPaths).toEqual([]);
+  });
+
+  it("chunks long lab code lists across Observation and DiagnosticReport GETs", async () => {
+    const manyCodes = Array.from({ length: 120 }, (_, i) => `${10000 + i}-1`);
+    (getSavedQueryByName as jest.Mock).mockResolvedValue(
+      buildSavedQuery({ labCodes: manyCodes }),
+    );
+
+    await runQuery();
+
+    const getPaths = mockFhirClient.get.mock.calls.map((c) => c[0] as string);
+    const observationPaths = getPaths.filter((p) =>
+      p.startsWith("/Observation?"),
+    );
+    const reportPaths = getPaths.filter((p) =>
+      p.startsWith("/DiagnosticReport?"),
+    );
+    expect(observationPaths).toHaveLength(3);
+    expect(reportPaths).toHaveLength(3);
+
+    const codesSent = (paths: string[]) =>
+      paths.flatMap((p) =>
+        (new URLSearchParams(p.split("?")[1]).get("code") ?? "").split(","),
       );
-    }
+    expect(codesSent(observationPaths)).toEqual(manyCodes);
+    expect(codesSent(reportPaths)).toEqual(manyCodes);
+    expect(mockFhirClient.post).not.toHaveBeenCalled();
+  });
+
+  it("still returns DiagnosticReports when the Observation search fails", async () => {
+    const report = {
+      resourceType: "DiagnosticReport",
+      id: "dr-1",
+      status: "final",
+      code: { coding: [{ system: "http://loinc.org", code: "36643-5" }] },
+    };
+    mockFhirClient.get.mockImplementation(async (path: string) => {
+      if (path.startsWith("/Observation?")) {
+        throw new Error("ECONNRESET");
+      }
+      if (path.startsWith("/DiagnosticReport?")) {
+        return mockBundleResponse(path, {
+          resourceType: "Bundle",
+          type: "searchset",
+          entry: [{ resource: report }],
+        });
+      }
+      return mockBundleResponse(path, EMPTY_BUNDLE);
+    });
+
+    const result = await runQuery();
+
+    expect(result.DiagnosticReport?.map((r) => r.id)).toEqual(["dr-1"]);
+    expect(result.Observation).toBeUndefined();
+  });
+
+  it("issues the social history search as a GET", async () => {
+    (getSavedQueryByName as jest.Mock).mockResolvedValue(
+      buildSavedQuery({ socialDeterminants: true }),
+    );
+
+    await runQuery();
+
+    const getPaths = mockFhirClient.get.mock.calls.map((c) => c[0] as string);
+    expect(getPaths).toContain(
+      `/Observation?patient=${PATIENT_ID}&category=social-history`,
+    );
+    expect(mockFhirClient.post).not.toHaveBeenCalled();
   });
 
   it("skips the Encounter search when no Conditions match", async () => {
@@ -236,10 +314,7 @@ describe("patientRecordsQuery with the epic query strategy", () => {
       if (path.startsWith("/Condition")) {
         throw new Error("ECONNRESET");
       }
-      return mockBundleResponse(path, EMPTY_BUNDLE);
-    });
-    mockFhirClient.post.mockImplementation(async (path: string) => {
-      if (path.startsWith("/Observation")) {
+      if (path.startsWith("/Observation?")) {
         return mockBundleResponse(path, {
           resourceType: "Bundle",
           type: "searchset",
@@ -488,9 +563,15 @@ describe("patientRecordsQuery with the epic query strategy", () => {
         "/MedicationStatement/_search",
         "/Condition/_search",
         "/Encounter/_search",
+        "/Observation/_search",
+        "/DiagnosticReport/_search",
       ]),
     );
     const getPaths = mockFhirClient.get.mock.calls.map((c) => c[0] as string);
     expect(getPaths.some((p) => p.startsWith("/Condition?"))).toBe(false);
+    expect(getPaths.some((p) => p.startsWith("/Observation?"))).toBe(false);
+    expect(getPaths.some((p) => p.startsWith("/DiagnosticReport?"))).toBe(
+      false,
+    );
   });
 });

--- a/src/app/backend/query-execution/service.ts
+++ b/src/app/backend/query-execution/service.ts
@@ -525,8 +525,12 @@ class QueryService {
     ) {
       try {
         const { basePath, params } = builtQuery.getQuery("socialHistory");
+        // Epic documents GET-only search; other servers get the spec-standard
+        // POST _search.
         medicalRecordSectionResults.push(
-          await fhirClient.post(basePath, params),
+          queryStrategy === "epic"
+            ? await fhirClient.get(`${basePath}?${params}`)
+            : await fhirClient.post(basePath, params),
         );
       } catch (error) {
         console.error("Social history FHIR query failed: ", error);
@@ -557,12 +561,14 @@ class QueryService {
         });
 
     if (queryStrategy === "epic" && !isImmunizationGateway) {
-      // Epic doesn't support POST _search (or server-side code filtering) for
-      // MedicationRequest, so it goes out as a GET alongside the POST batch,
-      // followed by reads of any referenced Medications the search didn't
-      // include (Epic ignores _include). Medication results are filtered to
-      // the query's codes downstream. MedicationStatement isn't queried in
-      // Epic mode at all — Epic has no R4 endpoint for it.
+      // Epic documents GET as the only search method for every resource (no
+      // POST _search), so every Epic-mode search goes out as a GET and the
+      // POST batch above is empty. MedicationRequest additionally can't be
+      // code-filtered server-side, so its GET is followed by reads of any
+      // referenced Medications the search didn't include (Epic ignores
+      // _include) and the results are filtered to the query's codes
+      // downstream. MedicationStatement isn't queried in Epic mode at all —
+      // Epic has no R4 endpoint for it.
       const { basePath, params } = builtQuery.getQuery("medicationRequest");
       if (basePath !== "") {
         postPromises.push(
@@ -574,6 +580,7 @@ class QueryService {
       }
       postPromises.push(
         QueryService.runEpicConditionEncounterChain(fhirClient, builtQuery),
+        QueryService.runEpicResultQueries(fhirClient, builtQuery),
       );
     }
 
@@ -626,6 +633,31 @@ class QueryService {
       medicationFilterCodes:
         queryStrategy === "epic" ? builtQuery.medicationCodes : undefined,
     };
+  }
+
+  /**
+   * Epic-mode Observation and DiagnosticReport retrieval. Epic documents GET
+   * as the only search method, so the query's lab codes go out as chunked
+   * GETs (one Observation and one DiagnosticReport search per chunk) instead
+   * of the default POST _search. Each request is independent, so one failure
+   * doesn't lose the others.
+   * @param fhirClient - client for the FHIR server being queried
+   * @param builtQuery - the compiled CustomQuery
+   * @returns the Observation and DiagnosticReport responses that succeeded
+   */
+  private static async runEpicResultQueries(
+    fhirClient: FHIRClient,
+    builtQuery: CustomQuery,
+  ): Promise<Response[]> {
+    const results = await Promise.allSettled(
+      builtQuery
+        .compileEpicResultQueries()
+        .map(({ basePath, params }) => fhirClient.get(`${basePath}?${params}`)),
+    );
+    return QueryService.collectSettledResponses(
+      results,
+      "Epic Observation/DiagnosticReport FHIR query rejected: ",
+    );
   }
 
   /**

--- a/src/docs/fhir-connection-guide.mdx
+++ b/src/docs/fhir-connection-guide.mdx
@@ -187,8 +187,11 @@ that would otherwise cause queries to silently return incomplete records:
   references those Conditions. If no Conditions match, the Encounter search
   is skipped.
 
-Observation and DiagnosticReport queries are unaffected — Epic supports
-code-filtered searches for those natively.
+- Epic's FHIR search APIs are documented as GET only — there is no
+  `POST /{Resource}/_search` support for any resource, including Observation
+  and DiagnosticReport. With the Epic strategy, every patient record search
+  is sent as a GET, with long code lists split across multiple requests to
+  keep URLs short.
 
 Optional settings:
 


### PR DESCRIPTION
# PULL REQUEST

## Summary

CA CDPH's TB test query against Cedars-Sinai's Epic returned no DiagnosticReport for the confirmatory chest X-ray, even though Cedars confirmed it exists on the test patient and retrieved it with a plain `GET DiagnosticReport?patient={id}&code=36643-5`.

The Epic query strategy (#966, refined in #998) moved Condition, Encounter, MedicationRequest and Immunization to GET but left Observation, DiagnosticReport and the social-history Observation search on `POST /{Resource}/_search`, on the assumption that Epic's POST support was reliable for those. Checking Epic's API specifications for every R4 search QC issues — DiagnosticReport.Search (Results), Observation.Search (Labs / Social History), Condition, MedicationRequest, Encounter, Immunization, Procedure, ServiceRequest, DocumentReference, Patient — each one documents `GET` as its HTTP method. Epic publishes no `POST …/_search` specification for any resource.

With this change, every patient-record search in Epic mode is a GET:

- **Observation / DiagnosticReport**: Epic mode no longer compiles the POST entries. A new `CustomQuery.compileEpicResultQueries()` emits one Observation and one DiagnosticReport GET per chunk of 50 lab codes (reusing `chunkArray`), with a bare `patient={id}` — matching the other Epic-mode searches after #998 — and the labs time filter. `QueryService.runEpicResultQueries()` dispatches them with `allSettled` + `collectSettledResponses`, so a failed chunk doesn't lose the others. Each request gets its own `URLSearchParams` (the default path shares one object between the two resources).
- **Social history**: `GET /Observation?patient={id}&category=social-history` in Epic mode; default mode keeps POST `_search`. It is also now marked `excludeFromPost` — it was previously both in the POST batch *and* dispatched separately, so default-mode servers received the search twice.
- Default strategy is unchanged: spec-standard POST `_search` remains the right choice for servers that support it and avoids URL-length concerns.
- Docs (`fhir-connection-guide.mdx`) and the `QueryStrategy` docstring now describe Epic mode as GET-only.

Request fan-out is the trade-off: lab codes weren't chunked before because they rode in a POST body. The MDRO query (655 distinct LOINCs) becomes ~14 GETs each for Observation and DiagnosticReport; TB/HIV/STI-sized queries stay at 1–3 per resource. Requests already run concurrently.

## Related Issue

Follow-up to #966 and #998 (CDPH ↔ Cedars-Sinai Epic testing).

## Additional Information

**Testing**

- Unit: new cases in `epic-strategy.test.ts` and `custom-query.test.ts` cover the GET dispatch and bare patient id, no POSTs at all in Epic mode, chunking (120 codes → 3 Observation + 3 DiagnosticReport requests), DiagnosticReport results surviving an Observation request failure, the social-history GET, and the default-strategy regression (extended to assert Observation/DiagnosticReport still POST). Full unit suite green.
- End-to-end against local Aidbox with the server's query strategy flipped to Epic: the Chlamydia demo query returns identical Observation (4) and DiagnosticReport (3) rows to default mode, and the results drawer's request log shows 15 requests, all GET, zero POST.

**For CDPH's retest**, two things this PR doesn't change could still hide the X-ray: the TB query's lab value sets must contain 36643-5 (QC only sends labs-type LOINCs), and the labs time window must cover the report's `effectiveDateTime`. The results drawer request log will show the exact `GET /DiagnosticReport?…` sent.

## Checklist

- [x] Descriptive Pull Request title
- [x] Link to relevant issues
- [x] Provide necessary context for design reviewers (no UI changes)
- [x] Ensure test coverage is above agreed upon threshold
- [x] Update documentation
