### PR TITLE
Release v1.2.2

### DIFF
--- a/app_version.yml
+++ b/app_version.yml
@@ -1,1 +1,1 @@
-version: 1.2.1
+version: 1.2.2

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "query-connector",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "query-connector",
-      "version": "1.2.1",
+      "version": "1.2.2",
       "dependencies": {
         "@aws-sdk/client-secrets-manager": "^3.1113.0",
         "@axe-core/playwright": "^4.13.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "query-connector",
   "description": "DIBBs Query Connector: a Next.js full-stack application for public health staff to query healthcare organizations for patient records via FHIR and TEFCA networks.",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "private": true,
   "scripts": {
     "dev": "docker compose -f docker-compose-dev.yaml up -d && next dev --turbopack; docker compose -f docker-compose-dev.yaml down --remove-orphans",


### PR DESCRIPTION
## Summary
Bumps the app version to **v1.2.2** to trigger a release.

Patch release containing:
- #1030 — feat: show a DiagnosticReport's referenced result Observations on the results page (Epic strategy reads the `result[]` Observations Epic's search leaves out, default strategy adds `_include=DiagnosticReport:result`, Diagnostic Reports table gains a Results column; verified against the Epic sandbox on dev)
- #1027 — Rename Query Connector FAQ_Final.pdf to Frequently Asked Questions Guide
- #1029 — chore(deps-dev): bump @types/react-dom from 19.2.4 to 19.2.5 (auto-merge pending; included if it lands before this PR)

## Checklist
- [x] Descriptive Pull Request title
- [x] Provide necessary context for design reviewers