### PR TITLE
feat: show a DiagnosticReport's referenced result Observations on the results page

### DIFF
--- a/e2e/query_execution.spec.ts
+++ b/e2e/query_execution.spec.ts
@@ -131,7 +131,7 @@ test.describe("querying with the Query Connector", () => {
         .getByRole("table")
         .getByRole("row")
         .filter({ hasText: "Chlamydia trachomatis DNA" }),
-    ).toHaveCount(4);
+    ).toHaveCount(6);
     // Encounters
     await expect(
       page
@@ -385,19 +385,20 @@ test.describe("alternate queries with the Query Connector", () => {
         .filter({ hasText: "Vancomycin resistant enterococcus" }),
     ).toHaveCount(2);
     // The molecular results are members of the nares report rather than reports
-    // in their own right, so they stay at one row each.
+    // in their own right: one Observation row each, plus the nares report row
+    // that lists them under its Results column.
     await expect(
       page
         .getByRole("table")
         .getByRole("row")
         .filter({ hasText: "Methicillin resistance mecA gene" }),
-    ).toHaveCount(1);
+    ).toHaveCount(2);
     await expect(
       page
         .getByRole("table")
         .getByRole("row")
         .filter({ hasText: "Vancomycin resistance vanA gene" }),
-    ).toHaveCount(1);
+    ).toHaveCount(2);
 
     // June infections: the MRSA sacral-wound Condition is a single row, while
     // the carbapenem-resistant Enterobacteriaceae code drives both a Condition

--- a/src/app/(pages)/query/components/ResultsView.test.tsx
+++ b/src/app/(pages)/query/components/ResultsView.test.tsx
@@ -1,6 +1,6 @@
 import { renderWithUser } from "@/app/tests/unit/setup";
 import ResultsView from "./ResultsView";
