### PR TITLE
feat: query ImmunizationRecommendation on Immunization Gateways and surface the FHIR server select

### DIFF
--- a/e2e/audit_logs.spec.ts
+++ b/e2e/audit_logs.spec.ts
@@ -9,10 +9,7 @@ import { runAxeAccessibilityChecks } from "./utils";
 async function generateAuditEntry(page: Page) {
   await page.goto(TEST_URL);
   await page.getByRole("button", { name: "Fill fields" }).click();
-  await page.getByRole("button", { name: "Advanced" }).click();
-  await page
-    .getByLabel("Healthcare Organization (HCO)")
-    .selectOption(DEFAULT_FHIR_SERVER);
+  await page.getByLabel("FHIR server").selectOption(DEFAULT_FHIR_SERVER);
   await page.getByRole("button", { name: "Search for patient" }).click();
   await expect(page.getByText("Loading")).toHaveCount(0, { timeout: 10000 });
 }

--- a/e2e/mtls.spec.ts
+++ b/e2e/mtls.spec.ts
@@ -185,17 +185,10 @@ testWithMock.describe("Mutual TLS", () => {
         }),
       ).toBeVisible();
 
-      // Click "Advanced" to show FHIR server selection
-      await page.getByRole("button", { name: "Advanced" }).click();
+      // The FHIR server select is always visible on the search form
+      await expect(page.getByLabel("FHIR server")).toBeVisible();
 
-      // Wait for advanced options to be visible
-      await expect(
-        page.getByLabel("Healthcare Organization (HCO)"),
-      ).toBeVisible();
-
-      await page
-        .getByLabel("Healthcare Organization (HCO)")
-        .selectOption(serverName);
+      await page.getByLabel("FHIR server").selectOption(serverName);
 
       // Fill out the patient lookup form
       await page.getByTestId("textInput").nth(0).fill("John"); // First name

