### PR TITLE
Release v1.2.1

### DIFF
--- a/app_version.yml
+++ b/app_version.yml
@@ -1,1 +1,1 @@
-version: 1.2.0
+version: 1.2.1

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "query-connector",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "query-connector",
-      "version": "1.2.0",
+      "version": "1.2.1",
       "dependencies": {
         "@aws-sdk/client-secrets-manager": "^3.1113.0",
         "@axe-core/playwright": "^4.13.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "query-connector",
   "description": "DIBBs Query Connector: a Next.js full-stack application for public health staff to query healthcare organizations for patient records via FHIR and TEFCA networks.",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "private": true,
   "scripts": {
     "dev": "docker compose -f docker-compose-dev.yaml up -d && next dev --turbopack; docker compose -f docker-compose-dev.yaml down --remove-orphans",


### PR DESCRIPTION
## Summary
Bumps the app version to **v1.2.1** to trigger a release.

Patch release containing:
- #1025 — feat: query ImmunizationRecommendation on Immunization Gateways and surface the FHIR server select (SNHD IZ Gateway forecast; server select always visible and renamed "FHIR server"; results header shows the queried server; side-nav hover contrast fix)
- #1024 — fix: send all Epic query strategy searches as GET requests
- #1023 — chore(deps): combine Dependabot updates (Next 16.3, react-uswds 12, next-auth beta.32, jsdoc 64, undici 8.10 + minors)
- #1019 — Add files via upload (FAQ, IT, maintenance, UAT and user guide documents under `src/docs`)