-import { screen } from "@testing-library/react";
+import { screen, within } from "@testing-library/react";
 import type { PatientRecordsResponse } from "../../../backend/query-execution/service";
 
 const TEST_QUERY = {
@@ -34,6 +34,16 @@ const POPULATED_RESPONSE = {
       resourceType: "Condition",
       id: "c1",
       code: { text: "Chlamydia" },
+    },
+  ],
+  DiagnosticReport: [
+    {
+      resourceType: "DiagnosticReport",
+      id: "dr1",
+      status: "final",
+      code: { text: "XR Chest 2 Views" },
+      effectiveDateTime: "2026-02-25T08:00:00Z",
+      result: [{ reference: "Observation/o1", display: "Impression" }],
     },
   ],
   MedicationRequest: [
@@ -164,6 +174,25 @@ describe("ResultsView", () => {
 
     // Rendered child-table content confirms the resources were mapped through.
     expect(screen.getByText("Hyper Unlucky")).toBeInTheDocument();
+    expect(screen.getByText("Glucose")).toBeInTheDocument();
+  });
+
+  it("shows a DiagnosticReport's referenced result Observations under the report", () => {
+    renderWithUser(
+      <ResultsView
+        patientRecordsResponse={POPULATED_RESPONSE}
+        selectedQuery={TEST_QUERY}
+        goBack={() => {}}
+        goToBeginning={() => {}}
+        loading={false}
+      />,
+    );
+
+    const reportRow = screen.getByRole("row", { name: /XR Chest 2 Views/ });
+    expect(within(reportRow).getByText("Impression")).toBeInTheDocument();
+    expect(within(reportRow).getByText("5.4 mg/dL")).toBeInTheDocument();
+    // The Observation still appears in the Observations table as well.
+    expect(screen.getAllByText("5.4 mg/dL")).toHaveLength(2);
     expect(screen.getByText("Glucose")).toBeInTheDocument();
   });
 

--- a/src/app/(pages)/query/components/ResultsView.tsx
+++ b/src/app/(pages)/query/components/ResultsView.tsx
@@ -212,7 +212,10 @@ function mapQueryResponseToAccordionDataStructure(
     {
       title: "Diagnostic Reports",
       content: diagnosticReports ? (
-        <DiagnosticReportTable diagnosticReports={diagnosticReports} />
+        <DiagnosticReportTable
+          diagnosticReports={diagnosticReports}
+          observations={observations ?? []}
+        />
       ) : null,
     },
     {

--- a/src/app/(pages)/query/components/resultsView/tableComponents/DiagnosticReportTable.test.tsx
+++ b/src/app/(pages)/query/components/resultsView/tableComponents/DiagnosticReportTable.test.tsx
@@ -1,0 +1,160 @@
+import { render, screen, within } from "@testing-library/react";
+import { DiagnosticReport, Observation } from "fhir/r4";
+import DiagnosticReportTable from "./DiagnosticReportTable";
+
+const baseReport: DiagnosticReport = {
+  resourceType: "DiagnosticReport",
+  id: "dr-1",
+  status: "final",
+  code: { text: "XR Chest 2 Views" },
+  effectiveDateTime: "2026-02-25T08:00:00Z",
+};
+
+const NARRATIVE_TEXT =
+  "FINDINGS:\nThe lungs are clear.\n\nNo pleural effusion or pneumothorax.";
+
+const narrative: Observation = {
+  resourceType: "Observation",
+  id: "obs-narrative",
+  status: "final",
+  code: { text: "Narrative" },
+  valueString: NARRATIVE_TEXT,
+};
+
+const impression: Observation = {
+  resourceType: "Observation",
+  id: "obs-impression",
+  status: "final",
+  code: { text: "Impression" },
+  valueString: "No acute cardiopulmonary process.",
+};
+
+function headers() {
+  return screen.getAllByRole("columnheader").map((h) => h.textContent);
+}
+
+describe("DiagnosticReportTable", () => {
+  it("renders only Date and Code when no report references results", () => {
+    render(<DiagnosticReportTable diagnosticReports={[baseReport]} />);
+
+    expect(headers()).toEqual(["Date", "Code"]);
+    expect(screen.getByText("02/25/2026")).toBeInTheDocument();
+    expect(screen.getByText("XR Chest 2 Views")).toBeInTheDocument();
+  });
+
+  it("does not add the Results column for an empty result list", () => {
+    render(
+      <DiagnosticReportTable
+        diagnosticReports={[{ ...baseReport, result: [] }]}
+        observations={[narrative]}
+      />,
+    );
+
+    expect(headers()).toEqual(["Date", "Code"]);
+  });
+
+  it("shows each referenced Observation's text under its reference display, keeping line breaks", () => {
+    const report: DiagnosticReport = {
+      ...baseReport,
+      result: [
+        { reference: "Observation/obs-narrative", display: "Narrative" },
+        { reference: "Observation/obs-impression", display: "Impression" },
+      ],
+    };
+
+    render(
+      <DiagnosticReportTable
+        diagnosticReports={[report]}
+        observations={[narrative, impression]}
+      />,
+    );
+
+    expect(headers()).toEqual(["Date", "Code", "Results"]);
+    const row = screen.getByRole("row", { name: /XR Chest 2 Views/ });
+    const resultsCell = within(row).getAllByRole("cell")[2];
+    expect(within(resultsCell).getByText("Narrative")).toBeInTheDocument();
+    expect(within(resultsCell).getByText("Impression")).toBeInTheDocument();
+    // Matched without whitespace normalization so the paragraph breaks are
+    // asserted, not collapsed away.
+    expect(
+      within(resultsCell).getByText(NARRATIVE_TEXT, {
+        normalizer: (text) => text,
+      }),
+    ).toBeInTheDocument();
+    expect(
+      within(resultsCell).getByText("No acute cardiopulmonary process."),
+    ).toBeInTheDocument();
+  });
+
+  it("labels a result with the Observation's code when the reference has no display", () => {
+    const glucose: Observation = {
+      resourceType: "Observation",
+      id: "obs-glucose",
+      status: "final",
+      code: { text: "Glucose" },
+      valueQuantity: { value: 5.4, unit: "mg/dL" },
+    };
+    const report: DiagnosticReport = {
+      ...baseReport,
+      code: { text: "Metabolic panel" },
+      result: [{ reference: "Observation/obs-glucose" }],
+    };
+
+    render(
+      <DiagnosticReportTable
+        diagnosticReports={[report]}
+        observations={[glucose]}
+      />,
+    );
+
+    const row = screen.getByRole("row", { name: /Metabolic panel/ });
+    const resultsCell = within(row).getAllByRole("cell")[2];
+    expect(within(resultsCell).getByText("Glucose")).toBeInTheDocument();
+    expect(within(resultsCell).getByText("5.4 mg/dL")).toBeInTheDocument();
+  });
+
+  it("falls back to the reference display alone when the Observation wasn't returned", () => {
+    const report: DiagnosticReport = {
+      ...baseReport,
+      result: [
+        { reference: "Observation/obs-missing", display: "Narrative" },
+        // Neither a display nor a resolvable Observation: nothing to show.
+        { reference: "Observation/obs-also-missing" },
+      ],
+    };
+
+    render(<DiagnosticReportTable diagnosticReports={[report]} />);
+
+    const row = screen.getByRole("row", { name: /XR Chest 2 Views/ });
+    const resultsCell = within(row).getAllByRole("cell")[2];
+    expect(within(resultsCell).getByText("Narrative")).toBeInTheDocument();
+    expect(resultsCell.querySelectorAll("div")).toHaveLength(1);
+  });
+
+  it("leaves the Results cell empty for a report without results when another report has them", () => {
+    const withResults: DiagnosticReport = {
+      ...baseReport,
+      id: "dr-with",
+      result: [
+        { reference: "Observation/obs-impression", display: "Impression" },
+      ],
+    };
+    const without: DiagnosticReport = {
+      ...baseReport,
+      id: "dr-without",
+      code: { text: "CBC" },
+    };
+
+    render(
+      <DiagnosticReportTable
+        diagnosticReports={[withResults, without]}
+        observations={[impression]}
+      />,
+    );
+
+    const row = screen.getByRole("row", { name: /CBC/ });
+    const cells = within(row).getAllByRole("cell");
+    expect(cells).toHaveLength(3);
+    expect(cells[2]).toHaveTextContent("");
+  });
+});

--- a/src/app/(pages)/query/components/resultsView/tableComponents/DiagnosticReportTable.tsx
+++ b/src/app/(pages)/query/components/resultsView/tableComponents/DiagnosticReportTable.tsx
@@ -94,7 +94,9 @@ function renderResults(
     const value = observation ? formatObservationValue(observation) : "";
     if (!label && !value) return null;
     return (
-      <div key={ref.reference ?? index} className={styles.reportResult}>
+      // A report can list the same reference more than once, so the key
+      // can't be the reference alone.
+      <div key={index} className={styles.reportResult}>
         {label && <strong>{label}</strong>}
         {value && <div>{value}</div>}
       </div>

--- a/src/app/(pages)/query/components/resultsView/tableComponents/DiagnosticReportTable.tsx
+++ b/src/app/(pages)/query/components/resultsView/tableComponents/DiagnosticReportTable.tsx
@@ -1,33 +1,59 @@
-import React from "react";
+import React, { useMemo } from "react";
 import Table from "@/app/ui/designSystem/table/Table";
-import { DiagnosticReport } from "fhir/r4";
+import { DiagnosticReport, Observation } from "fhir/r4";
 import {
   formatCodeableConcept,
   formatDate,
 } from "../../../../../utils/format-service";
+import { referencedResourceId } from "../../../../../utils/fhir-reference";
+import { codeableConceptText, formatObservationValue } from "./utils";
+import styles from "./resultsTables.module.scss";
+import classNames from "classnames";
 
 /**
  * The props for the DiagnosticReportTable component.
  */
 export interface DiagnosticReportTableProps {
   diagnosticReports: DiagnosticReport[];
+  observations?: Observation[];
 }
 
 /**
  * Displays a table of data from array of DiagnosticReport resources.
  * @param props - DiagnosticReport table props.
  * @param props.diagnosticReports - The array of DiagnosticReport resources.
+ * @param props.observations - Observation resources returned with the query,
+ * used to show the results (a narrative, an impression, panel members) that a
+ * report references rather than carries itself.
  * @returns - The DiagnosticReportTable component.
  */
 const DiagnosticReportTable: React.FC<DiagnosticReportTableProps> = ({
   diagnosticReports,
+  observations = [],
 }) => {
+  const observationIndex = useMemo(
+    () =>
+      new Map(
+        observations
+          .filter((obs) => obs.id)
+          .map((obs) => [obs.id as string, obs]),
+      ),
+    [observations],
+  );
+  const hasResults = diagnosticReports.some(
+    (report) => (report.result?.length ?? 0) > 0,
+  );
+
   return (
-    <Table contained={false}>
+    <Table
+      contained={false}
+      className={classNames(hasResults && styles.diagnosticReportsFixedTable)}
+    >
       <thead>
         <tr>
           <th>Date</th>
           <th>Code</th>
+          {hasResults && <th>Results</th>}
         </tr>
       </thead>
       <tbody>
@@ -35,6 +61,9 @@ const DiagnosticReportTable: React.FC<DiagnosticReportTableProps> = ({
           <tr key={diagnosticReport.id}>
             <td>{formatDate(diagnosticReport?.effectiveDateTime)}</td>
             <td>{formatCodeableConcept(diagnosticReport.code)}</td>
+            {hasResults && (
+              <td>{renderResults(diagnosticReport, observationIndex)}</td>
+            )}
           </tr>
         ))}
       </tbody>
@@ -43,3 +72,32 @@ const DiagnosticReportTable: React.FC<DiagnosticReportTableProps> = ({
 };
 
 export default DiagnosticReportTable;
+
+/**
+ * Renders each Observation a report's `result` element references, resolved
+ * against the Observations returned with the query. A result whose
+ * Observation wasn't returned shows its reference display alone; one with
+ * neither is skipped.
+ * @param report - The DiagnosticReport whose results to render.
+ * @param observationIndex - Observations returned with the query, keyed by id.
+ * @returns One block per displayable result.
+ */
+function renderResults(
+  report: DiagnosticReport,
+  observationIndex: Map<string, Observation>,
+) {
+  return (report.result ?? []).map((ref, index) => {
+    const id = referencedResourceId(ref.reference, "Observation");
+    const observation = id ? observationIndex.get(id) : undefined;
+    const label =
+      ref.display ?? (observation ? codeableConceptText(observation.code) : "");
+    const value = observation ? formatObservationValue(observation) : "";
+    if (!label && !value) return null;
+    return (
+      <div key={ref.reference ?? index} className={styles.reportResult}>
+        {label && <strong>{label}</strong>}
+        {value && <div>{value}</div>}
+      </div>
+    );
+  });
+}

--- a/src/app/(pages)/query/components/resultsView/tableComponents/ObservationTable.tsx
+++ b/src/app/(pages)/query/components/resultsView/tableComponents/ObservationTable.tsx
@@ -5,7 +5,10 @@ import {
   formatCodeableConcept,
   formatDate,
 } from "../../../../../utils/format-service";
-import { checkIfSomeElementWithPropertyExists } from "./utils";
+import {
+  checkIfSomeElementWithPropertyExists,
+  formatObservationValue,
+} from "./utils";
 
 /**
  * The props for the ObservationTable component.
@@ -56,7 +59,7 @@ const ObservationTable: React.FC<ObservationTableProps> = ({
                   : ""}
               </td>
             )}
-            <td>{formatValue(obs)}</td>
+            <td>{formatObservationValue(obs)}</td>
             {availableElements.referenceRange && (
               <td>{formatReferenceRange(obs)}</td>
             )}
@@ -67,22 +70,6 @@ const ObservationTable: React.FC<ObservationTableProps> = ({
   );
 };
 export default ObservationTable;
-
-/**
- * Formats the value of an Observation object for display.
- * @param obs - The Observation object.
- * @returns The value of the Observation object formatted for display.
- */
-function formatValue(obs: Observation) {
-  if (obs.valueCodeableConcept) {
-    return formatCodeableConcept(obs.valueCodeableConcept);
-  } else if (obs.valueQuantity) {
-    return [obs.valueQuantity.value, obs.valueQuantity.unit].join(" ");
-  } else if (obs.valueString) {
-    return obs.valueString;
-  }
-  return "";
-}
 
 /**
  * Formats the reference range of an Observation object for display.

--- a/src/app/(pages)/query/components/resultsView/tableComponents/ObservationTable.tsx
+++ b/src/app/(pages)/query/components/resultsView/tableComponents/ObservationTable.tsx
@@ -9,6 +9,7 @@ import {
   checkIfSomeElementWithPropertyExists,
   formatObservationValue,
 } from "./utils";
+import styles from "./resultsTables.module.scss";
 
 /**
  * The props for the ObservationTable component.
@@ -59,7 +60,9 @@ const ObservationTable: React.FC<ObservationTableProps> = ({
                   : ""}
               </td>
             )}
-            <td>{formatObservationValue(obs)}</td>
+            <td className={styles.multilineValue}>
+              {formatObservationValue(obs)}
+            </td>
             {availableElements.referenceRange && (
               <td>{formatReferenceRange(obs)}</td>
             )}

--- a/src/app/(pages)/query/components/resultsView/tableComponents/resultsTables.module.scss
+++ b/src/app/(pages)/query/components/resultsView/tableComponents/resultsTables.module.scss
@@ -35,10 +35,14 @@
 }
 
 // Report narratives and impressions arrive as multi-paragraph text, so the
-// cell keeps their line breaks.
-.reportResult {
+// cells that show them keep their line breaks.
+.multilineValue {
   white-space: pre-wrap;
   word-break: break-word;
+}
+
+.reportResult {
+  @extend .multilineValue;
 
   & + & {
     margin-top: 0.5rem;

--- a/src/app/(pages)/query/components/resultsView/tableComponents/resultsTables.module.scss
+++ b/src/app/(pages)/query/components/resultsView/tableComponents/resultsTables.module.scss
@@ -1,18 +1,46 @@
 @use "../../../../../ui/styles/_variables" as *;
 
-.medicationsFixedTable table{
-    table-layout: fixed;
-    word-wrap: break-word;
+.medicationsFixedTable table {
+  table-layout: fixed;
+  word-wrap: break-word;
 
-    thead tr th{
-        width: 32%;
+  thead tr th {
+    width: 32%;
 
-        &:first-child{
-            width:20%;
-        }
-
-        &:last-child{
-            width:15%;
-        }
+    &:first-child {
+      width: 20%;
     }
+
+    &:last-child {
+      width: 15%;
+    }
+  }
+}
+
+.diagnosticReportsFixedTable table {
+  table-layout: fixed;
+  word-wrap: break-word;
+
+  thead tr th {
+    width: 30%;
+
+    &:first-child {
+      width: 20%;
+    }
+
+    &:last-child {
+      width: 50%;
+    }
+  }
+}
+
+// Report narratives and impressions arrive as multi-paragraph text, so the
+// cell keeps their line breaks.
+.reportResult {
+  white-space: pre-wrap;
+  word-break: break-word;
+
+  & + & {
+    margin-top: 0.5rem;
+  }
 }

--- a/src/app/(pages)/query/components/resultsView/tableComponents/utils.test.ts
+++ b/src/app/(pages)/query/components/resultsView/tableComponents/utils.test.ts
@@ -27,6 +27,15 @@ describe("formatObservationValue", () => {
     ).toBe("Lungs are clear.");
   });
 
+  it("trims padding around a string value but keeps interior line breaks", () => {
+    expect(
+      formatObservationValue({
+        ...base,
+        valueString: " \r\nNo findings.\r\n\r\nRefer to cardiology.\r\n\r\n",
+      }),
+    ).toBe("No findings.\r\n\r\nRefer to cardiology.");
+  });
+
   it("formats a codeable concept value", () => {
     // formatCodeableConcept renders JSX, so just confirm a value came back.
     expect(

--- a/src/app/(pages)/query/components/resultsView/tableComponents/utils.test.ts
+++ b/src/app/(pages)/query/components/resultsView/tableComponents/utils.test.ts
@@ -1,4 +1,71 @@
-import { checkIfSomeElementWithPropertyExists } from "./utils";
+import { Observation } from "fhir/r4";
+import {
+  checkIfSomeElementWithPropertyExists,
+  codeableConceptText,
+  formatObservationValue,
+} from "./utils";
+
+describe("formatObservationValue", () => {
+  const base: Observation = {
+    resourceType: "Observation",
+    status: "final",
+    code: { text: "Test" },
+  };
+
+  it("joins a quantity's value and unit", () => {
+    expect(
+      formatObservationValue({
+        ...base,
+        valueQuantity: { value: 5.4, unit: "mg/dL" },
+      }),
+    ).toBe("5.4 mg/dL");
+  });
+
+  it("returns a string value as is", () => {
+    expect(
+      formatObservationValue({ ...base, valueString: "Lungs are clear." }),
+    ).toBe("Lungs are clear.");
+  });
+
+  it("formats a codeable concept value", () => {
+    // formatCodeableConcept renders JSX, so just confirm a value came back.
+    expect(
+      formatObservationValue({
+        ...base,
+        valueCodeableConcept: { text: "Detected" },
+      }),
+    ).toBeTruthy();
+  });
+
+  it("returns an empty string when there is no recognizable value", () => {
+    expect(formatObservationValue(base)).toBe("");
+  });
+});
+
+describe("codeableConceptText", () => {
+  it("prefers text, then the first coding's display, then its code", () => {
+    expect(
+      codeableConceptText({
+        text: "Chest X-ray",
+        coding: [{ display: "XR Chest", code: "36643-5" }],
+      }),
+    ).toBe("Chest X-ray");
+    expect(
+      codeableConceptText({
+        coding: [{ display: "XR Chest", code: "36643-5" }],
+      }),
+    ).toBe("XR Chest");
+    expect(codeableConceptText({ coding: [{ code: "36643-5" }] })).toBe(
+      "36643-5",
+    );
+  });
+
+  it("returns an empty string for a missing or empty concept", () => {
+    expect(codeableConceptText(undefined)).toBe("");
+    expect(codeableConceptText({})).toBe("");
+    expect(codeableConceptText({ coding: [] })).toBe("");
+  });
+});
 
 describe("checkIfSomeElementWithPropertyExists", () => {
   it("reports every checked property as false for an empty array", () => {

--- a/src/app/(pages)/query/components/resultsView/tableComponents/utils.ts
+++ b/src/app/(pages)/query/components/resultsView/tableComponents/utils.ts
@@ -14,7 +14,9 @@ export function formatObservationValue(obs: Observation) {
   } else if (obs.valueQuantity) {
     return [obs.valueQuantity.value, obs.valueQuantity.unit].join(" ");
   } else if (obs.valueString) {
-    return obs.valueString;
+    // Epic pads narrative text with leading and trailing line breaks, which
+    // would otherwise render as blank lines in a pre-wrap cell.
+    return obs.valueString.trim();
   }
   return "";
 }

--- a/src/app/(pages)/query/components/resultsView/tableComponents/utils.ts
+++ b/src/app/(pages)/query/components/resultsView/tableComponents/utils.ts
@@ -1,3 +1,40 @@
+import { CodeableConcept, Observation } from "fhir/r4";
+import { formatCodeableConcept } from "../../../../../utils/format-service";
+
+/**
+ * Formats the value of an Observation for display, whichever value[x]
+ * variant it carries.
+ * @param obs - The Observation resource.
+ * @returns The formatted value, or an empty string when the Observation has
+ * no displayable value.
+ */
+export function formatObservationValue(obs: Observation) {
+  if (obs.valueCodeableConcept) {
+    return formatCodeableConcept(obs.valueCodeableConcept);
+  } else if (obs.valueQuantity) {
+    return [obs.valueQuantity.value, obs.valueQuantity.unit].join(" ");
+  } else if (obs.valueString) {
+    return obs.valueString;
+  }
+  return "";
+}
+
+/**
+ * Plain-text rendering of a CodeableConcept, for places where the JSX
+ * produced by formatCodeableConcept doesn't fit (a label inside a cell).
+ * @param concept - The CodeableConcept, if any.
+ * @returns The concept's text, else its first coding's display, else that
+ * coding's code, else an empty string.
+ */
+export function codeableConceptText(concept?: CodeableConcept): string {
+  return (
+    concept?.text ??
+    concept?.coding?.[0]?.display ??
+    concept?.coding?.[0]?.code ??
+    ""
+  );
+}
+
 /**
  * Helper function to not display tables in results view where there are no
  * elements in a column to display. Allows for non-lengthwise properties

--- a/src/app/backend/query-execution/custom-query.test.ts
+++ b/src/app/backend/query-execution/custom-query.test.ts
@@ -166,6 +166,22 @@ function buildLabsQuery(
   return new CustomQuery(savedQuery, PATIENT_ID, queryStrategy);
 }
 
+describe("CustomQuery lab queries", () => {
+  it("asks default-strategy servers to include a DiagnosticReport's result Observations", () => {
+    const defaultQuery = buildLabsQuery("default");
+    const observation = defaultQuery.getQuery("observation").params;
+    const report = defaultQuery.getQuery("diagnosticReport").params;
+
+    expect(report.get("_include")).toBe("DiagnosticReport:result");
+    expect(report.get("subject")).toBe(`Patient/${PATIENT_ID}`);
+    expect(report.get("code")).toBe(observation.get("code"));
+    // The _include is specific to the report search and mustn't leak onto
+    // the Observation search, so the two searches own separate params.
+    expect(observation.get("_include")).toBeNull();
+    expect(report).not.toBe(observation);
+  });
+});
+
 describe("CustomQuery epic strategy", () => {
   it("keeps default-mode query shapes unchanged", () => {
     const customQuery = buildConditionQuery("default");
@@ -325,20 +341,6 @@ describe("CustomQuery epic strategy", () => {
     expect(defaultQuery.getQuery("observation").params.get("subject")).toBe(
       `Patient/${PATIENT_ID}`,
     );
-  });
-
-  it("asks default-strategy servers to include a DiagnosticReport's result Observations", () => {
-    const defaultQuery = buildLabsQuery("default");
-    const observation = defaultQuery.getQuery("observation").params;
-    const report = defaultQuery.getQuery("diagnosticReport").params;
-
-    expect(report.get("_include")).toBe("DiagnosticReport:result");
-    expect(report.get("subject")).toBe(`Patient/${PATIENT_ID}`);
-    expect(report.get("code")).toBe(observation.get("code"));
-    // The _include is specific to the report search and mustn't leak onto
-    // the Observation search, so the two searches own separate params.
-    expect(observation.get("_include")).toBeNull();
-    expect(report).not.toBe(observation);
   });
 
   it("compiles GET-based Observation and DiagnosticReport queries with the lab codes", () => {

--- a/src/app/backend/query-execution/custom-query.test.ts
+++ b/src/app/backend/query-execution/custom-query.test.ts
@@ -327,6 +327,20 @@ describe("CustomQuery epic strategy", () => {
     );
   });
 
+  it("asks default-strategy servers to include a DiagnosticReport's result Observations", () => {
+    const defaultQuery = buildLabsQuery("default");
+    const observation = defaultQuery.getQuery("observation").params;
+    const report = defaultQuery.getQuery("diagnosticReport").params;
+
+    expect(report.get("_include")).toBe("DiagnosticReport:result");
+    expect(report.get("subject")).toBe(`Patient/${PATIENT_ID}`);
+    expect(report.get("code")).toBe(observation.get("code"));
+    // The _include is specific to the report search and mustn't leak onto
+    // the Observation search, so the two searches own separate params.
+    expect(observation.get("_include")).toBeNull();
+    expect(report).not.toBe(observation);
+  });
+
   it("compiles GET-based Observation and DiagnosticReport queries with the lab codes", () => {
     const customQuery = buildLabsQuery("epic", [LOINC_CODE], {
       labs: {

--- a/src/app/backend/query-execution/custom-query.ts
+++ b/src/app/backend/query-execution/custom-query.ts
@@ -307,9 +307,18 @@ export class CustomQuery {
         params: formattedParams,
       };
 
+      // A report's narrative, impression, or panel members live in the
+      // Observations its `result` element references, which the code-filtered
+      // Observation search above won't return. Spec-compliant servers include
+      // them in the same bundle via _include. (Epic ignores _include, so the
+      // Epic path reads them individually instead; see
+      // QueryService.runEpicResultQueries.) The params are copied so the
+      // _include doesn't leak onto the Observation search.
+      const reportParams = new URLSearchParams(formattedParams);
+      reportParams.append("_include", "DiagnosticReport:result");
       this.fhirResourceQueries["diagnosticReport"] = {
         basePath: `/DiagnosticReport/_search`,
-        params: formattedParams,
+        params: reportParams,
       };
     }
     // In Epic mode, Observation and DiagnosticReport queries aren't compiled

--- a/src/app/backend/query-execution/epic-strategy.test.ts
+++ b/src/app/backend/query-execution/epic-strategy.test.ts
@@ -553,6 +553,205 @@ describe("patientRecordsQuery with the epic query strategy", () => {
     ]);
   });
 
+  describe("DiagnosticReport result Observations", () => {
+    const observationReads = () =>
+      mockFhirClient.get.mock.calls
+        .map((c) => c[0] as string)
+        .filter((p) => p.startsWith("/Observation/"));
+
+    const report = (id: string, references: object[]) => ({
+      resourceType: "DiagnosticReport",
+      id,
+      status: "final",
+      code: { coding: [{ system: "http://loinc.org", code: LOINC_CODE }] },
+      result: references,
+    });
+
+    const observation = (id: string, valueString: string) => ({
+      resourceType: "Observation",
+      id,
+      status: "final",
+      code: { text: "Narrative" },
+      valueString,
+    });
+
+    it("reads the result Observations the Observation search didn't return (Epic ignores _include)", async () => {
+      const chestXray = report("dr-cxr", [
+        { reference: "Observation/obs-narrative", display: "Narrative" },
+        { reference: "Observation/obs-in-search", display: "Impression" },
+        // Schemed and contained references can't be read from this server.
+        { reference: "urn:uuid:not-a-local-id" },
+        { reference: "#contained" },
+      ]);
+      mockFhirClient.get.mockImplementation(async (path: string) => {
+        if (path.startsWith("/Observation?")) {
+          return mockBundleResponse(path, {
+            resourceType: "Bundle",
+            type: "searchset",
+            entry: [{ resource: observation("obs-in-search", "Normal.") }],
+          });
+        }
+        if (path.startsWith("/DiagnosticReport?")) {
+          return mockBundleResponse(path, {
+            resourceType: "Bundle",
+            type: "searchset",
+            entry: [{ resource: chestXray }],
+          });
+        }
+        // Reads return the bare resource, not a searchset Bundle.
+        if (path === "/Observation/obs-narrative") {
+          return mockBundleResponse(
+            path,
+            observation("obs-narrative", "The lungs are clear."),
+          );
+        }
+        return mockBundleResponse(path, EMPTY_BUNDLE);
+      });
+
+      const result = await runQuery();
+
+      expect(observationReads()).toEqual(["/Observation/obs-narrative"]);
+      expect(result.DiagnosticReport?.map((r) => r.id)).toEqual(["dr-cxr"]);
+      expect(result.Observation?.map((o) => o.id).sort()).toEqual([
+        "obs-in-search",
+        "obs-narrative",
+      ]);
+      expect(
+        result.Observation?.find((o) => o.id === "obs-narrative")?.valueString,
+      ).toBe("The lungs are clear.");
+    });
+
+    it("reads each referenced Observation once across chunked DiagnosticReport searches", async () => {
+      const manyCodes = Array.from({ length: 120 }, (_, i) => `${10000 + i}-1`);
+      (getSavedQueryByName as jest.Mock).mockResolvedValue(
+        buildSavedQuery({ labCodes: manyCodes }),
+      );
+      mockFhirClient.get.mockImplementation(async (path: string) => {
+        if (path.startsWith("/DiagnosticReport?")) {
+          return mockBundleResponse(path, {
+            resourceType: "Bundle",
+            type: "searchset",
+            entry: [
+              {
+                resource: report("dr-1", [
+                  { reference: "Observation/obs-shared" },
+                ]),
+              },
+            ],
+          });
+        }
+        if (path === "/Observation/obs-shared") {
+          return mockBundleResponse(path, observation("obs-shared", "text"));
+        }
+        return mockBundleResponse(path, EMPTY_BUNDLE);
+      });
+
+      const result = await runQuery();
+
+      expect(observationReads()).toEqual(["/Observation/obs-shared"]);
+      expect(result.Observation?.map((o) => o.id)).toEqual(["obs-shared"]);
+    });
+
+    it("caps the number of result Observation reads", async () => {
+      const references = Array.from({ length: 250 }, (_, i) => ({
+        reference: `Observation/obs-${i}`,
+      }));
+      mockFhirClient.get.mockImplementation(async (path: string) => {
+        if (path.startsWith("/DiagnosticReport?")) {
+          return mockBundleResponse(path, {
+            resourceType: "Bundle",
+            type: "searchset",
+            entry: [{ resource: report("dr-big", references) }],
+          });
+        }
+        if (path.startsWith("/Observation/")) {
+          const id = path.slice("/Observation/".length);
+          return mockBundleResponse(path, observation(id, "text"));
+        }
+        return mockBundleResponse(path, EMPTY_BUNDLE);
+      });
+
+      const result = await runQuery();
+
+      expect(observationReads()).toHaveLength(200);
+      expect(result.Observation).toHaveLength(200);
+      expect(result.DiagnosticReport?.map((r) => r.id)).toEqual(["dr-big"]);
+    });
+
+    it("drops failed and non-Observation reads without losing the report", async () => {
+      mockFhirClient.get.mockImplementation(async (path: string) => {
+        if (path.startsWith("/DiagnosticReport?")) {
+          return mockBundleResponse(path, {
+            resourceType: "Bundle",
+            type: "searchset",
+            entry: [
+              {
+                resource: report("dr-1", [
+                  { reference: "Observation/obs-404" },
+                  { reference: "Observation/obs-outcome" },
+                  { reference: "Observation/obs-rejected" },
+                  { reference: "Observation/obs-ok" },
+                ]),
+              },
+            ],
+          });
+        }
+        if (path === "/Observation/obs-404") {
+          return { status: 404, url: path } as unknown as Response;
+        }
+        if (path === "/Observation/obs-outcome") {
+          return mockBundleResponse(path, {
+            resourceType: "OperationOutcome",
+            issue: [{ severity: "error", code: "forbidden" }],
+          });
+        }
+        if (path === "/Observation/obs-rejected") {
+          throw new Error("ECONNRESET");
+        }
+        if (path === "/Observation/obs-ok") {
+          return mockBundleResponse(path, observation("obs-ok", "fine"));
+        }
+        return mockBundleResponse(path, EMPTY_BUNDLE);
+      });
+
+      const result = await runQuery();
+
+      expect(result.DiagnosticReport?.map((r) => r.id)).toEqual(["dr-1"]);
+      expect(result.Observation?.map((o) => o.id)).toEqual(["obs-ok"]);
+      expect(result.OperationOutcome).toBeUndefined();
+    });
+
+    it("still reads result Observations when the Observation search failed", async () => {
+      mockFhirClient.get.mockImplementation(async (path: string) => {
+        if (path.startsWith("/Observation?")) {
+          throw new Error("ECONNRESET");
+        }
+        if (path.startsWith("/DiagnosticReport?")) {
+          return mockBundleResponse(path, {
+            resourceType: "Bundle",
+            type: "searchset",
+            entry: [
+              {
+                resource: report("dr-1", [
+                  { reference: "Observation/obs-narrative" },
+                ]),
+              },
+            ],
+          });
+        }
+        if (path === "/Observation/obs-narrative") {
+          return mockBundleResponse(path, observation("obs-narrative", "x"));
+        }
+        return mockBundleResponse(path, EMPTY_BUNDLE);
+      });
+
+      const result = await runQuery();
+
+      expect(observationReads()).toEqual(["/Observation/obs-narrative"]);
+      expect(result.Observation?.map((o) => o.id)).toEqual(["obs-narrative"]);
+    });
+  });
+
   it("keeps the default POST _search behavior for default-strategy servers", async () => {
     await runQuery("Standard Server");
 
@@ -567,6 +766,20 @@ describe("patientRecordsQuery with the epic query strategy", () => {
         "/DiagnosticReport/_search",
       ]),
     );
+    // Default-strategy servers are asked to include a report's result
+    // Observations in the same bundle instead of QC reading them.
+    const reportSearch = mockFhirClient.post.mock.calls.find(
+      (c) => c[0] === "/DiagnosticReport/_search",
+    );
+    expect((reportSearch?.[1] as URLSearchParams).get("_include")).toBe(
+      "DiagnosticReport:result",
+    );
+    const observationSearch = mockFhirClient.post.mock.calls.find(
+      (c) => c[0] === "/Observation/_search",
+    );
+    expect(
+      (observationSearch?.[1] as URLSearchParams).get("_include"),
+    ).toBeNull();
     const getPaths = mockFhirClient.get.mock.calls.map((c) => c[0] as string);
     expect(getPaths.some((p) => p.startsWith("/Condition?"))).toBe(false);
     expect(getPaths.some((p) => p.startsWith("/Observation?"))).toBe(false);

--- a/src/app/backend/query-execution/service.ts
+++ b/src/app/backend/query-execution/service.ts
@@ -1,13 +1,5 @@
 "use server";
-import {
-  Bundle,
-  FhirResource,
-  Medication,
-  Observation,
-  OperationOutcome,
-  Patient,
-  Task,
-} from "fhir/r4";
+import { Bundle, FhirResource, OperationOutcome, Patient, Task } from "fhir/r4";
 
 import {
   isFhirResource,
@@ -77,21 +69,15 @@ const TASK_POLLING = {
   RETRY_DELAY_MS: 5000,
 } as const;
 
-// Epic-mode Medication reads (see runEpicMedicationRequestChain) are capped so
-// a patient with an enormous medication history can't fan out into an
+// Epic-mode reads of referenced resources (see readEpicResourcesById) are
+// capped so a patient with an enormous history can't fan out into an
 // unbounded number of requests, and are issued in small concurrent batches to
-// avoid hammering the server. Unresolved medications are kept unfiltered by
-// the downstream code filter (fail open), so hitting the cap over-includes
-// rather than drops records.
-const EPIC_MEDICATION_READ_LIMIT = 200;
-const EPIC_MEDICATION_READ_BATCH_SIZE = 10;
-
-// Epic-mode reads of the Observations a DiagnosticReport's `result` element
-// references (see readEpicDiagnosticReportResultObservations) are capped and
-// batched for the same reasons. Hitting the cap leaves the excess reports
-// without their narrative text in the UI rather than dropping the reports.
-const EPIC_RESULT_OBSERVATION_READ_LIMIT = 200;
-const EPIC_RESULT_OBSERVATION_READ_BATCH_SIZE = 10;
+// avoid hammering the server. Hitting the cap over-includes or under-decorates
+// rather than drops records: unresolved Medications are kept unfiltered by the
+// downstream code filter (fail open), and unresolved result Observations
+// leave their DiagnosticReport without its narrative text in the UI.
+const EPIC_REFERENCE_READ_LIMIT = 200;
+const EPIC_REFERENCE_READ_BATCH_SIZE = 10;
 
 const TASK_TEMPLATE: Partial<Task> = {
   resourceType: "Task",
@@ -803,32 +789,59 @@ class QueryService {
       }
     }
 
-    let idsToRead = [...referencedIds].filter((id) => !includedIds.has(id));
-    if (idsToRead.length > EPIC_RESULT_OBSERVATION_READ_LIMIT) {
+    return QueryService.readEpicResourcesById(
+      fhirClient,
+      "Observation",
+      [...referencedIds].filter((id) => !includedIds.has(id)),
+    );
+  }
+
+  /**
+   * Reads resources of one type from an Epic server by id, in small
+   * concurrent batches and up to a cap, and wraps the ones that came back in
+   * a synthetic collection Bundle response for parseFhirSearch to merge. Epic
+   * ignores _include, so the resources a search should have carried along (a
+   * MedicationRequest's Medication, a DiagnosticReport's result Observations)
+   * are fetched this way instead. A rejected or non-200 read, or a 200 whose
+   * body isn't the requested type (an error payload, a misrouted resource),
+   * is logged and dropped rather than injected into query results.
+   * @param fhirClient - client for the FHIR server being queried
+   * @param resourceType - the resource type being read
+   * @param ids - the ids to read; those past the cap are skipped with a
+   * warning
+   * @returns a single synthetic Bundle response carrying the resources the
+   * reads resolved, or no responses when nothing was read
+   */
+  private static async readEpicResourcesById(
+    fhirClient: FHIRClient,
+    resourceType: FhirResource["resourceType"],
+    ids: string[],
+  ): Promise<Response[]> {
+    let idsToRead = ids;
+    if (idsToRead.length > EPIC_REFERENCE_READ_LIMIT) {
       console.warn(
-        "Epic query strategy: %s distinct DiagnosticReport result Observations exceed the read cap of %s; the excess are not resolved",
+        "Epic query strategy: %s distinct %s references exceed the read cap of %s; the excess are not resolved",
         idsToRead.length,
-        EPIC_RESULT_OBSERVATION_READ_LIMIT,
+        resourceType,
+        EPIC_REFERENCE_READ_LIMIT,
       );
-      idsToRead = idsToRead.slice(0, EPIC_RESULT_OBSERVATION_READ_LIMIT);
+      idsToRead = idsToRead.slice(0, EPIC_REFERENCE_READ_LIMIT);
     }
 
-    const observations: Observation[] = [];
-    for (const batch of chunkArray(
-      idsToRead,
-      EPIC_RESULT_OBSERVATION_READ_BATCH_SIZE,
-    )) {
+    const resources: FhirResource[] = [];
+    for (const batch of chunkArray(idsToRead, EPIC_REFERENCE_READ_BATCH_SIZE)) {
       const results = await Promise.allSettled(
-        batch.map((id) => fhirClient.get(`/Observation/${id}`)),
+        batch.map((id) => fhirClient.get(`/${resourceType}/${id}`)),
       );
       const responses = QueryService.collectSettledResponses(
         results,
-        "Epic Observation read rejected: ",
+        `Epic ${resourceType} read rejected: `,
       );
       for (const response of responses) {
         if (response.status !== 200) {
           console.error(
-            "Epic Observation read failed from %s with status %s",
+            "Epic %s read failed from %s with status %s",
+            resourceType,
             response.url,
             response.status,
           );
@@ -836,27 +849,27 @@ class QueryService {
         }
         try {
           const body = (await response.json()) as FhirResource | null;
-          // Only genuine Observation bodies are surfaced; anything else a
-          // server returns with a 200 (an error payload, a misrouted
-          // resource) is dropped rather than injected into query results.
-          if (body?.resourceType === "Observation") {
-            observations.push(body);
+          if (body?.resourceType === resourceType) {
+            resources.push(body);
           }
         } catch (error) {
-          console.error("Failed to parse Epic Observation read body: ", error);
+          console.error(
+            `Failed to parse Epic ${resourceType} read body: `,
+            error,
+          );
         }
       }
     }
 
-    if (observations.length === 0) return [];
+    if (resources.length === 0) return [];
 
-    const observationBundle: Bundle = {
+    const bundle: Bundle = {
       resourceType: "Bundle",
       type: "collection",
-      entry: observations.map((observation) => ({ resource: observation })),
+      entry: resources.map((resource) => ({ resource })),
     };
     return [
-      new Response(JSON.stringify(observationBundle), {
+      new Response(JSON.stringify(bundle), {
         status: 200,
         headers: { "content-type": "application/fhir+json" },
       }),
@@ -992,67 +1005,14 @@ class QueryService {
       }
     });
 
-    let idsToRead = [...referencedMedicationIds].filter(
-      (id) => !includedMedicationIds.has(id),
+    const medicationResponses = await QueryService.readEpicResourcesById(
+      fhirClient,
+      "Medication",
+      [...referencedMedicationIds].filter(
+        (id) => !includedMedicationIds.has(id),
+      ),
     );
-    if (idsToRead.length > EPIC_MEDICATION_READ_LIMIT) {
-      console.warn(
-        "Epic query strategy: %s distinct Medication references exceed the read cap of %s; the excess are kept unfiltered rather than resolved",
-        idsToRead.length,
-        EPIC_MEDICATION_READ_LIMIT,
-      );
-      idsToRead = idsToRead.slice(0, EPIC_MEDICATION_READ_LIMIT);
-    }
-
-    const medications: Medication[] = [];
-    for (const batch of chunkArray(
-      idsToRead,
-      EPIC_MEDICATION_READ_BATCH_SIZE,
-    )) {
-      const results = await Promise.allSettled(
-        batch.map((id) => fhirClient.get(`/Medication/${id}`)),
-      );
-      const responses = QueryService.collectSettledResponses(
-        results,
-        "Epic Medication read rejected: ",
-      );
-      for (const response of responses) {
-        if (response.status !== 200) {
-          console.error(
-            "Epic Medication read failed from %s with status %s",
-            response.url,
-            response.status,
-          );
-          continue;
-        }
-        try {
-          const body = (await response.json()) as FhirResource | null;
-          // Only genuine Medication bodies are surfaced; anything else a
-          // server returns with a 200 (an error payload, a misrouted
-          // resource) is dropped rather than injected into query results.
-          if (body?.resourceType === "Medication") {
-            medications.push(body);
-          }
-        } catch (error) {
-          console.error("Failed to parse Epic Medication read body: ", error);
-        }
-      }
-    }
-
-    if (medications.length === 0) return [searchResponse];
-
-    const medicationBundle: Bundle = {
-      resourceType: "Bundle",
-      type: "collection",
-      entry: medications.map((medication) => ({ resource: medication })),
-    };
-    return [
-      searchResponse,
-      new Response(JSON.stringify(medicationBundle), {
-        status: 200,
-        headers: { "content-type": "application/fhir+json" },
-      }),
-    ];
+    return [searchResponse, ...medicationResponses];
   }
 
   /**

--- a/src/app/backend/query-execution/service.ts
+++ b/src/app/backend/query-execution/service.ts
@@ -3,6 +3,7 @@ import {
   Bundle,
   FhirResource,
   Medication,
+  Observation,
   OperationOutcome,
   Patient,
   Task,
@@ -28,6 +29,7 @@ import {
   referencedMedicationKey,
 } from "./medication-filter";
 import { GetPhoneQueryFormats } from "../../utils/format-service";
+import { referencedResourceId } from "../../utils/fhir-reference";
 import { auditable } from "../audit-logs/decorator";
 import type { QueryTableResult } from "../../(pages)/queryBuilding/utils";
 import type {
@@ -83,6 +85,13 @@ const TASK_POLLING = {
 // rather than drops records.
 const EPIC_MEDICATION_READ_LIMIT = 200;
 const EPIC_MEDICATION_READ_BATCH_SIZE = 10;
+
+// Epic-mode reads of the Observations a DiagnosticReport's `result` element
+// references (see readEpicDiagnosticReportResultObservations) are capped and
+// batched for the same reasons. Hitting the cap leaves the excess reports
+// without their narrative text in the UI rather than dropping the reports.
+const EPIC_RESULT_OBSERVATION_READ_LIMIT = 200;
+const EPIC_RESULT_OBSERVATION_READ_BATCH_SIZE = 10;
 
 const TASK_TEMPLATE: Partial<Task> = {
   resourceType: "Task",
@@ -602,7 +611,9 @@ class QueryService {
       // referenced Medications the search didn't include (Epic ignores
       // _include) and the results are filtered to the query's codes
       // downstream. MedicationStatement isn't queried in Epic mode at all —
-      // Epic has no R4 endpoint for it.
+      // Epic has no R4 endpoint for it. DiagnosticReport searches are likewise
+      // followed by reads of the result Observations they reference, since
+      // Epic ignores _include and keeps report narratives there.
       const { basePath, params } = builtQuery.getQuery("medicationRequest");
       if (basePath !== "") {
         postPromises.push(
@@ -674,24 +685,182 @@ class QueryService {
    * as the only search method, so the query's lab codes go out as chunked
    * GETs (one Observation and one DiagnosticReport search per chunk) instead
    * of the default POST _search. Each request is independent, so one failure
-   * doesn't lose the others.
+   * doesn't lose the others. The DiagnosticReport responses are then followed
+   * up with reads of the result Observations they reference (see
+   * readEpicDiagnosticReportResultObservations).
    * @param fhirClient - client for the FHIR server being queried
    * @param builtQuery - the compiled CustomQuery
-   * @returns the Observation and DiagnosticReport responses that succeeded
+   * @returns the Observation and DiagnosticReport responses that succeeded,
+   * followed by a synthetic Bundle response carrying any result Observations
+   * the follow-up reads resolved
    */
   private static async runEpicResultQueries(
     fhirClient: FHIRClient,
     builtQuery: CustomQuery,
   ): Promise<Response[]> {
-    const results = await Promise.allSettled(
-      builtQuery
-        .compileEpicResultQueries()
-        .map(({ basePath, params }) => fhirClient.get(`${basePath}?${params}`)),
+    const specs = builtQuery.compileEpicResultQueries();
+    const settled = await Promise.allSettled(
+      specs.map(({ basePath, params }) =>
+        fhirClient.get(`${basePath}?${params}`),
+      ),
     );
-    return QueryService.collectSettledResponses(
-      results,
-      "Epic Observation/DiagnosticReport FHIR query rejected: ",
-    );
+
+    // Responses are paired with their specs by index so the DiagnosticReport
+    // searches can be told apart without parsing response URLs.
+    const observationResponses: Response[] = [];
+    const reportResponses: Response[] = [];
+    const searchResponses: Response[] = [];
+    settled.forEach((result, i) => {
+      if (result.status !== "fulfilled") {
+        console.error(
+          "Epic Observation/DiagnosticReport FHIR query rejected: ",
+          result.reason,
+        );
+        return;
+      }
+      searchResponses.push(result.value);
+      if (specs[i].basePath === "/DiagnosticReport") {
+        reportResponses.push(result.value);
+      } else {
+        observationResponses.push(result.value);
+      }
+    });
+
+    if (reportResponses.length === 0) return searchResponses;
+
+    const resultObservationResponses =
+      await QueryService.readEpicDiagnosticReportResultObservations(
+        fhirClient,
+        observationResponses,
+        reportResponses,
+      );
+    return [...searchResponses, ...resultObservationResponses];
+  }
+
+  /**
+   * Epic-mode resolution of the Observations a DiagnosticReport's `result`
+   * element references. Epic represents a report's text (a radiology
+   * narrative and impression, a panel's member results) as Observations
+   * referenced from the report rather than in the report itself, and its
+   * DiagnosticReport search ignores _include. The code-filtered Observation
+   * search won't return them either, since they aren't coded with the query's
+   * lab codes. So every referenced Observation the Observation search didn't
+   * already return is read individually, in small concurrent batches and up
+   * to a cap, and returned as one synthetic Bundle response for
+   * parseFhirSearch to merge (it dedupes any overlap by id).
+   * @param fhirClient - client for the FHIR server being queried
+   * @param observationResponses - the Epic Observation search responses
+   * @param reportResponses - the Epic DiagnosticReport search responses
+   * @returns a single synthetic Bundle response carrying the Observations the
+   * reads resolved, or no responses when there was nothing to read
+   */
+  private static async readEpicDiagnosticReportResultObservations(
+    fhirClient: FHIRClient,
+    observationResponses: Response[],
+    reportResponses: Response[],
+  ): Promise<Response[]> {
+    // Bodies are cloned because parseFhirSearch reads them again downstream.
+    const includedIds = new Set<string>();
+    for (const response of observationResponses) {
+      if (response.status !== 200) continue;
+      try {
+        const bundle = (await response.clone().json()) as Bundle;
+        bundle?.entry?.forEach((entry) => {
+          const resource = entry.resource as FhirResource | undefined;
+          if (resource?.resourceType === "Observation" && resource.id) {
+            includedIds.add(resource.id);
+          }
+        });
+      } catch (error) {
+        console.error(
+          "Failed to parse Epic Observation response for DiagnosticReport result resolution: ",
+          error,
+        );
+      }
+    }
+
+    // A Set dedupes references shared by reports returned in more than one
+    // chunked code query. Contained (#id) and schemed references are skipped
+    // by referencedResourceId for the same reasons as the Medication reads.
+    const referencedIds = new Set<string>();
+    for (const response of reportResponses) {
+      if (response.status !== 200) continue;
+      try {
+        const bundle = (await response.clone().json()) as Bundle;
+        bundle?.entry?.forEach((entry) => {
+          const resource = entry.resource as FhirResource | undefined;
+          if (resource?.resourceType !== "DiagnosticReport") return;
+          resource.result?.forEach((ref) => {
+            const id = referencedResourceId(ref.reference, "Observation");
+            if (id) referencedIds.add(id);
+          });
+        });
+      } catch (error) {
+        console.error(
+          "Failed to parse Epic DiagnosticReport response for result Observation resolution: ",
+          error,
+        );
+      }
+    }
+
+    let idsToRead = [...referencedIds].filter((id) => !includedIds.has(id));
+    if (idsToRead.length > EPIC_RESULT_OBSERVATION_READ_LIMIT) {
+      console.warn(
+        "Epic query strategy: %s distinct DiagnosticReport result Observations exceed the read cap of %s; the excess are not resolved",
+        idsToRead.length,
+        EPIC_RESULT_OBSERVATION_READ_LIMIT,
+      );
+      idsToRead = idsToRead.slice(0, EPIC_RESULT_OBSERVATION_READ_LIMIT);
+    }
+
+    const observations: Observation[] = [];
+    for (const batch of chunkArray(
+      idsToRead,
+      EPIC_RESULT_OBSERVATION_READ_BATCH_SIZE,
+    )) {
+      const results = await Promise.allSettled(
+        batch.map((id) => fhirClient.get(`/Observation/${id}`)),
+      );
+      const responses = QueryService.collectSettledResponses(
+        results,
+        "Epic Observation read rejected: ",
+      );
+      for (const response of responses) {
+        if (response.status !== 200) {
+          console.error(
+            "Epic Observation read failed from %s with status %s",
+            response.url,
+            response.status,
+          );
+          continue;
+        }
+        try {
+          const body = (await response.json()) as FhirResource | null;
+          // Only genuine Observation bodies are surfaced; anything else a
+          // server returns with a 200 (an error payload, a misrouted
+          // resource) is dropped rather than injected into query results.
+          if (body?.resourceType === "Observation") {
+            observations.push(body);
+          }
+        } catch (error) {
+          console.error("Failed to parse Epic Observation read body: ", error);
+        }
+      }
+    }
+
+    if (observations.length === 0) return [];
+
+    const observationBundle: Bundle = {
+      resourceType: "Bundle",
+      type: "collection",
+      entry: observations.map((observation) => ({ resource: observation })),
+    };
+    return [
+      new Response(JSON.stringify(observationBundle), {
+        status: 200,
+        headers: { "content-type": "application/fhir+json" },
+      }),
+    ];
   }
 
   /**

--- a/src/app/utils/fhir-reference.test.ts
+++ b/src/app/utils/fhir-reference.test.ts
@@ -37,4 +37,22 @@ describe("referencedResourceId", () => {
     expect(referencedResourceId("", "Observation")).toBeUndefined();
     expect(referencedResourceId(undefined, "Observation")).toBeUndefined();
   });
+
+  it("rejects ids outside the FHIR id charset, so the id is always a plain path segment", () => {
+    expect(
+      referencedResourceId("Observation/..", "Observation"),
+    ).toBeUndefined();
+    expect(
+      referencedResourceId("Observation/abc%2Fdef", "Observation"),
+    ).toBeUndefined();
+    expect(
+      referencedResourceId("Observation/abc?_format=json", "Observation"),
+    ).toBeUndefined();
+    expect(
+      referencedResourceId("Observation/abc/extra", "Observation"),
+    ).toBeUndefined();
+    expect(
+      referencedResourceId(`Observation/${"a".repeat(65)}`, "Observation"),
+    ).toBeUndefined();
+  });
 });

--- a/src/app/utils/fhir-reference.test.ts
+++ b/src/app/utils/fhir-reference.test.ts
@@ -1,0 +1,40 @@
+import { referencedResourceId } from "./fhir-reference";
+
+describe("referencedResourceId", () => {
+  it("extracts the id from a relative reference of the requested type", () => {
+    expect(referencedResourceId("Observation/abc", "Observation")).toBe("abc");
+    expect(
+      referencedResourceId("Observation/abc/_history/2", "Observation"),
+    ).toBe("abc");
+    expect(
+      referencedResourceId(
+        "Observation/eSoe91dRn5pTDcXUNbFuFBShhuDnd0MX5qxiuhLTw3-I3",
+        "Observation",
+      ),
+    ).toBe("eSoe91dRn5pTDcXUNbFuFBShhuDnd0MX5qxiuhLTw3-I3");
+  });
+
+  it("rejects references that can't safely be read from the same server", () => {
+    // Absolute URLs and urn: references carry a scheme.
+    expect(
+      referencedResourceId(
+        "https://other.example.com/fhir/Observation/abc",
+        "Observation",
+      ),
+    ).toBeUndefined();
+    expect(
+      referencedResourceId("urn:uuid:1234", "Observation"),
+    ).toBeUndefined();
+    // Contained resources resolve locally, not via a read.
+    expect(referencedResourceId("#local", "Observation")).toBeUndefined();
+  });
+
+  it("rejects references to another type, bare ids, and missing references", () => {
+    expect(
+      referencedResourceId("Medication/abc", "Observation"),
+    ).toBeUndefined();
+    expect(referencedResourceId("abc", "Observation")).toBeUndefined();
+    expect(referencedResourceId("", "Observation")).toBeUndefined();
+    expect(referencedResourceId(undefined, "Observation")).toBeUndefined();
+  });
+});

--- a/src/app/utils/fhir-reference.test.ts
+++ b/src/app/utils/fhir-reference.test.ts
@@ -51,8 +51,14 @@ describe("referencedResourceId", () => {
     expect(
       referencedResourceId("Observation/abc/extra", "Observation"),
     ).toBeUndefined();
-    expect(
-      referencedResourceId(`Observation/${"a".repeat(65)}`, "Observation"),
-    ).toBeUndefined();
+  });
+
+  it("accepts Epic ids, which exceed the spec's 64-character limit", () => {
+    const epicId =
+      "eyPMWgv2u2RUfsV4p1lLKuUtqyPs2-QNi2zKvbTsFYtRByc6B.cSi1iVU5V2HOpX23";
+    expect(epicId.length).toBeGreaterThan(64);
+    expect(referencedResourceId(`Observation/${epicId}`, "Observation")).toBe(
+      epicId,
+    );
   });
 });

--- a/src/app/utils/fhir-reference.ts
+++ b/src/app/utils/fhir-reference.ts
@@ -4,9 +4,11 @@
  * Only scheme-less, relative references resolve: "Observation/abc" and
  * "Observation/abc/_history/2" both yield "abc". Contained references (#id),
  * references with a scheme (absolute URLs, urn:uuid:, urn:oid:), references to
- * a different resource type, and bare ids all yield undefined. A caller that
+ * a different resource type, bare ids, and ids outside the FHIR id charset
+ * ([A-Za-z0-9\-.], at most 64 characters) all yield undefined. A caller that
  * turns the id into a read request against the same server can therefore trust
- * that the id belongs to that server and that resource type.
+ * that the id belongs to that server and that resource type, and that it is a
+ * plain path segment (no traversal or encoded characters).
  * @param reference - the Reference.reference string, if any
  * @param resourceType - the FHIR resource type the reference must point at
  * @returns the referenced resource's id, or undefined when it can't be
@@ -19,6 +21,14 @@ export function referencedResourceId(
   if (!reference || reference.startsWith("#") || reference.includes(":")) {
     return undefined;
   }
-  const match = reference.match(new RegExp(`(?:^|/)${resourceType}/([^/?#]+)`));
-  return match?.[1];
+  const match = reference.match(
+    new RegExp(
+      `(?:^|/)${resourceType}/([A-Za-z0-9\\-.]{1,64})(?:/_history/[^/]+)?$`,
+    ),
+  );
+  const id = match?.[1];
+  // "." and ".." are within the FHIR id charset but aren't real ids, and would
+  // change the path a read request resolves to.
+  if (!id || id === "." || id === "..") return undefined;
+  return id;
 }

--- a/src/app/utils/fhir-reference.ts
+++ b/src/app/utils/fhir-reference.ts
@@ -1,0 +1,24 @@
+/**
+ * Extracts the logical id from a relative FHIR reference of the given type.
+ *
+ * Only scheme-less, relative references resolve: "Observation/abc" and
+ * "Observation/abc/_history/2" both yield "abc". Contained references (#id),
+ * references with a scheme (absolute URLs, urn:uuid:, urn:oid:), references to
+ * a different resource type, and bare ids all yield undefined. A caller that
+ * turns the id into a read request against the same server can therefore trust
+ * that the id belongs to that server and that resource type.
+ * @param reference - the Reference.reference string, if any
+ * @param resourceType - the FHIR resource type the reference must point at
+ * @returns the referenced resource's id, or undefined when it can't be
+ * determined safely
+ */
+export function referencedResourceId(
+  reference: string | undefined,
+  resourceType: string,
+): string | undefined {
+  if (!reference || reference.startsWith("#") || reference.includes(":")) {
+    return undefined;
+  }
+  const match = reference.match(new RegExp(`(?:^|/)${resourceType}/([^/?#]+)`));
+  return match?.[1];
+}

--- a/src/app/utils/fhir-reference.ts
+++ b/src/app/utils/fhir-reference.ts
@@ -5,7 +5,8 @@
  * "Observation/abc/_history/2" both yield "abc". Contained references (#id),
  * references with a scheme (absolute URLs, urn:uuid:, urn:oid:), references to
  * a different resource type, bare ids, and ids outside the FHIR id charset
- * ([A-Za-z0-9\-.], at most 64 characters) all yield undefined. A caller that
+ * ([A-Za-z0-9\-.]) all yield undefined. The spec's 64-character limit isn't
+ * enforced because Epic issues longer ids. A caller that
  * turns the id into a read request against the same server can therefore trust
  * that the id belongs to that server and that resource type, and that it is a
  * plain path segment (no traversal or encoded characters).
@@ -23,7 +24,7 @@ export function referencedResourceId(
   }
   const match = reference.match(
     new RegExp(
-      `(?:^|/)${resourceType}/([A-Za-z0-9\\-.]{1,64})(?:/_history/[^/]+)?$`,
+      `(?:^|/)${resourceType}/([A-Za-z0-9\\-.]+)(?:/_history/[^/]+)?$`,
     ),
   );
   const id = match?.[1];

--- a/src/docs/API Reference Documentation.mdx
+++ b/src/docs/API Reference Documentation.mdx
@@ -13,7 +13,7 @@ Query results are returned as a FHIR Bundle containing the patient's records. De
 
 - `Patient`
 - `Observation` (lab results, plus social determinants of health if enabled for the query)
-- `DiagnosticReport`
+- `DiagnosticReport` (plus the `Observation` resources its `result` element references, which carry a report's narrative, impression, or panel members)
 - `Condition`
 - `Encounter`
 - `MedicationRequest`
@@ -22,7 +22,7 @@ Query results are returned as a FHIR Bundle containing the patient's records. De
 - `ImmunizationRecommendation` (immunization forecast, from Immunization Gateway servers)
 - `ServiceRequest`
 
-Lab, condition, and medication resources are filtered to the value set codes configured in the query. `Immunization`, social determinants `Observation`, and `ServiceRequest` resources are returned when the corresponding medical record sections are enabled for the query. Servers configured with the Immunization Gateway endpoint type also return `ImmunizationRecommendation` resources alongside `Immunization`. Medication and service request queries may also return related resources (such as `Medication`, `MedicationAdministration`, `Practitioner`, and `Specimen`) via `_include`/`_revinclude` search parameters.
+Lab, condition, and medication resources are filtered to the value set codes configured in the query. `Immunization`, social determinants `Observation`, and `ServiceRequest` resources are returned when the corresponding medical record sections are enabled for the query. Servers configured with the Immunization Gateway endpoint type also return `ImmunizationRecommendation` resources alongside `Immunization`. Medication and service request queries may also return related resources (such as `Medication`, `MedicationAdministration`, `Practitioner`, and `Specimen`) via `_include`/`_revinclude` search parameters, and the `DiagnosticReport` search requests `_include=DiagnosticReport:result` so a report's referenced `Observation` resources are returned even when their codes are not in the query's value sets.
 
 ## Authentication
 

--- a/src/docs/FHIR Connection Guide.mdx
+++ b/src/docs/FHIR Connection Guide.mdx
@@ -192,6 +192,13 @@ that would otherwise cause queries to silently return incomplete records:
   and DiagnosticReport. With the Epic strategy, every patient record search
   is sent as a GET, with long code lists split across multiple requests to
   keep URLs short.
+- Epic stores a report's text (a radiology narrative and impression, a
+  panel's member results) as Observations referenced from
+  `DiagnosticReport.result`, and its DiagnosticReport search ignores
+  `_include`. With the Epic strategy, QC reads each referenced Observation
+  that the lab search did not already return (up to 200 per query) so the
+  report's text can be displayed alongside the report. This can include panel
+  member results whose codes are not in the query's value sets.
 
 Optional settings:
 


### PR DESCRIPTION
# PULL REQUEST
<img width="836" height="385" alt="08-diagnostic-reports" src="https://github.com/user-attachments/assets/f81869e6-21f3-498c-9a71-131131287450" />


## Summary

Epic represents a report's text (a radiology narrative and impression, a panel's member results) as Observations referenced from `DiagnosticReport.result` rather than in the report itself, and its DiagnosticReport search ignores `_include`. Query Connector's code-filtered Observation search never returned those Observations, and the Diagnostic Reports table only showed Date and Code, so a report like a chest X-ray came back with no visible text. This surfaced while validating CDPH's connection to Cedars-Sinai's Epic.

Changes:

- **Epic query strategy**: after the chunked DiagnosticReport GETs, QC reads each referenced Observation the Observation search didn't already return (batches of 10, capped at 200 per query) and merges them into the query response. Contained, schemed, and wrong-type references are skipped, and a failed or non-Observation read is dropped without losing the report.
- **Default query strategy**: the DiagnosticReport `_search` now sends `_include=DiagnosticReport:result`, using its own params object so the include doesn't leak onto the Observation search.
- **Results page (UI)**: the Diagnostic Reports table gains a Results column, shown only when at least one report references results. Each result renders its reference display (or the Observation's code text when there is no display) in bold, with the value beneath it and line breaks preserved for multi-paragraph narratives. The Observations table still lists these Observations as well, since lab panel components already appear in both places.
- Adds a shared `referencedResourceId` helper for relative FHIR references.
- Updates the FHIR Connection Guide (Epic strategy section) and the API reference resource list.
- Adjusts the e2e row-count assertions now that report rows list their result labels.

Design review note: the Results column takes half the table width and stacks one block per result (bold label, value beneath, coded sub-label). Running the MDRO case investigation against the local Aidbox seed shows it populated for every report.

## Related Issue

Fixes #

## Additional Information

- Reading every `result[]` member of a matched lab panel can surface component Observations whose codes aren't in the query's value sets. This over-inclusion is intentional and matches the fail-open approach used for Epic medications.
- Verified with the unit suite, the Playwright query execution spec on Chrome against the local Aidbox stack, and a manual run of the MDRO query confirming the Results column and the `_include` on the DiagnosticReport search in the request drawer.
- For Epic servers, the client registration needs the Observation.Read (Labs) (R4) API for the follow-up reads to succeed.

## Checklist

- [x] Descriptive Pull Request title
- [ ] Link to relevant issues
- [x] Provide necessary context for design reviewers
- [x] Ensure test coverage is above agreed upon threshold
- [x] Update documentation