--- a/e2e/query_editing.spec.ts
+++ b/e2e/query_editing.spec.ts
@@ -428,7 +428,7 @@ async function checkForCancerMedication(
   await expect(
     page.getByRole("heading", { name: "Select a query" }),
   ).toBeVisible();
-  await page.getByTestId("Select").selectOption(queryName);
+  await page.getByTestId("query-select").selectOption(queryName);
 
   await page.getByRole("button", { name: "Submit" }).click();
   await expect(page.getByText("Loading")).toHaveCount(0, { timeout: 10000 });

--- a/e2e/query_execution.spec.ts
+++ b/e2e/query_execution.spec.ts
@@ -28,10 +28,7 @@ test.describe("querying with the Query Connector", () => {
     await page.getByLabel("First name").fill("Shouldnt");
     await page.getByLabel("Last name").fill("Findanyone");
     // Select FHIR server from drop down
-    await page.getByRole("button", { name: "Advanced" }).click();
-    await page
-      .getByLabel("Healthcare Organization (HCO)")
-      .selectOption(DEFAULT_FHIR_SERVER);
+    await page.getByLabel("FHIR server").selectOption(DEFAULT_FHIR_SERVER);
 
     await page.getByRole("button", { name: "Search for patient" }).click();
 
@@ -76,10 +73,7 @@ test.describe("querying with the Query Connector", () => {
 
     await page.getByRole("button", { name: "Fill fields" }).click();
     // Select FHIR server from drop down
-    await page.getByRole("button", { name: "Advanced" }).click();
-    await page
-      .getByLabel("Healthcare Organization (HCO)")
-      .selectOption(DEFAULT_FHIR_SERVER);
+    await page.getByLabel("FHIR server").selectOption(DEFAULT_FHIR_SERVER);
     await runAxeAccessibilityChecks(page);
 
     await page.getByRole("button", { name: "Search for patient" }).click();
@@ -91,7 +85,7 @@ test.describe("querying with the Query Connector", () => {
       page.getByRole("heading", { name: "Select a query" }),
     ).toBeVisible();
     await page
-      .getByTestId("Select")
+      .getByTestId("query-select")
       .selectOption("Chlamydia case investigation");
 
     await runAxeAccessibilityChecks(page);
@@ -104,6 +98,10 @@ test.describe("querying with the Query Connector", () => {
       page.getByRole("heading", { name: "Patient Record" }),
     ).toBeVisible();
     await expect(page.getByText("Patient Name")).toBeVisible();
+    // The results header shows which FHIR server answered the query
+    await expect(page.getByTestId("results-fhir-server")).toContainText(
+      DEFAULT_FHIR_SERVER,
+    );
     await expect(page.getByText(TEST_PATIENT_NAME)).toBeVisible();
     await expect(page.getByText("Patient Identifiers")).toBeVisible();
     await expect(
@@ -257,10 +255,7 @@ test.describe("alternate queries with the Query Connector", () => {
     await page.getByLabel("Medical Record Number").clear();
 
     // Select FHIR server from drop down
-    await page.getByRole("button", { name: "Advanced" }).click();
-    await page
-      .getByLabel("Healthcare Organization (HCO)")
-      .selectOption(DEFAULT_FHIR_SERVER);
+    await page.getByLabel("FHIR server").selectOption(DEFAULT_FHIR_SERVER);
 
     // Among verification, make sure phone number is right
     await page.getByRole("button", { name: "Search for patient" }).click();
@@ -273,7 +268,7 @@ test.describe("alternate queries with the Query Connector", () => {
       page.getByRole("heading", { name: PAGE_TITLES["select-query"].title }),
     ).toBeVisible();
     await page
-      .getByTestId("Select")
+      .getByTestId("query-select")
       .selectOption("Chlamydia case investigation");
     await page.getByRole("button", { name: "Submit" }).click();
     await expect(page.getByText("Loading")).toHaveCount(0, { timeout: 10000 });
@@ -290,10 +285,7 @@ test.describe("alternate queries with the Query Connector", () => {
   test("cancer query with generalized function", async ({ page }) => {
     await page.getByRole("button", { name: "Fill fields" }).click();
     // Select FHIR server from drop down
-    await page.getByRole("button", { name: "Advanced" }).click();
-    await page
-      .getByLabel("Healthcare Organization (HCO)")
-      .selectOption(DEFAULT_FHIR_SERVER);
+    await page.getByLabel("FHIR server").selectOption(DEFAULT_FHIR_SERVER);
 
     await page.getByRole("button", { name: "Search for patient" }).click();
     await expect(page.getByText("Loading")).toHaveCount(0, { timeout: 10000 });
@@ -302,7 +294,9 @@ test.describe("alternate queries with the Query Connector", () => {
     await expect(
       page.getByRole("heading", { name: "Select a query" }),
     ).toBeVisible();
-    await page.getByTestId("Select").selectOption("Cancer case investigation");
+    await page
+      .getByTestId("query-select")
+      .selectOption("Cancer case investigation");
     await page.getByRole("button", { name: "Submit" }).click();
     await expect(page.getByText("Loading")).toHaveCount(0, { timeout: 10000 });
 
@@ -316,16 +310,13 @@ test.describe("alternate queries with the Query Connector", () => {
   }) => {
     await page.getByRole("button", { name: "Fill fields" }).click();
     // Select FHIR server from drop down
-    await page.getByRole("button", { name: "Advanced" }).click();
-    await page
-      .getByLabel("Healthcare Organization (HCO)")
-      .selectOption(DEFAULT_FHIR_SERVER);
+    await page.getByLabel("FHIR server").selectOption(DEFAULT_FHIR_SERVER);
 
     await page.getByRole("button", { name: "Search for patient" }).click();
     await expect(page.getByText("Loading")).toHaveCount(0, { timeout: 10000 });
     await page.getByRole("button", { name: "Select patient" }).nth(0).click();
     await page
-      .getByTestId("Select")
+      .getByTestId("query-select")
       .selectOption("Chlamydia case investigation");
     await page.getByRole("button", { name: "Submit" }).click();
     await expect(page.getByText("Loading")).toHaveCount(0, { timeout: 10000 });
@@ -340,10 +331,7 @@ test.describe("alternate queries with the Query Connector", () => {
   }) => {
     await page.getByRole("button", { name: "Fill fields" }).click();
     // Select FHIR server from drop down
-    await page.getByRole("button", { name: "Advanced" }).click();
-    await page
-      .getByLabel("Healthcare Organization (HCO)")
-      .selectOption(DEFAULT_FHIR_SERVER);
+    await page.getByLabel("FHIR server").selectOption(DEFAULT_FHIR_SERVER);
 
     await page.getByRole("button", { name: "Search for patient" }).click();
     await expect(page.getByText("Loading")).toHaveCount(0, { timeout: 10000 });
@@ -352,7 +340,9 @@ test.describe("alternate queries with the Query Connector", () => {
     await expect(
       page.getByRole("heading", { name: "Select a query" }),
     ).toBeVisible();
-    await page.getByTestId("Select").selectOption("MDRO case investigation");
+    await page
+      .getByTestId("query-select")
+      .selectOption("MDRO case investigation");
     await page.getByRole("button", { name: "Submit" }).click();
     await expect(page.getByText("Loading")).toHaveCount(0, { timeout: 10000 });
 

--- a/src/app/(pages)/fhirServers/fhirServersModal.tsx
+++ b/src/app/(pages)/fhirServers/fhirServersModal.tsx
@@ -1156,8 +1156,8 @@ export const FhirServersModal: React.FC<FhirServersModal> = ({
       <Label htmlFor="endpoint-type">Endpoint Type</Label>
       <div className="usa-hint margin-bottom-1 margin-top-05">
         Determines which resource is queried: Standard FHIR uses /Patient,
-        Immunization Gateway uses /Immunization, and Fanout uses /Task-based
-        discovery.
+        Immunization Gateway uses /Immunization and /ImmunizationRecommendation,
+        and Fanout uses /Task-based discovery.
       </div>
       <select
         className="usa-select margin-top-05"

--- a/src/app/(pages)/fhirServers/page.tsx
+++ b/src/app/(pages)/fhirServers/page.tsx
@@ -18,11 +18,7 @@ import { FhirServersModal } from "./fhirServersModal";
 import { ModalRef } from "@/app/ui/designSystem/modal/Modal";
 
 export type AuthMethodType =
-  | "none"
-  | "basic"
-  | "client_credentials"
-  | "SMART"
-  | "mutual-tls";
+  "none" | "basic" | "client_credentials" | "SMART" | "mutual-tls";
 
 /**
  * The kind of FHIR endpoint a server exposes. Drives which resource the

--- a/src/app/(pages)/fhirServers/page.tsx
+++ b/src/app/(pages)/fhirServers/page.tsx
@@ -18,7 +18,11 @@ import { FhirServersModal } from "./fhirServersModal";
 import { ModalRef } from "@/app/ui/designSystem/modal/Modal";
 
 export type AuthMethodType =
-  "none" | "basic" | "client_credentials" | "SMART" | "mutual-tls";
+  | "none"
+  | "basic"
+  | "client_credentials"
+  | "SMART"
+  | "mutual-tls";
 
 /**
  * The kind of FHIR endpoint a server exposes. Drives which resource the
@@ -26,9 +30,10 @@ export type AuthMethodType =
  * - "standard": direct /Patient search and clinical record queries
  * - "immunization": an Immunization Gateway (probes /Immunization), discovery
  *   still uses the standard /Patient path. Record queries send only the
- *   Immunization search, built from the patient's demographics
+ *   Immunization and ImmunizationRecommendation (history + forecast)
+ *   searches, built from the patient's demographics
  *   (patient.given/patient.family/patient.birthdate) — the gateway
- *   translates it into an HL7v2 QBP query and can't resolve FHIR patient
+ *   translates them into HL7v2 QBP queries and can't resolve FHIR patient
  *   ids or answer other resource searches
  * - "fanout": TEFCA-style fanout via /Task resources (POST + polling)
  */

--- a/src/app/(pages)/query/components/ResultsView.test.tsx
+++ b/src/app/(pages)/query/components/ResultsView.test.tsx
@@ -68,6 +68,31 @@ const POPULATED_RESPONSE = {
   fhirRequests: [{ method: "GET", url: "https://fhir.example.com/Patient" }],
 } as unknown as PatientRecordsResponse;
 
+const FORECAST_RESPONSE = {
+  ...POPULATED_RESPONSE,
+  ImmunizationRecommendation: [
+    {
+      resourceType: "ImmunizationRecommendation",
+      id: "ir1",
+      patient: { reference: "Patient/p1" },
+      recommendation: [
+        {
+          vaccineCode: [{ text: "MMR" }],
+          forecastStatus: { text: "Due" },
+          dateCriterion: [
+            {
+              code: {
+                coding: [{ system: "http://loinc.org", code: "30980-7" }],
+              },
+              value: "2026-09-01",
+            },
+          ],
+        },
+      ],
+    },
+  ],
+} as unknown as PatientRecordsResponse;
+
 describe("ResultsView", () => {
   beforeAll(() => {
     const windowMock = {
@@ -284,5 +309,70 @@ describe("ResultsView", () => {
     // The accordion container is present but empty (no resource sections).
     const accordion = screen.getByTestId("accordion");
     expect(accordion).toBeEmptyDOMElement();
+  });
+  it("splits the Immunizations section into history and forecast when recommendations are present", () => {
+    renderWithUser(
+      <ResultsView
+        patientRecordsResponse={FORECAST_RESPONSE}
+        selectedQuery={TEST_QUERY}
+        goBack={() => {}}
+        goToBeginning={() => {}}
+        loading={false}
+      />,
+    );
+
+    expect(screen.getByText("Immunization history")).toBeInTheDocument();
+    expect(screen.getByText("Immunization forecast")).toBeInTheDocument();
+    expect(screen.getByText("MMR")).toBeInTheDocument();
+    expect(screen.getByText("Due")).toBeInTheDocument();
+    expect(screen.getByText("09/01/2026")).toBeInTheDocument();
+  });
+
+  it("renders the immunization table without sub-headings when there is no forecast", () => {
+    renderWithUser(
+      <ResultsView
+        patientRecordsResponse={POPULATED_RESPONSE}
+        selectedQuery={TEST_QUERY}
+        goBack={() => {}}
+        goToBeginning={() => {}}
+        loading={false}
+      />,
+    );
+
+    expect(screen.queryByText("Immunization history")).not.toBeInTheDocument();
+    expect(screen.queryByText("Immunization forecast")).not.toBeInTheDocument();
+    // The Immunization fixture's occurrence date still renders in the table.
+    expect(screen.getByText("01/01/2023")).toBeInTheDocument();
+  });
+
+  it("shows the queried FHIR server name when provided", () => {
+    renderWithUser(
+      <ResultsView
+        patientRecordsResponse={POPULATED_RESPONSE}
+        selectedQuery={TEST_QUERY}
+        goBack={() => {}}
+        goToBeginning={() => {}}
+        loading={false}
+        fhirServer="IZ Gateway: eHealthExchange"
+      />,
+    );
+
+    const serverLine = screen.getByTestId("results-fhir-server");
+    expect(serverLine).toHaveTextContent("FHIR server:");
+    expect(serverLine).toHaveTextContent("IZ Gateway: eHealthExchange");
+  });
+
+  it("omits the FHIR server line when no server name is provided", () => {
+    renderWithUser(
+      <ResultsView
+        patientRecordsResponse={POPULATED_RESPONSE}
+        selectedQuery={TEST_QUERY}
+        goBack={() => {}}
+        goToBeginning={() => {}}
+        loading={false}
+      />,
+    );
+
+    expect(screen.queryByTestId("results-fhir-server")).not.toBeInTheDocument();
   });
 });

--- a/src/app/(pages)/query/components/ResultsView.tsx
+++ b/src/app/(pages)/query/components/ResultsView.tsx
@@ -17,6 +17,7 @@ import Backlink from "../../../ui/designSystem/backLink/Backlink";
 import { RETURN_LABEL } from "@/app/(pages)/query/components/stepIndicator/StepIndicator";
 import TitleBox from "./stepIndicator/TitleBox";
 import ImmunizationTable from "./resultsView/tableComponents/ImmunizationTable";
+import ImmunizationRecommendationTable from "./resultsView/tableComponents/ImmunizationRecommendationTable";
 import { CustomUserQuery } from "@/app/models/entities/query";
 import Skeleton from "react-loading-skeleton";
 import { Button } from "@trussworks/react-uswds";
@@ -28,6 +29,8 @@ type ResultsViewProps = {
   goBack: () => void;
   goToBeginning: () => void;
   loading: boolean;
+  /** Name of the FHIR server the records were queried from. */
+  fhirServer?: string;
 };
 
 export type ResultsViewAccordionItem = {
@@ -44,6 +47,7 @@ export type ResultsViewAccordionItem = {
  * @param props.goToBeginning - Function to return to patient discover
  * @param props.selectedQuery - query that's been selected to view for results
  * @param props.loading -  whether the component is in a loading state
+ * @param props.fhirServer - name of the FHIR server that was queried
  * @returns The QueryView component.
  */
 const ResultsView: React.FC<ResultsViewProps> = ({
@@ -52,6 +56,7 @@ const ResultsView: React.FC<ResultsViewProps> = ({
   goBack,
   goToBeginning,
   loading,
+  fhirServer,
 }) => {
   useEffect(() => {
     window.scrollTo(0, 0);
@@ -109,6 +114,17 @@ const ResultsView: React.FC<ResultsViewProps> = ({
             View FHIR request &amp; response
           </Button>
         </div>
+        {fhirServer && (
+          <div
+            className="display-flex flex-align-center"
+            data-testid="results-fhir-server"
+          >
+            <strong>FHIR server:&nbsp;</strong>
+            <span className="text-normal display-inline-block">
+              {fhirServer}
+            </span>
+          </div>
+        )}
       </h2>
 
       <div className=" grid-container-desktop-lg grid-row grid-gap-md padding-0 ">
@@ -164,6 +180,8 @@ function mapQueryResponseToAccordionDataStructure(
   const immunizations = resultsQueryResponse.Immunization
     ? resultsQueryResponse.Immunization
     : null;
+  const immunizationRecommendations =
+    resultsQueryResponse.ImmunizationRecommendation ?? null;
 
   const accordionItems: ResultsViewAccordionItem[] = [
     {
@@ -233,7 +251,30 @@ function mapQueryResponseToAccordionDataStructure(
     },
     {
       title: "Immunizations",
-      content: immunizations ? (
+      content: immunizationRecommendations ? (
+        // Immunization Gateways return the forecast alongside the history;
+        // split the section into two sub-tables only when a forecast exists.
+        <>
+          {immunizations && (
+            <>
+              <h4
+                className={`${styles.accordionHeading} ${styles.subTableHeading}`}
+              >
+                Immunization history
+              </h4>
+              <ImmunizationTable immunizations={immunizations} />
+            </>
+          )}
+          <h4
+            className={`${styles.accordionHeading} ${styles.subTableHeading}`}
+          >
+            Immunization forecast
+          </h4>
+          <ImmunizationRecommendationTable
+            recommendations={immunizationRecommendations}
+          />
+        </>
+      ) : immunizations ? (
         <ImmunizationTable immunizations={immunizations} />
       ) : null,
     },

--- a/src/app/(pages)/query/components/resultsView/tableComponents/ImmunizationRecommendationTable.test.tsx
+++ b/src/app/(pages)/query/components/resultsView/tableComponents/ImmunizationRecommendationTable.test.tsx
@@ -1,0 +1,194 @@
+import { render, screen, within } from "@testing-library/react";
+import {
+  Bundle,
+  ImmunizationRecommendation,
+  ImmunizationRecommendationRecommendationDateCriterion,
+} from "fhir/r4";
+import ImmunizationRecommendationTable, {
+  FORECAST_DATE_LOINC,
+  getDateCriterion,
+  getRecommendationDate,
+} from "./ImmunizationRecommendationTable";
+import { readJsonFile } from "@/app/tests/shared_utils/readJsonFile";
+
+const LOINC = "http://loinc.org";
+
+const historyRow: ImmunizationRecommendation = {
+  resourceType: "ImmunizationRecommendation",
+  id: "shared-id",
+  patient: { reference: "Patient/p1" },
+  date: "2026-06-05",
+  recommendation: [
+    {
+      vaccineCode: [
+        {
+          coding: [
+            {
+              system: "http://hl7.org/fhir/sid/cvx",
+              code: "09",
+              display:
+                "Td (adult), 2 Lf tetanus toxoid, preservative free, adsorbed",
+            },
+          ],
+        },
+      ],
+      dateCriterion: [{ value: "2022-08-10" }],
+      doseNumberPositiveInt: 1,
+      // forecastStatus is required by the type but absent in gateway data.
+    } as ImmunizationRecommendation["recommendation"][number],
+  ],
+};
+
+// Mirrors the gateway forecast entry, which omits the (spec-required) date.
+const forecastRow = {
+  resourceType: "ImmunizationRecommendation",
+  id: "shared-id",
+  patient: { reference: "Patient/p1" },
+  recommendation: [
+    {
+      vaccineCode: [
+        {
+          coding: [
+            {
+              system: "http://hl7.org/fhir/sid/cvx",
+              code: "998",
+              display: "no vaccine administered",
+            },
+          ],
+        },
+      ],
+      forecastStatus: {
+        coding: [{ system: LOINC, code: "LA13424-9", display: "Too Old" }],
+      },
+      dateCriterion: [
+        // The gateway reports the evaluation date without a code.
+        {
+          value: "2026-08-10",
+        } as ImmunizationRecommendationRecommendationDateCriterion,
+        {
+          code: { coding: [{ system: LOINC, code: "30981-5" }] },
+          value: "2000-10-01",
+        },
+        {
+          code: { coding: [{ system: LOINC, code: "30980-7" }] },
+          value: "2000-10-02",
+        },
+        {
+          code: { coding: [{ system: LOINC, code: "59778-1" }] },
+          value: "2000-10-28",
+        },
+        // A second flattened window — must not override the first.
+        {
+          code: { coding: [{ system: LOINC, code: "30981-5" }] },
+          value: "2001-10-01",
+        },
+        {
+          code: { coding: [{ system: LOINC, code: "30980-7" }] },
+          value: "2001-10-01",
+        },
+      ],
+    },
+  ],
+} as ImmunizationRecommendation;
+
+describe("ImmunizationRecommendationTable", () => {
+  it("renders one row per recommendation with the forecast columns", () => {
+    render(
+      <ImmunizationRecommendationTable
+        recommendations={[historyRow, forecastRow]}
+      />,
+    );
+
+    const headers = screen
+      .getAllByRole("columnheader")
+      .map((h) => h.textContent);
+    expect(headers).toEqual([
+      "Vaccine",
+      "Forecast status",
+      "Dose",
+      "Date",
+      "Earliest date",
+      "Date due",
+      "Overdue date",
+    ]);
+
+    const rows = screen.getAllByRole("row").slice(1);
+    expect(rows).toHaveLength(2);
+
+    const historyCells = within(rows[0])
+      .getAllByRole("cell")
+      .map((c) => c.textContent);
+    expect(historyCells).toEqual([
+      "Td (adult), 2 Lf tetanus toxoid, preservative free, adsorbed",
+      "",
+      "1",
+      "08/10/2022",
+      "",
+      "",
+      "",
+    ]);
+
+    const forecastCells = within(rows[1])
+      .getAllByRole("cell")
+      .map((c) => c.textContent);
+    expect(forecastCells).toEqual([
+      "no vaccine administered",
+      "Too Old",
+      "",
+      "08/10/2026",
+      "10/01/2000",
+      "10/02/2000",
+      "10/28/2000",
+    ]);
+  });
+
+  it("renders every recommendation from the real IZ Gateway bundle even though they share an id", () => {
+    const bundle = readJsonFile<Bundle>(
+      "./src/app/tests/assets/BundleIzGatewayImmunizationRecommendation.json",
+    );
+    const recommendations =
+      bundle?.entry
+        ?.map((e) => e.resource)
+        .filter(
+          (r): r is ImmunizationRecommendation =>
+            r?.resourceType === "ImmunizationRecommendation",
+        ) ?? [];
+    expect(recommendations).toHaveLength(3);
+
+    render(
+      <ImmunizationRecommendationTable recommendations={recommendations} />,
+    );
+
+    expect(screen.getAllByRole("row").slice(1)).toHaveLength(3);
+    expect(screen.getByText("Too Old")).toBeInTheDocument();
+    expect(
+      screen.getByText("Influenza, split virus, quadrivalent, PF"),
+    ).toBeInTheDocument();
+  });
+
+  it("falls back to the resource date when no uncoded dateCriterion exists", () => {
+    const recommendation = {
+      vaccineCode: [{ text: "Flu" }],
+      dateCriterion: [
+        {
+          code: { coding: [{ system: LOINC, code: FORECAST_DATE_LOINC.due }] },
+          value: "2027-01-01",
+        },
+      ],
+    } as ImmunizationRecommendation["recommendation"][number];
+    const resource: ImmunizationRecommendation = {
+      resourceType: "ImmunizationRecommendation",
+      patient: { reference: "Patient/p1" },
+      date: "2026-06-03",
+      recommendation: [recommendation],
+    };
+
+    expect(getRecommendationDate(recommendation, resource)).toBe("2026-06-03");
+    expect(getDateCriterion(recommendation, FORECAST_DATE_LOINC.due)).toBe(
+      "2027-01-01",
+    );
+    expect(
+      getDateCriterion(recommendation, FORECAST_DATE_LOINC.earliest),
+    ).toBeUndefined();
+  });
+});

--- a/src/app/(pages)/query/components/resultsView/tableComponents/ImmunizationRecommendationTable.tsx
+++ b/src/app/(pages)/query/components/resultsView/tableComponents/ImmunizationRecommendationTable.tsx
@@ -1,0 +1,149 @@
+import React from "react";
+import Table from "@/app/ui/designSystem/table/Table";
+import {
+  ImmunizationRecommendation,
+  ImmunizationRecommendationRecommendation,
+} from "fhir/r4";
+import { formatDate } from "../../../../../utils/format-service";
+
+/**
+ * LOINC codes an immunization forecast uses to label its dateCriterion
+ * entries (the FHIR ImmunizationRecommendation dateCriterion value set).
+ */
+export const FORECAST_DATE_LOINC = {
+  earliest: "30981-5",
+  due: "30980-7",
+  overdue: "59778-1",
+  latest: "59777-3",
+} as const;
+
+/**
+ * Finds the first dateCriterion on a recommendation labeled with the given
+ * LOINC code. Some gateways flatten several forecast windows into one
+ * recommendation, repeating each code; the first occurrence is used.
+ * @param recommendation - a single ImmunizationRecommendation.recommendation entry
+ * @param loinc - the dateCriterion code to look for
+ * @returns the matching date string, if any
+ */
+export function getDateCriterion(
+  recommendation: ImmunizationRecommendationRecommendation,
+  loinc: string,
+): string | undefined {
+  return recommendation.dateCriterion?.find((criterion) =>
+    criterion.code?.coding?.some((coding) => coding.code === loinc),
+  )?.value;
+}
+
+/**
+ * The date a recommendation applies to: the first dateCriterion without a
+ * code (how the IZ Gateway reports an administered or evaluation date),
+ * falling back to the resource-level date.
+ * @param recommendation - a single ImmunizationRecommendation.recommendation entry
+ * @param resource - the parent ImmunizationRecommendation resource
+ * @returns the date string, if any
+ */
+export function getRecommendationDate(
+  recommendation: ImmunizationRecommendationRecommendation,
+  resource: ImmunizationRecommendation,
+): string | undefined {
+  return (
+    recommendation.dateCriterion?.find((criterion) => !criterion.code)?.value ??
+    resource.date
+  );
+}
+
+function getVaccineName(
+  recommendation: ImmunizationRecommendationRecommendation,
+): string | undefined {
+  const vaccine = recommendation.vaccineCode?.[0];
+  return (
+    vaccine?.coding?.[0]?.display ??
+    vaccine?.text ??
+    recommendation.targetDisease?.coding?.[0]?.display ??
+    recommendation.targetDisease?.text
+  );
+}
+
+function getForecastStatus(
+  recommendation: ImmunizationRecommendationRecommendation,
+): string | undefined {
+  // forecastStatus is required by the spec but absent on the IZ Gateway's
+  // history-mirror entries, so treat it as optional.
+  return (
+    recommendation.forecastStatus?.coding?.[0]?.display ??
+    recommendation.forecastStatus?.text
+  );
+}
+
+/**
+ * The props for the ImmunizationRecommendationTable component.
+ */
+export interface ImmunizationRecommendationTableProps {
+  recommendations: ImmunizationRecommendation[];
+}
+
+/**
+ * Displays a table of immunization forecast data from an array of
+ * ImmunizationRecommendation resources — one row per recommendation entry.
+ * @param props - Immunization recommendation table props.
+ * @param props.recommendations - The array of ImmunizationRecommendation resources.
+ * @returns - The ImmunizationRecommendationTable component.
+ */
+const ImmunizationRecommendationTable: React.FC<
+  ImmunizationRecommendationTableProps
+> = ({ recommendations }) => {
+  return (
+    <Table contained={false} className="margin-top-0-important">
+      <thead>
+        <tr>
+          <th>Vaccine</th>
+          <th>Forecast status</th>
+          <th>Dose</th>
+          <th>Date</th>
+          <th>Earliest date</th>
+          <th>Date due</th>
+          <th>Overdue date</th>
+        </tr>
+      </thead>
+      <tbody>
+        {recommendations.flatMap((resource, resourceIndex) =>
+          (resource.recommendation ?? []).map((recommendation, index) => (
+            // Gateways may stamp every resource with the same id, so key by
+            // position rather than resource.id.
+            <tr key={`${resourceIndex}-${index}`}>
+              <td>{getVaccineName(recommendation)}</td>
+              <td>{getForecastStatus(recommendation)}</td>
+              <td>
+                {recommendation.doseNumberPositiveInt ??
+                  recommendation.doseNumberString}
+              </td>
+              <td>
+                {formatDate(getRecommendationDate(recommendation, resource))}
+              </td>
+              <td>
+                {formatDate(
+                  getDateCriterion(
+                    recommendation,
+                    FORECAST_DATE_LOINC.earliest,
+                  ),
+                )}
+              </td>
+              <td>
+                {formatDate(
+                  getDateCriterion(recommendation, FORECAST_DATE_LOINC.due),
+                )}
+              </td>
+              <td>
+                {formatDate(
+                  getDateCriterion(recommendation, FORECAST_DATE_LOINC.overdue),
+                )}
+              </td>
+            </tr>
+          )),
+        )}
+      </tbody>
+    </Table>
+  );
+};
+
+export default ImmunizationRecommendationTable;

--- a/src/app/(pages)/query/components/searchForm/SearchForm.tsx
+++ b/src/app/(pages)/query/components/searchForm/SearchForm.tsx
@@ -90,7 +90,6 @@ const SearchForm: React.FC<SearchFormProps> = function SearchForm({
   const [fhirServerConfig, setFhirServerConfig] =
     useState<FhirServerConfig | null>(null);
   const [patientMatchEnabled, setPatientMatchEnabled] = useState<boolean>();
-  const [showAdvanced, setShowAdvanced] = useState(false);
   const params = useSearchParams();
 
   const prefillFromQueryParams = () => {
@@ -335,64 +334,53 @@ const SearchForm: React.FC<SearchFormProps> = function SearchForm({
               >
                 Fill fields
               </Button>
-              <Button
-                unstyled
-                className={`margin-left-auto`}
-                type="button"
-                onClick={() => {
-                  setShowAdvanced(!showAdvanced);
-                }}
-              >
-                Advanced
-              </Button>
             </div>
           </div>
         }
         <Fieldset className={`${styles.searchFormContainer} bg-white`}>
-          {showAdvanced && (
-            <div className="grid-row grid-gap margin-bottom-4">
-              <h3 className={`font-sans-md ${styles.searchFormSectionLabel}`}>
-                Advanced
-              </h3>
-              <Label
-                htmlFor="fhir_server"
-                className="margin-top-0-important width-full"
-              >
-                Healthcare Organization (HCO)
-              </Label>
-              <div className="grid-col-6">
-                <div className="usa-combo-box">
-                  <Select
-                    id="fhir_server"
-                    name="fhir_server"
-                    value={params?.get("server") || fhirServer}
-                    onChange={(event) => {
-                      setFhirServer(event.target.value as string);
-                    }}
-                    required
-                  >
-                    {fhirServers.map((fhirServer: string) => (
-                      <option key={fhirServer} value={fhirServer}>
-                        {fhirServer}
-                      </option>
-                    ))}
-                  </Select>
-                </div>
-                {fhirServerConfig?.patientMatchConfiguration?.supportsMatch && (
-                  <div className="padding-top-1">
-                    <Checkbox
-                      id="enable-patient-match"
-                      data-testid="enable-patient-match"
-                      label="Enable patient match"
-                      aria-label="Enable patient $match protocol for this query"
-                      checked={patientMatchEnabled}
-                      onChange={(e) => setPatientMatchEnabled(e.target.checked)}
-                    />
-                  </div>
-                )}
+          <div className="grid-row grid-gap margin-bottom-4">
+            <h3 className={`font-sans-md ${styles.searchFormSectionLabel}`}>
+              FHIR server
+            </h3>
+            <Label
+              htmlFor="fhir_server"
+              className="margin-top-0-important width-full"
+            >
+              FHIR server
+            </Label>
+            <div className="grid-col-6">
+              <div className="usa-combo-box">
+                <Select
+                  id="fhir_server"
+                  name="fhir_server"
+                  data-testid="fhir-server-select"
+                  value={fhirServer}
+                  onChange={(event) => {
+                    setFhirServer(event.target.value as string);
+                  }}
+                  required
+                >
+                  {fhirServers.map((fhirServer: string) => (
+                    <option key={fhirServer} value={fhirServer}>
+                      {fhirServer}
+                    </option>
+                  ))}
+                </Select>
               </div>
+              {fhirServerConfig?.patientMatchConfiguration?.supportsMatch && (
+                <div className="padding-top-1">
+                  <Checkbox
+                    id="enable-patient-match"
+                    data-testid="enable-patient-match"
+                    label="Enable patient match"
+                    aria-label="Enable patient $match protocol for this query"
+                    checked={patientMatchEnabled}
+                    onChange={(e) => setPatientMatchEnabled(e.target.checked)}
+                  />
+                </div>
+              )}
             </div>
-          )}
+          </div>
 
           <div className="grid-row grid-gap margin-bottom-4">
             <h3 className={`font-sans-md ${styles.searchFormSectionLabel}`}>

--- a/src/app/(pages)/query/components/searchForm/__snapshots__/searchForm.test.tsx.snap
+++ b/src/app/(pages)/query/components/searchForm/__snapshots__/searchForm.test.tsx.snap
@@ -54,19 +54,49 @@ exports[`SearchForm does not prefill address with bad data 1`] = `
           >
             Fill fields
           </button>
-          <button
-            class="usa-button usa-button--unstyled margin-left-auto"
-            data-testid="button"
-            type="button"
-          >
-            Advanced
-          </button>
         </div>
       </div>
       <fieldset
         class="usa-fieldset searchFormContainer bg-white"
         data-testid="fieldset"
       >
+        <div
+          class="grid-row grid-gap margin-bottom-4"
+        >
+          <h3
+            class="font-sans-md searchFormSectionLabel"
+          >
+            FHIR server
+          </h3>
+          <label
+            class="usa-label margin-top-0-important width-full"
+            data-testid="label"
+            for="fhir_server"
+          >
+            FHIR server
+          </label>
+          <div
+            class="grid-col-6"
+          >
+            <div
+              class="usa-combo-box"
+            >
+              <select
+                class="usa-select"
+                data-testid="fhir-server-select"
+                id="fhir_server"
+                name="fhir_server"
+                required=""
+              >
+                <option
+                  value="Default server"
+                >
+                  Default server
+                </option>
+              </select>
+            </div>
+          </div>
+        </div>
         <div
           class="grid-row grid-gap margin-bottom-4"
         >
@@ -865,19 +895,54 @@ exports[`SearchForm does not prefill fhir server with bad data 1`] = `
           >
             Fill fields
           </button>
-          <button
-            class="usa-button usa-button--unstyled margin-left-auto"
-            data-testid="button"
-            type="button"
-          >
-            Advanced
-          </button>
         </div>
       </div>
       <fieldset
         class="usa-fieldset searchFormContainer bg-white"
         data-testid="fieldset"
       >
+        <div
+          class="grid-row grid-gap margin-bottom-4"
+        >
+          <h3
+            class="font-sans-md searchFormSectionLabel"
+          >
+            FHIR server
+          </h3>
+          <label
+            class="usa-label margin-top-0-important width-full"
+            data-testid="label"
+            for="fhir_server"
+          >
+            FHIR server
+          </label>
+          <div
+            class="grid-col-6"
+          >
+            <div
+              class="usa-combo-box"
+            >
+              <select
+                class="usa-select"
+                data-testid="fhir-server-select"
+                id="fhir_server"
+                name="fhir_server"
+                required=""
+              >
+                <option
+                  value="Default FHIR"
+                >
+                  Default FHIR
+                </option>
+                <option
+                  value="Some other server name"
+                >
+                  Some other server name
+                </option>
+              </select>
+            </div>
+          </div>
+        </div>
         <div
           class="grid-row grid-gap margin-bottom-4"
         >
@@ -1676,19 +1741,43 @@ exports[`SearchForm prefills form fields from query params 1`] = `
           >
             Fill fields
           </button>
-          <button
-            class="usa-button usa-button--unstyled margin-left-auto"
-            data-testid="button"
-            type="button"
-          >
-            Advanced
-          </button>
         </div>
       </div>
       <fieldset
         class="usa-fieldset searchFormContainer bg-white"
         data-testid="fieldset"
       >
+        <div
+          class="grid-row grid-gap margin-bottom-4"
+        >
+          <h3
+            class="font-sans-md searchFormSectionLabel"
+          >
+            FHIR server
+          </h3>
+          <label
+            class="usa-label margin-top-0-important width-full"
+            data-testid="label"
+            for="fhir_server"
+          >
+            FHIR server
+          </label>
+          <div
+            class="grid-col-6"
+          >
+            <div
+              class="usa-combo-box"
+            >
+              <select
+                class="usa-select"
+                data-testid="fhir-server-select"
+                id="fhir_server"
+                name="fhir_server"
+                required=""
+              />
+            </div>
+          </div>
+        </div>
         <div
           class="grid-row grid-gap margin-bottom-4"
         >
@@ -2487,19 +2576,43 @@ exports[`SearchForm renders fhir server form options on button click 1`] = `
           >
             Fill fields
           </button>
-          <button
-            class="usa-button usa-button--unstyled margin-left-auto"
-            data-testid="button"
-            type="button"
-          >
-            Advanced
-          </button>
         </div>
       </div>
       <fieldset
         class="usa-fieldset searchFormContainer bg-white"
         data-testid="fieldset"
       >
+        <div
+          class="grid-row grid-gap margin-bottom-4"
+        >
+          <h3
+            class="font-sans-md searchFormSectionLabel"
+          >
+            FHIR server
+          </h3>
+          <label
+            class="usa-label margin-top-0-important width-full"
+            data-testid="label"
+            for="fhir_server"
+          >
+            FHIR server
+          </label>
+          <div
+            class="grid-col-6"
+          >
+            <div
+              class="usa-combo-box"
+            >
+              <select
+                class="usa-select"
+                data-testid="fhir-server-select"
+                id="fhir_server"
+                name="fhir_server"
+                required=""
+              />
+            </div>
+          </div>
+        </div>
         <div
           class="grid-row grid-gap margin-bottom-4"
         >
@@ -3298,19 +3411,43 @@ exports[`SearchForm renders the patient search form 1`] = `
           >
             Fill fields
           </button>
-          <button
-            class="usa-button usa-button--unstyled margin-left-auto"
-            data-testid="button"
-            type="button"
-          >
-            Advanced
-          </button>
         </div>
       </div>
       <fieldset
         class="usa-fieldset searchFormContainer bg-white"
         data-testid="fieldset"
       >
+        <div
+          class="grid-row grid-gap margin-bottom-4"
+        >
+          <h3
+            class="font-sans-md searchFormSectionLabel"
+          >
+            FHIR server
+          </h3>
+          <label
+            class="usa-label margin-top-0-important width-full"
+            data-testid="label"
+            for="fhir_server"
+          >
+            FHIR server
+          </label>
+          <div
+            class="grid-col-6"
+          >
+            <div
+              class="usa-combo-box"
+            >
+              <select
+                class="usa-select"
+                data-testid="fhir-server-select"
+                id="fhir_server"
+                name="fhir_server"
+                required=""
+              />
+            </div>
+          </div>
+        </div>
         <div
           class="grid-row grid-gap margin-bottom-4"
         >

--- a/src/app/(pages)/query/components/searchForm/searchForm.test.tsx
+++ b/src/app/(pages)/query/components/searchForm/searchForm.test.tsx
@@ -88,12 +88,11 @@ describe("SearchForm", () => {
     expect(screen.getByText("Enter patient information")).toBeVisible();
     expect(document.body).toMatchSnapshot();
 
-    const advancedOptions = await screen.findByText("Advanced");
-    await user.click(advancedOptions);
-
+    // The server select is always visible — there is no Advanced toggle.
     expect(
-      await screen.findByText("Healthcare Organization (HCO)"),
-    ).toBeVisible();
+      screen.queryByRole("button", { name: "Advanced" }),
+    ).not.toBeInTheDocument();
+    expect(screen.getByRole("combobox", { name: "FHIR server" })).toBeVisible();
   });
 
   it("prefills form fields from query params", async () => {
@@ -248,10 +247,8 @@ describe("SearchForm", () => {
     expect(screen.getByText("Enter patient information")).toBeVisible();
     expect(document.body).toMatchSnapshot();
 
-    const advancedOptions = await screen.findByText("Advanced");
-    await user.click(advancedOptions);
     const selectedServer = screen.getByRole("combobox", {
-      name: "Healthcare Organization (HCO)",
+      name: "FHIR server",
     });
     expect(selectedServer).not.toHaveValue(badServerName);
     expect(selectedServer).toHaveValue(defaultServerName);
@@ -340,11 +337,6 @@ describe("SearchForm", () => {
         />
       </RootProviderMock>,
     );
-
-    const advancedButton = await screen.findByRole("button", {
-      name: "Advanced",
-    });
-    await user.click(advancedButton);
 
     const checkbox = await screen.findByRole("checkbox", {
       name: /enable patient match/i,
@@ -687,11 +679,8 @@ describe("SearchForm", () => {
       </RootProviderMock>,
     );
 
-    await user.click(screen.getByRole("button", { name: "Advanced" }));
     await user.selectOptions(
-      await screen.findByRole("combobox", {
-        name: "Healthcare Organization (HCO)",
-      }),
+      await screen.findByRole("combobox", { name: "FHIR server" }),
       "Server B",
     );
 

--- a/src/app/(pages)/query/components/selectQuery/SelectSavedQuery.test.tsx
+++ b/src/app/(pages)/query/components/selectQuery/SelectSavedQuery.test.tsx
@@ -117,7 +117,7 @@ describe("SelectSavedQuery", () => {
     });
   });
 
-  it("shows the FHIR servers from props behind the advanced toggle", async () => {
+  it("shows the FHIR servers from props without an advanced toggle", async () => {
     render(
       <RootProviderMock currentPage="/query">
         <SelectSavedQuery {...defaultProps} />
@@ -128,7 +128,10 @@ describe("SelectSavedQuery", () => {
       expect(screen.getByLabelText("Query")).toBeInTheDocument(),
     );
 
-    fireEvent.click(screen.getByRole("button", { name: "Advanced..." }));
+    expect(
+      screen.queryByRole("button", { name: "Advanced..." }),
+    ).not.toBeInTheDocument();
+    expect(screen.getByLabelText("FHIR server")).toBeInTheDocument();
 
     TEST_FHIR_SERVERS.forEach((server) => {
       expect(screen.getByRole("option", { name: server })).toBeInTheDocument();

--- a/src/app/(pages)/query/components/selectQuery/SelectSavedQuery.tsx
+++ b/src/app/(pages)/query/components/selectQuery/SelectSavedQuery.tsx
@@ -44,7 +44,6 @@ const SelectSavedQuery: React.FC<SelectSavedQueryProps> = ({
   handleSubmit,
   setFhirServer,
 }) => {
-  const [showAdvanced, setShowAdvanced] = useState(false);
   const [queryOptions, setQueryOptions] = useState<QuerySummary[]>([]);
   const [loading, setLoading] = useState<boolean>(true);
 
@@ -118,6 +117,7 @@ const SelectSavedQuery: React.FC<SelectSavedQueryProps> = ({
             <Select
               id="querySelect"
               name="querySelect"
+              data-testid="query-select"
               value={selectedQuery.queryName}
               onChange={(e) => {
                 handleQuerySelection(e.target.value);
@@ -135,39 +135,26 @@ const SelectSavedQuery: React.FC<SelectSavedQueryProps> = ({
               ))}
             </Select>
           </div>
-          {showAdvanced && (
-            <div>
-              <h3 className={styles.queryDropdownLabel}>
-                Health Care Organization (HCO)
-              </h3>
-              <Select
-                id="fhir_server"
-                name="fhir_server"
-                value={fhirServer}
-                onChange={(e) => setFhirServer(e.target.value as string)}
-                required
-                className={`${styles.queryDropDown}`}
-              >
-                Select HCO
-                {fhirServers.map((fhirServer: string) => (
-                  <option key={fhirServer} value={fhirServer}>
-                    {fhirServer}
-                  </option>
-                ))}
-              </Select>
-            </div>
-          )}
-          {!showAdvanced && (
-            <div>
-              <Button
-                className={`usa-button--unstyled margin-left-auto ${styles.searchCallToActionButton}`}
-                type="button"
-                onClick={() => setShowAdvanced(true)}
-              >
-                Advanced...
-              </Button>
-            </div>
-          )}
+          <div className={styles.queryRow}>
+            <label className={styles.queryDropdownLabel} htmlFor="fhir_server">
+              FHIR server
+            </label>
+            <Select
+              id="fhir_server"
+              name="fhir_server"
+              data-testid="fhir-server-select"
+              value={fhirServer}
+              onChange={(e) => setFhirServer(e.target.value as string)}
+              required
+              className={`${styles.queryDropDown}`}
+            >
+              {fhirServers.map((fhirServer: string) => (
+                <option key={fhirServer} value={fhirServer}>
+                  {fhirServer}
+                </option>
+              ))}
+            </Select>
+          </div>
 
           {/* Submit Button */}
           <div className="margin-top-5">

--- a/src/app/(pages)/query/components/selectQuery/selectQuery.module.scss
+++ b/src/app/(pages)/query/components/selectQuery/selectQuery.module.scss
@@ -1,9 +1,5 @@
 @use "../../../../ui/styles/_variables" as *;
 
-.searchCallToActionButton {
-  height: 2.5rem;
-}
-
 .selectQueryHeaderText {
   line-height: 2.0625rem;
   word-wrap: break-word;

--- a/src/app/(pages)/query/page.tsx
+++ b/src/app/(pages)/query/page.tsx
@@ -153,6 +153,7 @@ const Query: React.FC = () => {
               setMode("search");
             }}
             loading={loading}
+            fhirServer={fhirServer}
           />
         )}
       </div>

--- a/src/app/backend/query-execution/custom-query.test.ts
+++ b/src/app/backend/query-execution/custom-query.test.ts
@@ -475,6 +475,49 @@ describe("CustomQuery immunization queries", () => {
     expect(epicImmunization.params.get("patient")).toBe(PATIENT_ID);
   });
 
+  it("adds an ImmunizationRecommendation search with the same params on immunization endpoints only", () => {
+    const gatewayQuery = new CustomQuery(
+      immunizationSavedQuery,
+      PATIENT_ID,
+      "default",
+      { endpointType: "immunization", patientDemographics: DEMOGRAPHICS },
+    );
+    const immunization = gatewayQuery.getQuery("immunization");
+    const recommendation = gatewayQuery.getQuery("immunizationRecommendation");
+
+    expect(recommendation.basePath).toBe("/ImmunizationRecommendation");
+    expect(recommendation.params.toString()).toBe(
+      immunization.params.toString(),
+    );
+    // Separate instances: mutating one must not affect the other.
+    expect(recommendation.params).not.toBe(immunization.params);
+    expect(
+      gatewayQuery.compileAllPostRequests().map((r) => r.path),
+    ).not.toContain("/ImmunizationRecommendation");
+
+    // Without demographics the fallback patient param is shared too.
+    const fallback = new CustomQuery(
+      immunizationSavedQuery,
+      PATIENT_ID,
+      "epic",
+      {
+        endpointType: "immunization",
+      },
+    ).getQuery("immunizationRecommendation");
+    expect(fallback.params.get("patient")).toBe(PATIENT_ID);
+
+    // Standard and Epic servers never get the recommendation search.
+    for (const strategy of ["default", "epic"] as const) {
+      const standard = new CustomQuery(
+        immunizationSavedQuery,
+        PATIENT_ID,
+        strategy,
+        { endpointType: "standard", patientDemographics: DEMOGRAPHICS },
+      ).getQuery("immunizationRecommendation");
+      expect(standard.basePath).toBe("");
+    }
+  });
+
   it("ignores demographics on standard endpoints", () => {
     const immunization = new CustomQuery(
       immunizationSavedQuery,

--- a/src/app/backend/query-execution/custom-query.ts
+++ b/src/app/backend/query-execution/custom-query.ts
@@ -249,38 +249,25 @@ export class CustomQuery {
     }
 
     if (medicalRecordSections && medicalRecordSections.immunizations) {
-      const formattedParams = new URLSearchParams();
-      if (this.endpointType === "immunization" && this.patientDemographics) {
-        // Immunization Gateways (e.g. eHealth Exchange's fhirproxy) translate
-        // the FHIR search into an HL7v2 QBP Z34 query, which identifies the
-        // patient by demographics ("must contain patient.identifier or
-        // name+birthDate") — a patient={id} search returns nothing. Use
-        // chained demographic params from the discovered Patient instead.
-        formattedParams.append("patient.given", this.patientDemographics.given);
-        formattedParams.append(
-          "patient.family",
-          this.patientDemographics.family,
-        );
-        formattedParams.append(
-          "patient.birthdate",
-          this.patientDemographics.birthDate,
-        );
-      } else {
-        // FHIR R4 Immunization has no "subject" search param; the patient-scoping
-        // param is "patient". Using "subject" leaves the query unscoped and the IZ
-        // Gateway rejects it ("must contain patient.identifier or name+birthDate").
-        // Epic's search expects a bare patient id, not a Patient/ reference.
-        formattedParams.append(
-          "patient",
-          this.queryStrategy === "epic" ? patientId : `Patient/${patientId}`,
-        );
-      }
-
       this.fhirResourceQueries["immunization"] = {
         basePath: `/Immunization`,
-        params: formattedParams,
+        params: this.buildImmunizationPatientParams(patientId),
         excludeFromPost: true,
       };
+
+      if (this.endpointType === "immunization") {
+        // Immunization Gateways also answer /ImmunizationRecommendation,
+        // which they translate into an HL7v2 QBP Z44 "evaluated history and
+        // forecast" query — the only way to get the forecast. Same
+        // patient-scoping params as the Immunization search; the service
+        // layer dispatches it as its own GET so a failure on one can't hide
+        // the other. Standard/Epic servers never receive it.
+        this.fhirResourceQueries["immunizationRecommendation"] = {
+          basePath: `/ImmunizationRecommendation`,
+          params: this.buildImmunizationPatientParams(patientId),
+          excludeFromPost: true,
+        };
+      }
     }
 
     if (medicalRecordSections && medicalRecordSections.serviceRequests) {
@@ -519,6 +506,41 @@ export class CustomQuery {
         return { basePath: `/Encounter`, params };
       },
     );
+  }
+
+  /**
+   * Builds the patient-scoping params shared by the Immunization and
+   * ImmunizationRecommendation searches. Returns a fresh URLSearchParams so
+   * the two queries never share (and mutate) one instance.
+   * @param patientId the discovered patient's id
+   * @returns chained patient.given / patient.family / patient.birthdate params
+   * on Immunization Gateways with demographics; otherwise a patient={id} param
+   */
+  private buildImmunizationPatientParams(patientId: string): URLSearchParams {
+    const formattedParams = new URLSearchParams();
+    if (this.endpointType === "immunization" && this.patientDemographics) {
+      // Immunization Gateways (e.g. eHealth Exchange's fhirproxy) translate
+      // the FHIR search into an HL7v2 QBP query, which identifies the
+      // patient by demographics ("must contain patient.identifier or
+      // name+birthDate") — a patient={id} search returns nothing. Use
+      // chained demographic params from the discovered Patient instead.
+      formattedParams.append("patient.given", this.patientDemographics.given);
+      formattedParams.append("patient.family", this.patientDemographics.family);
+      formattedParams.append(
+        "patient.birthdate",
+        this.patientDemographics.birthDate,
+      );
+    } else {
+      // FHIR R4 Immunization has no "subject" search param; the patient-scoping
+      // param is "patient". Using "subject" leaves the query unscoped and the IZ
+      // Gateway rejects it ("must contain patient.identifier or name+birthDate").
+      // Epic's search expects a bare patient id, not a Patient/ reference.
+      formattedParams.append(
+        "patient",
+        this.queryStrategy === "epic" ? patientId : `Patient/${patientId}`,
+      );
+    }
+    return formattedParams;
   }
 
   compilePostRequest(resource: { basePath: string; params: URLSearchParams }) {

--- a/src/app/backend/query-execution/iz-gateway.test.ts
+++ b/src/app/backend/query-execution/iz-gateway.test.ts
@@ -13,6 +13,8 @@ import {
 } from "@/app/(pages)/queryBuilding/utils";
 import { DibbsValueSet } from "@/app/models/entities/valuesets";
 import { suppressConsoleLogs } from "@/app/tests/integration/fixtures";
+import { readJsonFile } from "@/app/tests/shared_utils/readJsonFile";
+import { Bundle } from "fhir/r4";
 
 jest.mock("@/app/utils/auth", () => ({
   superAdminAccessCheck: jest.fn().mockReturnValue(true),
@@ -175,16 +177,20 @@ describe("patientRecordsQuery against an Immunization Gateway", () => {
   );
 
   it.each(["IZ Gateway", "Epic IZ Gateway"])(
-    "sends only the Immunization search to %s, skipping other record sections",
+    "sends only the Immunization and ImmunizationRecommendation searches to %s, skipping other record sections",
     async (server) => {
       await runQuery(server, PATIENT);
 
-      // The gateway only serves immunization history, so the other sections
-      // in the saved query (social history, service requests, labs POST
-      // batch, and the epic medication/condition chains) never fire.
+      // The gateway only serves immunization history and forecast, so the
+      // other sections in the saved query (social history, service requests,
+      // labs POST batch, and the epic medication/condition chains) never fire.
       const getPaths = mockFhirClient.get.mock.calls.map((c) => c[0] as string);
-      expect(getPaths).toHaveLength(1);
-      expect(getPaths[0]).toMatch(/^\/Immunization\?/);
+      const chainedParams =
+        "patient.given=WayneTWOIZG&patient.family=WatersSNHDIZGTWO&patient.birthdate=2018-02-19";
+      expect(getPaths).toEqual([
+        `/Immunization?${chainedParams}`,
+        `/ImmunizationRecommendation?${chainedParams}`,
+      ]);
       expect(mockFhirClient.post).not.toHaveBeenCalled();
       expect(mockFhirClient.postJson).not.toHaveBeenCalled();
     },
@@ -197,6 +203,9 @@ describe("patientRecordsQuery against an Immunization Gateway", () => {
     expect(getPaths.find((p) => p.startsWith("/Immunization?"))).toBe(
       `/Immunization?patient=Patient%2F${PATIENT_ID}`,
     );
+    expect(
+      getPaths.find((p) => p.startsWith("/ImmunizationRecommendation?")),
+    ).toBe(`/ImmunizationRecommendation?patient=Patient%2F${PATIENT_ID}`);
 
     jest.clearAllMocks();
     (prepareFhirClient as jest.Mock).mockResolvedValue(mockFhirClient);
@@ -210,6 +219,9 @@ describe("patientRecordsQuery against an Immunization Gateway", () => {
     expect(getPaths.find((p) => p.startsWith("/Immunization?"))).toBe(
       `/Immunization?patient=${PATIENT_ID}`,
     );
+    expect(
+      getPaths.find((p) => p.startsWith("/ImmunizationRecommendation?")),
+    ).toBe(`/ImmunizationRecommendation?patient=${PATIENT_ID}`);
   });
 
   it("returns the gateway's Immunizations and drops its search-outcome entries", async () => {
@@ -263,5 +275,72 @@ describe("patientRecordsQuery against an Immunization Gateway", () => {
 
     expect(result.Immunization?.map((i) => i.id)).toEqual(["imm-1", "imm-2"]);
     expect(result.OperationOutcome).toBeUndefined();
+  });
+  it("returns every ImmunizationRecommendation from the gateway even though they share one id", async () => {
+    // Real Z42 response captured from the IZ Gateway: two search-outcome
+    // entries, two history-mirror recommendations and one forecast, all
+    // stamped with the same resource id.
+    const immunizationBundle = readJsonFile<Bundle>(
+      "./src/app/tests/assets/BundleIzGatewayImmunization.json",
+    ) as Bundle;
+    const recommendationBundle = readJsonFile<Bundle>(
+      "./src/app/tests/assets/BundleIzGatewayImmunizationRecommendation.json",
+    ) as Bundle;
+    mockFhirClient.get.mockImplementation(async (path: string) => {
+      if (path.startsWith("/ImmunizationRecommendation?")) {
+        return mockBundleResponse(path, recommendationBundle);
+      }
+      if (path.startsWith("/Immunization?")) {
+        return mockBundleResponse(path, immunizationBundle);
+      }
+      return mockBundleResponse(path, EMPTY_BUNDLE);
+    });
+
+    const result = await runQuery("IZ Gateway", PATIENT);
+
+    expect(result.Immunization).toHaveLength(2);
+    expect(result.ImmunizationRecommendation).toHaveLength(3);
+    const ids = new Set(result.ImmunizationRecommendation?.map((r) => r.id));
+    expect(ids.size).toBe(1);
+    expect(
+      result.ImmunizationRecommendation?.some((r) =>
+        r.recommendation?.some((rec) => rec.forecastStatus),
+      ),
+    ).toBe(true);
+    expect(result.OperationOutcome).toBeUndefined();
+  });
+
+  it("still returns Immunizations when the ImmunizationRecommendation search fails", async () => {
+    const immunizationBundle = readJsonFile<Bundle>(
+      "./src/app/tests/assets/BundleIzGatewayImmunization.json",
+    ) as Bundle;
+    mockFhirClient.get.mockImplementation(async (path: string) => {
+      if (path.startsWith("/ImmunizationRecommendation?")) {
+        throw new Error("fetch failed");
+      }
+      return mockBundleResponse(path, immunizationBundle);
+    });
+
+    const result = await runQuery("IZ Gateway", PATIENT);
+
+    expect(result.Immunization).toHaveLength(2);
+    expect(result.ImmunizationRecommendation).toBeUndefined();
+  });
+
+  it("still returns the forecast when the Immunization search fails", async () => {
+    const recommendationBundle = readJsonFile<Bundle>(
+      "./src/app/tests/assets/BundleIzGatewayImmunizationRecommendation.json",
+    ) as Bundle;
+    mockFhirClient.get.mockImplementation(async (path: string) => {
+      if (path.startsWith("/Immunization?")) {
+        throw new Error("fetch failed");
+      }
+      return mockBundleResponse(path, recommendationBundle);
+    });
+
+    const result = await runQuery("IZ Gateway", PATIENT);
+
+    expect(result.Immunization).toBeUndefined();
+    expect(result.ImmunizationRecommendation).toHaveLength(3);
   });
 });

--- a/src/app/backend/query-execution/service.ts
+++ b/src/app/backend/query-execution/service.ts
@@ -107,6 +107,18 @@ const TASK_TEMPLATE: Partial<Task> = {
   },
 };
 
+/**
+ * Resource types that are never deduplicated by id when parsing search
+ * results. Immunization Gateways (eHealth Exchange's IZ Gateway) stamp every
+ * ImmunizationRecommendation in a bundle with the same id — one per past dose
+ * plus the forecast — so id-based dedupe would keep only the first entry and
+ * silently drop the forecast. The recommendation search is issued once per
+ * patient, so there are no genuine duplicates to remove.
+ */
+const DEDUPE_EXEMPT_RESOURCE_TYPES: ReadonlySet<string> = new Set([
+  "ImmunizationRecommendation",
+]);
+
 class QueryService {
   /**
    * Builds a FHIR patient search query string from provided parameters
@@ -490,13 +502,13 @@ class QueryService {
       patientDemographics,
     });
 
-    // Immunization Gateways only serve immunization history — every other
-    // record-section search is a wasted round trip through the HL7v2
-    // translation layer that returns nothing, so skip them entirely.
+    // Immunization Gateways only serve immunization history and forecast —
+    // every other record-section search is a wasted round trip through the
+    // HL7v2 translation layer that returns nothing, so skip them entirely.
     const isImmunizationGateway = endpointType === "immunization";
     if (isImmunizationGateway) {
       console.log(
-        "Immunization Gateway server %s: skipping non-immunization record sections.",
+        "Immunization Gateway server %s: querying Immunization and ImmunizationRecommendation only; skipping other record sections.",
         fhirServer,
       );
     }
@@ -515,6 +527,28 @@ class QueryService {
         medicalRecordSectionResults.push(await fhirClient.get(fetchString));
       } catch (error) {
         console.error("Immunization FHIR query failed: ", error);
+      }
+    }
+
+    if (
+      isImmunizationGateway &&
+      medicalRecordSections &&
+      medicalRecordSections.immunizations
+    ) {
+      // The gateway's forecast only comes back from ImmunizationRecommendation
+      // (HL7v2 Z44). Dispatched separately from the Immunization search so a
+      // failure on either can't hide the other's results.
+      try {
+        const { basePath, params } = builtQuery.getQuery(
+          "immunizationRecommendation",
+        );
+        if (basePath !== "") {
+          medicalRecordSectionResults.push(
+            await fhirClient.get(`${basePath}?${params}`),
+          );
+        }
+      } catch (error) {
+        console.error("Immunization recommendation FHIR query failed: ", error);
       }
     }
 
@@ -1358,8 +1392,10 @@ class QueryService {
       // Dedupe on type-qualified ids: FHIR ids are only unique per resource
       // type, so two different resources can legitimately share a bare id.
       const resourceKey = `${resourceType}/${resource.id}`;
-      // Check if the resourceID has already been seen & only added resources that haven't been seen before
-      if (resource.id && !resourceIds.has(resourceKey)) {
+      if (DEDUPE_EXEMPT_RESOURCE_TYPES.has(resourceType)) {
+        (runningQueryResponse[resourceType] as FhirResource[]).push(resource);
+      } else if (resource.id && !resourceIds.has(resourceKey)) {
+        // Only add resources whose id hasn't been seen before.
         (runningQueryResponse[resourceType] as FhirResource[]).push(resource);
         resourceIds.add(resourceKey);
       } else if (resource.id && isFanoutSearch) {
@@ -1436,7 +1472,9 @@ class QueryService {
             // returned for the query. Ids are type-qualified: FHIR ids are
             // only unique per resource type.
             const resourceKey = `${entry.resource.resourceType}/${entry.resource.id}`;
-            if (!resourceIds.includes(resourceKey)) {
+            if (DEDUPE_EXEMPT_RESOURCE_TYPES.has(entry.resource.resourceType)) {
+              resourceArray.push(entry.resource);
+            } else if (!resourceIds.includes(resourceKey)) {
               resourceIds.push(resourceKey);
               resourceArray.push(entry.resource);
             }

--- a/src/app/tests/assets/BundleIzGatewayImmunization.json
+++ b/src/app/tests/assets/BundleIzGatewayImmunization.json
@@ -1,0 +1,357 @@
+{
+  "resourceType": "Bundle",
+  "id": "01KZP4E03KDTHKW5HV35AB6X45",
+  "meta": {
+    "profile": [
+      "CDCPHINVS#Z32"
+    ]
+  },
+  "implicitRules": "http://v2plus.hl7.org/2021Jan/message-structure/RSP_K11",
+  "identifier": {
+    "value": "NV000020260810250358"
+  },
+  "type": "searchset",
+  "timestamp": "2026-08-10T08:25:03.580-07:00",
+  "entry": [
+    {
+      "resource": {
+        "resourceType": "OperationOutcome",
+        "id": "01KZP4E03PA6GACPDE8VK73DYZ",
+        "meta": {
+          "_source": {
+            "extension": [
+              {
+                "url": "http://hl7.org/fhir/StructureDefinition/originalText",
+                "valueString": "MSA|AA|01KZP4DZ1FJCMC3YSXJNXM21XJ"
+              }
+            ]
+          }
+        },
+        "issue": [
+          {
+            "severity": "information",
+            "code": "informational",
+            "details": {
+              "coding": [
+                {
+                  "system": "http://terminology.hl7.org/CodeSystem/v2-0008",
+                  "code": "AA"
+                }
+              ]
+            }
+          }
+        ],
+        "identifier": []
+      },
+      "search": {
+        "mode": "outcome"
+      }
+    },
+    {
+      "resource": {
+        "resourceType": "OperationOutcome",
+        "id": "01KZP4E03P04B0ZV1M85052MX7",
+        "meta": {
+          "_source": {
+            "extension": [
+              {
+                "url": "http://hl7.org/fhir/StructureDefinition/originalText",
+                "valueString": "QAK|01KZP4DZ1FWX50G707BY3XCWD1|OK|Z34^Request Immunization History^CDCPHINVS"
+              }
+            ]
+          },
+          "tag": [
+            {
+              "system": "QueryTag",
+              "code": "01KZP4DZ1FWX50G707BY3XCWD1"
+            }
+          ]
+        },
+        "issue": [
+          {
+            "severity": "information",
+            "code": "informational",
+            "details": {
+              "coding": [
+                {
+                  "system": "http://terminology.hl7.org/CodeSystem/v2-0208",
+                  "code": "OK"
+                }
+              ]
+            }
+          }
+        ],
+        "identifier": []
+      },
+      "search": {
+        "mode": "outcome"
+      }
+    },
+    {
+      "resource": {
+        "resourceType": "Immunization",
+        "id": "TlYwMDAwfDM5NzM1NjV8TlYwMDAwfDQxMzQ4OTM1",
+        "meta": {
+          "_source": {
+            "extension": [
+              {
+                "url": "http://hl7.org/fhir/StructureDefinition/originalText",
+                "valueString": "ORC|RE||41348935^NV0000"
+              }
+            ]
+          }
+        },
+        "identifier": [
+          {
+            "type": {
+              "coding": [
+                {
+                  "code": "NV0000"
+                }
+              ]
+            },
+            "system": "NV0000",
+            "value": "41348935"
+          },
+          {
+            "type": {
+              "coding": [
+                {
+                  "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
+                  "code": "FILL",
+                  "display": "Filler Order Number"
+                }
+              ]
+            },
+            "system": "NV0000",
+            "value": "41348935"
+          }
+        ],
+        "status": "completed",
+        "vaccineCode": {
+          "coding": [
+            {
+              "system": "http://hl7.org/fhir/sid/cvx",
+              "code": "09",
+              "display": "Td (adult), 2 Lf tetanus toxoid, preservative free, adsorbed"
+            },
+            {
+              "system": "http://hl7.org/fhir/sid/ndc",
+              "code": "00006-4133-01",
+              "display": "Td (adult), adsorbed"
+            }
+          ]
+        },
+        "patient": {
+          "reference": "Patient/TlYwMDAwfDM5NzM1NjU",
+          "identifier": {
+            "type": {
+              "coding": [
+                {
+                  "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
+                  "code": "SR",
+                  "display": "State registry ID"
+                }
+              ]
+            },
+            "system": "NV0000",
+            "value": "3973565"
+          },
+          "display": "WENDYIZG SNHDIZGONE PRESTONSNHDONEZG"
+        },
+        "occurrenceDateTime": "2022-08-10",
+        "recorded": "2026-06-05",
+        "location": {
+          "reference": "Location/01KZP4E03RME2031263XVXNYYG",
+          "display": "IZGATEWAYART"
+        },
+        "manufacturer": {
+          "reference": "Organization/01KZP4E03RJNBJV3KG5CXPNX5P",
+          "identifier": {
+            "system": "http://hl7.org/fhir/sid/mvx",
+            "value": "MSD"
+          },
+          "display": "Merck and Co., Inc."
+        },
+        "lotNumber": "121584515",
+        "expirationDate": "2024-12-31",
+        "site": {
+          "coding": [
+            {
+              "system": "http://terminology.hl7.org/CodeSystem/v2-0163",
+              "code": "LD",
+              "display": "Left Deltoid"
+            }
+          ]
+        },
+        "route": {
+          "coding": [
+            {
+              "system": "http://ncicb.nci.nih.gov/xml/owl/EVS/Thesaurus.owl",
+              "code": "C28161",
+              "display": "Intramuscular"
+            },
+            {
+              "system": "http://terminology.hl7.org/CodeSystem/v2-0162",
+              "code": "IM",
+              "display": "Intramuscular"
+            }
+          ]
+        },
+        "doseQuantity": {
+          "value": 0.5,
+          "unit": "milliliter",
+          "system": "http://unitsofmeasure.org",
+          "code": "mL"
+        },
+        "programEligibility": [
+          {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/v2-0064",
+                "code": "V01",
+                "display": "Not VFC Eligible (insured)"
+              }
+            ]
+          }
+        ]
+      },
+      "search": {
+        "mode": "match"
+      }
+    },
+    {
+      "resource": {
+        "resourceType": "Immunization",
+        "id": "TlYwMDAwfDM5NzM1NjV8TlYwMDAwfDQxMzQ4OTM3",
+        "meta": {
+          "_source": {
+            "extension": [
+              {
+                "url": "http://hl7.org/fhir/StructureDefinition/originalText",
+                "valueString": "ORC|RE||41348937^NV0000"
+              }
+            ]
+          }
+        },
+        "identifier": [
+          {
+            "type": {
+              "coding": [
+                {
+                  "code": "NV0000"
+                }
+              ]
+            },
+            "system": "NV0000",
+            "value": "41348937"
+          },
+          {
+            "type": {
+              "coding": [
+                {
+                  "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
+                  "code": "FILL",
+                  "display": "Filler Order Number"
+                }
+              ]
+            },
+            "system": "NV0000",
+            "value": "41348937"
+          }
+        ],
+        "status": "completed",
+        "vaccineCode": {
+          "coding": [
+            {
+              "system": "http://hl7.org/fhir/sid/cvx",
+              "code": "150",
+              "display": "Influenza, split virus, quadrivalent, PF"
+            },
+            {
+              "system": "http://hl7.org/fhir/sid/ndc",
+              "code": "19515-0818-41",
+              "display": "Influenza Quad Inj P"
+            }
+          ]
+        },
+        "patient": {
+          "reference": "Patient/TlYwMDAwfDM5NzM1NjU",
+          "identifier": {
+            "type": {
+              "coding": [
+                {
+                  "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
+                  "code": "SR",
+                  "display": "State registry ID"
+                }
+              ]
+            },
+            "system": "NV0000",
+            "value": "3973565"
+          },
+          "display": "WENDYIZG SNHDIZGONE PRESTONSNHDONEZG"
+        },
+        "occurrenceDateTime": "2022-08-10",
+        "recorded": "2026-06-08",
+        "location": {
+          "reference": "Location/01KZP4E03VH4EA78BZH4ND0821",
+          "display": "IZGATEWAYART"
+        },
+        "manufacturer": {
+          "reference": "Organization/01KZP4E03VWWC5S0Z1DSYWDV10",
+          "identifier": {
+            "system": "http://hl7.org/fhir/sid/mvx",
+            "value": "SEQ"
+          },
+          "display": "Seqirus"
+        },
+        "lotNumber": "1215121515",
+        "expirationDate": "2024-12-31",
+        "site": {
+          "coding": [
+            {
+              "system": "http://terminology.hl7.org/CodeSystem/v2-0163",
+              "code": "LD",
+              "display": "Left Deltoid"
+            }
+          ]
+        },
+        "route": {
+          "coding": [
+            {
+              "system": "http://ncicb.nci.nih.gov/xml/owl/EVS/Thesaurus.owl",
+              "code": "C28161",
+              "display": "Intramuscular"
+            },
+            {
+              "system": "http://terminology.hl7.org/CodeSystem/v2-0162",
+              "code": "IM",
+              "display": "Intramuscular"
+            }
+          ]
+        },
+        "doseQuantity": {
+          "value": 0.5,
+          "unit": "milliliter",
+          "system": "http://unitsofmeasure.org",
+          "code": "mL"
+        },
+        "programEligibility": [
+          {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/v2-0064",
+                "code": "V01",
+                "display": "Not VFC Eligible (insured)"
+              }
+            ]
+          }
+        ]
+      },
+      "search": {
+        "mode": "match"
+      }
+    }
+  ]
+}

--- a/src/app/tests/assets/BundleIzGatewayImmunizationRecommendation.json
+++ b/src/app/tests/assets/BundleIzGatewayImmunizationRecommendation.json
@@ -1,0 +1,597 @@
+{
+  "resourceType": "Bundle",
+  "id": "01KZP4E1WTJCEAKMXZMBA8CJN1",
+  "meta": {
+    "profile": [
+      "CDCPHINVS#Z42"
+    ]
+  },
+  "implicitRules": "http://v2plus.hl7.org/2021Jan/message-structure/RSP_K11",
+  "identifier": {
+    "value": "NV000020260810250500"
+  },
+  "type": "searchset",
+  "timestamp": "2026-08-10T08:25:05.002-07:00",
+  "entry": [
+    {
+      "resource": {
+        "resourceType": "OperationOutcome",
+        "id": "01KZP4E1X6FCK0TAEXFWHC4EGP",
+        "meta": {
+          "_source": {
+            "extension": [
+              {
+                "url": "http://hl7.org/fhir/StructureDefinition/originalText",
+                "valueString": "MSA|AA|01KZP4E0S68Y65ZDRNN8QYQES4"
+              }
+            ]
+          }
+        },
+        "issue": [
+          {
+            "severity": "information",
+            "code": "informational",
+            "details": {
+              "coding": [
+                {
+                  "system": "http://terminology.hl7.org/CodeSystem/v2-0008",
+                  "code": "AA"
+                }
+              ]
+            }
+          }
+        ],
+        "identifier": []
+      },
+      "search": {
+        "mode": "outcome"
+      }
+    },
+    {
+      "resource": {
+        "resourceType": "OperationOutcome",
+        "id": "01KZP4E1X7C57DP6BY50ED7XTY",
+        "meta": {
+          "_source": {
+            "extension": [
+              {
+                "url": "http://hl7.org/fhir/StructureDefinition/originalText",
+                "valueString": "QAK|01KZP4E0S78Q0AD8TMG71NWXWT|OK|Z44^Request Evaluated History and Forecast^CDCPHINVS"
+              }
+            ]
+          },
+          "tag": [
+            {
+              "system": "QueryTag",
+              "code": "01KZP4E0S78Q0AD8TMG71NWXWT"
+            }
+          ]
+        },
+        "issue": [
+          {
+            "severity": "information",
+            "code": "informational",
+            "details": {
+              "coding": [
+                {
+                  "system": "http://terminology.hl7.org/CodeSystem/v2-0208",
+                  "code": "OK"
+                }
+              ]
+            }
+          }
+        ],
+        "identifier": []
+      },
+      "search": {
+        "mode": "outcome"
+      }
+    },
+    {
+      "resource": {
+        "resourceType": "ImmunizationRecommendation",
+        "id": "TlYwMDAwfDM5NzM1NjV8bnVsbHxudWxs",
+        "meta": {
+          "_source": {
+            "extension": [
+              {
+                "url": "http://hl7.org/fhir/StructureDefinition/originalText",
+                "valueString": "ORC|RE||41348935^NV0000"
+              }
+            ]
+          }
+        },
+        "patient": {
+          "reference": "Patient/TlYwMDAwfDM5NzM1NjU",
+          "identifier": {
+            "type": {
+              "coding": [
+                {
+                  "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
+                  "code": "SR",
+                  "display": "State registry ID"
+                }
+              ]
+            },
+            "system": "NV0000",
+            "value": "3973565"
+          },
+          "display": "WENDYIZG SNHDIZGONE PRESTONSNHDONEZG"
+        },
+        "date": "2026-06-05",
+        "recommendation": [
+          {
+            "vaccineCode": [
+              {
+                "coding": [
+                  {
+                    "system": "http://hl7.org/fhir/sid/cvx",
+                    "code": "09",
+                    "display": "Td (adult), 2 Lf tetanus toxoid, preservative free, adsorbed"
+                  },
+                  {
+                    "system": "http://hl7.org/fhir/sid/ndc",
+                    "code": "00006-4133-01",
+                    "display": "Td (adult), adsorbed"
+                  }
+                ]
+              }
+            ],
+            "dateCriterion": [
+              {
+                "value": "2022-08-10"
+              }
+            ],
+            "doseNumberPositiveInt": 1
+          }
+        ],
+        "identifier": []
+      },
+      "search": {
+        "mode": "match"
+      }
+    },
+    {
+      "resource": {
+        "resourceType": "ImmunizationRecommendation",
+        "id": "TlYwMDAwfDM5NzM1NjV8bnVsbHxudWxs",
+        "meta": {
+          "_source": {
+            "extension": [
+              {
+                "url": "http://hl7.org/fhir/StructureDefinition/originalText",
+                "valueString": "ORC|RE||41348937^NV0000"
+              }
+            ]
+          }
+        },
+        "patient": {
+          "reference": "Patient/TlYwMDAwfDM5NzM1NjU",
+          "identifier": {
+            "type": {
+              "coding": [
+                {
+                  "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
+                  "code": "SR",
+                  "display": "State registry ID"
+                }
+              ]
+            },
+            "system": "NV0000",
+            "value": "3973565"
+          },
+          "display": "WENDYIZG SNHDIZGONE PRESTONSNHDONEZG"
+        },
+        "date": "2026-06-08",
+        "recommendation": [
+          {
+            "vaccineCode": [
+              {
+                "coding": [
+                  {
+                    "system": "http://hl7.org/fhir/sid/cvx",
+                    "code": "150",
+                    "display": "Influenza, split virus, quadrivalent, PF"
+                  },
+                  {
+                    "system": "http://hl7.org/fhir/sid/ndc",
+                    "code": "19515-0818-41",
+                    "display": "Influenza Quad Inj P"
+                  }
+                ]
+              }
+            ],
+            "dateCriterion": [
+              {
+                "value": "2022-08-10"
+              }
+            ],
+            "doseNumberPositiveInt": 1
+          }
+        ],
+        "identifier": []
+      },
+      "search": {
+        "mode": "match"
+      }
+    },
+    {
+      "resource": {
+        "resourceType": "ImmunizationRecommendation",
+        "id": "TlYwMDAwfDM5NzM1NjV8bnVsbHxudWxs",
+        "meta": {
+          "_source": {
+            "extension": [
+              {
+                "url": "http://hl7.org/fhir/StructureDefinition/originalText",
+                "valueString": "ORC|RE||9999^NV0000"
+              }
+            ]
+          }
+        },
+        "patient": {
+          "reference": "Patient/TlYwMDAwfDM5NzM1NjU",
+          "identifier": {
+            "type": {
+              "coding": [
+                {
+                  "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
+                  "code": "SR",
+                  "display": "State registry ID"
+                }
+              ]
+            },
+            "system": "NV0000",
+            "value": "3973565"
+          },
+          "display": "WENDYIZG SNHDIZGONE PRESTONSNHDONEZG"
+        },
+        "recommendation": [
+          {
+            "vaccineCode": [
+              {
+                "coding": [
+                  {
+                    "system": "http://hl7.org/fhir/sid/cvx",
+                    "code": "998",
+                    "display": "no vaccine administered"
+                  }
+                ]
+              }
+            ],
+            "forecastStatus": {
+              "coding": [
+                {
+                  "system": "http://loinc.org",
+                  "code": "LA13424-9",
+                  "display": "Too Old"
+                }
+              ]
+            },
+            "dateCriterion": [
+              {
+                "value": "2026-08-10"
+              },
+              {
+                "code": {
+                  "coding": [
+                    {
+                      "system": "http://loinc.org",
+                      "code": "30981-5",
+                      "display": "Earliest date to give"
+                    }
+                  ]
+                },
+                "value": "2000-10-01"
+              },
+              {
+                "code": {
+                  "coding": [
+                    {
+                      "system": "http://loinc.org",
+                      "code": "30980-7",
+                      "display": "Date vaccine due"
+                    }
+                  ]
+                },
+                "value": "2000-10-01"
+              },
+              {
+                "code": {
+                  "coding": [
+                    {
+                      "system": "http://loinc.org",
+                      "code": "59778-1",
+                      "display": "Date when overdue for immunization"
+                    }
+                  ]
+                },
+                "value": "2000-10-28"
+              },
+              {
+                "code": {
+                  "coding": [
+                    {
+                      "system": "http://loinc.org",
+                      "code": "30981-5",
+                      "display": "Earliest date to give"
+                    }
+                  ]
+                },
+                "value": "2001-10-01"
+              },
+              {
+                "code": {
+                  "coding": [
+                    {
+                      "system": "http://loinc.org",
+                      "code": "30980-7",
+                      "display": "Date vaccine due"
+                    }
+                  ]
+                },
+                "value": "2001-10-01"
+              },
+              {
+                "code": {
+                  "coding": [
+                    {
+                      "system": "http://loinc.org",
+                      "code": "59778-1",
+                      "display": "Date when overdue for immunization"
+                    }
+                  ]
+                },
+                "value": "2002-02-28"
+              },
+              {
+                "code": {
+                  "coding": [
+                    {
+                      "system": "http://loinc.org",
+                      "code": "30981-5",
+                      "display": "Earliest date to give"
+                    }
+                  ]
+                },
+                "value": "2001-10-01"
+              },
+              {
+                "code": {
+                  "coding": [
+                    {
+                      "system": "http://loinc.org",
+                      "code": "30980-7",
+                      "display": "Date vaccine due"
+                    }
+                  ]
+                },
+                "value": "2001-10-01"
+              },
+              {
+                "code": {
+                  "coding": [
+                    {
+                      "system": "http://loinc.org",
+                      "code": "59778-1",
+                      "display": "Date when overdue for immunization"
+                    }
+                  ]
+                },
+                "value": "2002-02-28"
+              },
+              {
+                "code": {
+                  "coding": [
+                    {
+                      "system": "http://loinc.org",
+                      "code": "30981-5",
+                      "display": "Earliest date to give"
+                    }
+                  ]
+                },
+                "value": "2009-10-01"
+              },
+              {
+                "code": {
+                  "coding": [
+                    {
+                      "system": "http://loinc.org",
+                      "code": "30980-7",
+                      "display": "Date vaccine due"
+                    }
+                  ]
+                },
+                "value": "2011-10-01"
+              },
+              {
+                "code": {
+                  "coding": [
+                    {
+                      "system": "http://loinc.org",
+                      "code": "59777-3",
+                      "display": "Latest date to give immunization"
+                    }
+                  ]
+                },
+                "value": "2046-09-30"
+              },
+              {
+                "code": {
+                  "coding": [
+                    {
+                      "system": "http://loinc.org",
+                      "code": "59778-1",
+                      "display": "Date when overdue for immunization"
+                    }
+                  ]
+                },
+                "value": "2013-10-28"
+              },
+              {
+                "code": {
+                  "coding": [
+                    {
+                      "system": "http://loinc.org",
+                      "code": "30981-5",
+                      "display": "Earliest date to give"
+                    }
+                  ]
+                },
+                "value": "2022-08-10"
+              },
+              {
+                "code": {
+                  "coding": [
+                    {
+                      "system": "http://loinc.org",
+                      "code": "30980-7",
+                      "display": "Date vaccine due"
+                    }
+                  ]
+                },
+                "value": "2022-08-10"
+              },
+              {
+                "code": {
+                  "coding": [
+                    {
+                      "system": "http://loinc.org",
+                      "code": "59778-1",
+                      "display": "Date when overdue for immunization"
+                    }
+                  ]
+                },
+                "value": "2022-08-10"
+              },
+              {
+                "code": {
+                  "coding": [
+                    {
+                      "system": "http://loinc.org",
+                      "code": "30981-5",
+                      "display": "Earliest date to give"
+                    }
+                  ]
+                },
+                "value": "2025-08-27"
+              },
+              {
+                "code": {
+                  "coding": [
+                    {
+                      "system": "http://loinc.org",
+                      "code": "30980-7",
+                      "display": "Date vaccine due"
+                    }
+                  ]
+                },
+                "value": "2025-08-27"
+              },
+              {
+                "code": {
+                  "coding": [
+                    {
+                      "system": "http://loinc.org",
+                      "code": "30981-5",
+                      "display": "Earliest date to give"
+                    }
+                  ]
+                },
+                "value": "2026-07-01"
+              },
+              {
+                "code": {
+                  "coding": [
+                    {
+                      "system": "http://loinc.org",
+                      "code": "30980-7",
+                      "display": "Date vaccine due"
+                    }
+                  ]
+                },
+                "value": "2026-07-01"
+              },
+              {
+                "code": {
+                  "coding": [
+                    {
+                      "system": "http://loinc.org",
+                      "code": "30981-5",
+                      "display": "Earliest date to give"
+                    }
+                  ]
+                },
+                "value": "2050-10-01"
+              },
+              {
+                "code": {
+                  "coding": [
+                    {
+                      "system": "http://loinc.org",
+                      "code": "30980-7",
+                      "display": "Date vaccine due"
+                    }
+                  ]
+                },
+                "value": "2050-10-01"
+              },
+              {
+                "code": {
+                  "coding": [
+                    {
+                      "system": "http://loinc.org",
+                      "code": "30981-5",
+                      "display": "Earliest date to give"
+                    }
+                  ]
+                },
+                "value": "2050-10-01"
+              },
+              {
+                "code": {
+                  "coding": [
+                    {
+                      "system": "http://loinc.org",
+                      "code": "30980-7",
+                      "display": "Date vaccine due"
+                    }
+                  ]
+                },
+                "value": "2050-10-01"
+              },
+              {
+                "code": {
+                  "coding": [
+                    {
+                      "system": "http://loinc.org",
+                      "code": "30981-5",
+                      "display": "Earliest date to give"
+                    }
+                  ]
+                },
+                "value": "2075-10-01"
+              },
+              {
+                "code": {
+                  "coding": [
+                    {
+                      "system": "http://loinc.org",
+                      "code": "30980-7",
+                      "display": "Date vaccine due"
+                    }
+                  ]
+                },
+                "value": "2075-10-01"
+              }
+            ]
+          }
+        ],
+        "identifier": []
+      },
+      "search": {
+        "mode": "match"
+      }
+    }
+  ]
+}

--- a/src/app/tests/unit/query-service.test.tsx
+++ b/src/app/tests/unit/query-service.test.tsx
@@ -4,7 +4,7 @@ import {
 } from "@/app/backend/query-execution/service";
 import { isFhirResource } from "@/app/constants";
 import { readJsonFile } from "../shared_utils/readJsonFile";
-import { Bundle, DiagnosticReport, Observation } from "fhir/r4";
+import { Bundle, DiagnosticReport, FhirResource, Observation } from "fhir/r4";
 import { QueryResponse } from "@/app/models/entities/query";
 import { suppressConsoleLogs } from "../integration/fixtures";
 
@@ -59,6 +59,67 @@ describe("process response", () => {
     expect(
       resourceArray.filter((r) => r.resourceType === "Observation").length,
     ).toEqual(2);
+  });
+
+  it("keeps every ImmunizationRecommendation even when they share an id, while still deduping other types", async () => {
+    const sharedId = "TlYwMDAwfDM5NzM1NjV8bnVsbHxudWxs";
+    const bundle: Bundle<FhirResource> = {
+      resourceType: "Bundle",
+      type: "searchset",
+      entry: [
+        {
+          resource: {
+            resourceType: "ImmunizationRecommendation",
+            id: sharedId,
+            patient: { reference: "Patient/p1" },
+            date: "2026-06-05",
+            recommendation: [],
+          },
+        },
+        {
+          resource: {
+            resourceType: "ImmunizationRecommendation",
+            id: sharedId,
+            patient: { reference: "Patient/p1" },
+            date: "2026-06-05",
+            recommendation: [],
+          },
+        },
+        {
+          resource: {
+            resourceType: "Immunization",
+            id: "imm-1",
+            status: "completed",
+            vaccineCode: {},
+            patient: { reference: "Patient/p1" },
+          },
+        },
+        {
+          resource: {
+            resourceType: "Immunization",
+            id: "imm-1",
+            status: "completed",
+            vaccineCode: {},
+            patient: { reference: "Patient/p1" },
+          },
+        },
+      ],
+    };
+    const response = {
+      status: 200,
+      json: async () => bundle,
+    } as unknown as Response;
+
+    const resourceArray = await processFhirResponse(response);
+
+    expect(
+      resourceArray.filter(
+        (r) => r.resourceType === "ImmunizationRecommendation",
+      ),
+    ).toHaveLength(2);
+    expect(
+      resourceArray.filter((r) => r.resourceType === "Immunization"),
+    ).toHaveLength(1);
   });
 
   it("returns an empty array when a 200 response has an unparseable body", async () => {
@@ -131,6 +192,44 @@ describe("parse fhir search", () => {
     queryResponse.Observation?.forEach((o: Observation) => {
       expect(observationResources).toContain(o);
     });
+  });
+
+  it("does not dedupe ImmunizationRecommendation across responses", async () => {
+    const sharedId = "TlYwMDAwfDM5NzM1NjV8bnVsbHxudWxs";
+    const makeResponse = () =>
+      ({
+        status: 200,
+        json: async () => ({
+          resourceType: "Bundle",
+          type: "searchset",
+          entry: [
+            {
+              resource: {
+                resourceType: "ImmunizationRecommendation",
+                id: sharedId,
+                patient: { reference: "Patient/p1" },
+                date: "2026-06-05",
+                recommendation: [],
+              },
+            },
+            {
+              resource: {
+                resourceType: "ImmunizationRecommendation",
+                id: sharedId,
+                patient: { reference: "Patient/p1" },
+                date: "2026-06-05",
+                recommendation: [],
+              },
+            },
+          ],
+        }),
+      }) as unknown as Response;
+
+    const queryResponse: QueryResponse = await parseFhirSearch([
+      makeResponse(),
+    ]);
+
+    expect(queryResponse.ImmunizationRecommendation).toHaveLength(2);
   });
 
   it("keeps resources from good responses when one response in the array fails to parse", async () => {

--- a/src/app/tests/unit/search-form-validation.test.tsx
+++ b/src/app/tests/unit/search-form-validation.test.tsx
@@ -304,14 +304,8 @@ describe("Search Form mTLS Server Selection", () => {
       />,
     );
 
-    // Open advanced options
-    const advancedButton = screen.getByRole("button", { name: "Advanced" });
-    await user.click(advancedButton);
-
     // Select the mTLS server
-    const serverDropdown = screen.getByLabelText(
-      "Healthcare Organization (HCO)",
-    );
+    const serverDropdown = screen.getByLabelText("FHIR server");
     await user.selectOptions(serverDropdown, "mTLS Server");
 
     // Fill required fields

--- a/src/app/ui/components/sideNav/sidenav.module.scss
+++ b/src/app/ui/components/sideNav/sidenav.module.scss
@@ -19,6 +19,14 @@
   margin-left: 1px;
 }
 
+/* USWDS's hover style (primary text on base-lightest) only reaches 4.05:1
+   for bold 16px text, short of WCAG AA's 4.5:1, for both plain and
+   .usa-current links. Its selector stacks two :not()s, so !important is the
+   only way to win without mirroring that selector here. */
+.container a.item:hover {
+  color: $brand-dark !important;
+}
+
 .subItem {
   color: $text-secondary;
   font-size: 1rem;

--- a/src/docs/api.mdx
+++ b/src/docs/api.mdx
@@ -19,9 +19,10 @@ Query results are returned as a FHIR Bundle containing the patient's records. De
 - `MedicationRequest`
 - `MedicationStatement`
 - `Immunization`
+- `ImmunizationRecommendation` (immunization forecast, from Immunization Gateway servers)
 - `ServiceRequest`
 
-Lab, condition, and medication resources are filtered to the value set codes configured in the query. `Immunization`, social determinants `Observation`, and `ServiceRequest` resources are returned when the corresponding medical record sections are enabled for the query. Medication and service request queries may also return related resources (such as `Medication`, `MedicationAdministration`, `Practitioner`, and `Specimen`) via `_include`/`_revinclude` search parameters.
+Lab, condition, and medication resources are filtered to the value set codes configured in the query. `Immunization`, social determinants `Observation`, and `ServiceRequest` resources are returned when the corresponding medical record sections are enabled for the query. Servers configured with the Immunization Gateway endpoint type also return `ImmunizationRecommendation` resources alongside `Immunization`. Medication and service request queries may also return related resources (such as `Medication`, `MedicationAdministration`, `Practitioner`, and `Specimen`) via `_include`/`_revinclude` search parameters.
 
 ## Authentication
 

--- a/src/docs/mutual-tls-setup.mdx
+++ b/src/docs/mutual-tls-setup.mdx
@@ -91,9 +91,12 @@ server can be any of the three types:
 - **Standard FHIR** – probes `/Patient` and uses a direct `/Patient` search for
   patient discovery.
 - **Immunization Gateway** – probes `/Immunization`. Patient discovery still uses
-  the standard `/Patient` path, then immunization records are pulled with
-  `/Immunization?subject=Patient/{id}`. Choose this for an eHealth Exchange
-  immunization gateway (e.g. `IZGUAT`).
+  the standard `/Patient` path, then immunization history and forecast are pulled
+  with `/Immunization` and `/ImmunizationRecommendation` searches scoped by the
+  matched patient's demographics (`patient.given`, `patient.family`,
+  `patient.birthdate`), which the gateway translates into HL7v2 queries. No other
+  record sections are queried. Choose this for an eHealth Exchange immunization
+  gateway (e.g. `IZGUAT`).
 - **Fanout (Task)** – probes `/Task` and performs TEFCA-style fanout discovery by
   POSTing a `/Task` resource and polling for child tasks.
 
@@ -109,12 +112,12 @@ server can be any of the three types:
    - **DOB**: 01-05-1963
    - **Phone Number**: 555-306-8493
    - **State**: MA
-3. Click "Advanced" and select your mTLS server
+3. Select your mTLS server from the **FHIR server** dropdown
 4. Click "Search for patient"
 5. What happens next depends on the server's **Endpoint Type**:
    - **Standard FHIR / Immunization Gateway** — a direct `/Patient` search is
-     issued, then clinical records (e.g. `/Immunization`) are queried for the
-     matched patient.
+     issued, then clinical records (e.g. `/Immunization` and, for gateways,
+     `/ImmunizationRecommendation`) are queried for the matched patient.
    - **Fanout (Task)** — a `/Task` resource is POSTed, child tasks are polled to
      completion, and patient results are retrieved from the completed tasks.
 

--- a/src/docs/user-guide.mdx
+++ b/src/docs/user-guide.mdx
@@ -51,7 +51,7 @@ Running a basic query has four steps:
    4. Home address
    5. Medical Record Number (MRN)
 
-If you have super admin user privileges, you’ll also need to choose the Health Care Organization (HCO) you’d like to use; changing the HCO will change the data source you’re querying.
+Choose the FHIR server you’d like to query from the **FHIR server** dropdown at the top of the form; changing the server changes the data source you’re querying. The server you choose is carried through to the query selection step and shown on the results page.
 
 The Patient Information page can also pre-fill certain form fields from URL parameters. Available parameters are:
 - `first` (First name)
@@ -64,7 +64,7 @@ The Patient Information page can also pre-fill certain form fields from URL para
 - `state` (Address state abbreviation, e.g. MN) 
 - `zip` (Zip code) 
 - `mrn` (Medical Record Number)
-- `server` (Health Care Organization) 
+- `server` (FHIR server) 
 
 For example, if you navigate to `/query?first=Hyper&last=Unlucky&dob=1975-12-06`, the First name, Last name, and Date of birth fields would be pre-filled; the Phone number, Home address, and Medical Record Number fields would be blank. 
 
@@ -111,6 +111,7 @@ Query Connector retrieves patient data in the form of FHIR resources – the sta
 * **MedicationRequest** – medications ordered or prescribed for the patient
 * **MedicationStatement** – medications the patient is (or was) taking, as reported by the patient or a clinician
 * **Immunization** – the patient’s vaccination history
+* **ImmunizationRecommendation** – the patient’s immunization forecast (returned by Immunization Gateway servers)
 * **ServiceRequest** – lab orders and other requested services
 
 Lab, condition, and medication results are filtered to the value sets and codes selected when the query was built, so you’ll see only the records relevant to the query’s purpose.


### PR DESCRIPTION
# PULL REQUEST

## Summary

Follow-ups from SNHD's IZ Gateway testing (email from Prut, Aug 10). Four changes:

### 1. Immunization forecast from Immunization Gateways

SNHD needs the IZ Gateway's evaluated history **and forecast**, which only `/ImmunizationRecommendation` (HL7v2 Z44) returns. Rather than adding a separate endpoint type (which would force staff to choose between the two), servers with Endpoint Type "Immunization Gateway" now send **both** `/Immunization` and `/ImmunizationRecommendation`, using the same chained `patient.given/patient.family/patient.birthdate` params. `/Immunization` still carries the lot, manufacturer, site, route and dose that the recommendation's history mirror lacks; the recommendation adds the forecast.

- `custom-query.ts`: patient-scoping params factored into `buildImmunizationPatientParams`; `immunizationRecommendation` query compiled only for `endpointType === "immunization"`.
- `service.ts`: the recommendation search is dispatched as its own GET with its own try/catch, so a failure on either search can't hide the other's results.
- **Dedupe fix**: the IZ Gateway stamps every `ImmunizationRecommendation` in a bundle with the same `id` (base64 of `NV0000|<patientId>|null|null`). Our `${resourceType}/${id}` dedupe kept only the first history entry and silently dropped the forecast, so that resource type is now exempt in both `processFhirResponse` and `parseFhirSearch`.
- New `ImmunizationRecommendationTable` (Vaccine / Forecast status / Dose / Date / Earliest / Due / Overdue, first `dateCriterion` per LOINC code). The Immunizations accordion splits into "Immunization history" and "Immunization forecast" only when a forecast is present — standard servers render exactly as before.
- Prut's real gateway responses are checked in as fixtures (`BundleIzGatewayImmunization.json`, `BundleIzGatewayImmunizationRecommendation.json`; synthetic test patients) and drive the gateway unit tests.

Known gateway data quirk (not fixable here, to be raised with eHealth Exchange): the gateway flattens every forecast window into **one** recommendation (CVX 998 "no vaccine administered", ~25 undifferentiated earliest/due/overdue dates, no per-vaccine grouping). The table renders that as a single row until the transform is fixed.

### 2. FHIR server select always visible on Run a Query

SNHD staff will switch between UMC (Epic) and the IZ Gateway, and were likely to forget the select hidden behind "Advanced". The select is now always shown on Step 1 (patient search) and Step 3 (select query); both Advanced toggles are removed and the patient-match checkbox sits directly under the select. Also fixes the Step 1 select staying pinned to a stale `?server=` URL param after the user changes it, and removes a stray "Select HCO" text node inside Step 3's `<select>`.

### 3. Label renamed to "FHIR server"

"Healthcare Organization (HCO)" / "Health Care Organization (HCO)" → "FHIR server", matching the server configuration page. Docs, e2e specs and the Step 3 label (now a real `<label>`) updated.

### 4. Results header shows the queried server

"FHIR server: <name>" under the query name on the Patient Record page, so it's clear which server answered.

**Design review focus**: Step 1 now opens with a "FHIR server" section at the top of the form (same h3 + label pattern as "Date of Birth"); Step 3 shows the server select under the query select; results header gains a second line.

## Related Issue

N/A — customer request from SNHD.

## Additional Information

- Verified end-to-end against a local mock gateway serving Prut's bundles: both GETs are sent with chained demographics, history and forecast tables render, and the results header shows the server.
- Playwright `query_execution`, `audit_logs`, `query_editing` pass locally except two pre-existing/environmental cases (the `MDRO case investigation` seed isn't in my local DB; the audit-log drawer test fails identically on `main` in the local `AUTH_DISABLED` setup).
- Step 3's two selects both carried trussworks' default `data-testid="Select"`, so they now have `query-select` / `fhir-server-select` and the e2e specs use those.

## Checklist

- [x] Descriptive Pull Request title
- [x] Link to relevant issues
- [x] Provide necessary context for design reviewers
- [x] Ensure test coverage is above agreed upon threshold
- [x] Update documentation
